### PR TITLE
Fix error replacing 'to_json' by 'to_python'

### DIFF
--- a/aiogram/types/inline_keyboard.py
+++ b/aiogram/types/inline_keyboard.py
@@ -54,7 +54,7 @@ class InlineKeyboardMarkup(base.TelegramObject):
         """
         btn_array = []
         for button in args:
-            btn_array.append(button.to_json())
+            btn_array.append(button.to_python())
         self.inline_keyboard.append(btn_array)
         return self
 

--- a/aiogram/types/reply_keyboard.py
+++ b/aiogram/types/reply_keyboard.py
@@ -41,7 +41,7 @@ class ReplyKeyboardMarkup(base.TelegramObject):
             elif isinstance(button, bytes):
                 row.append({'text': button.decode('utf-8')})
             else:
-                row.append(button.to_json())
+                row.append(button.to_python())
             if i % self.row_width == 0:
                 self.keyboard.append(row)
                 row = []
@@ -55,7 +55,7 @@ class ReplyKeyboardMarkup(base.TelegramObject):
             if isinstance(button, str):
                 btn_array.append({'text': button})
             else:
-                btn_array.append(button.to_json())
+                btn_array.append(button.to_python())
         self.keyboard.append(btn_array)
         return self
 


### PR DESCRIPTION
While writing a bot, I've caught an error which solves replacing 'to_json' by 'to_python'.