### PR TITLE
Swap around checking of VENUE and LOCATION content

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -95,10 +95,10 @@ class Message(base.TelegramObject):
             return ContentType.VOICE[0]
         if self.contact:
             return ContentType.CONTACT[0]
-        if self.location:
-            return ContentType.LOCATION[0]
         if self.venue:
             return ContentType.VENUE[0]
+        if self.location:
+            return ContentType.LOCATION[0]
         if self.new_chat_members:
             return ContentType.NEW_CHAT_MEMBERS[0]
         if self.left_chat_member:


### PR DESCRIPTION
Fix for issue https://github.com/aiogram/aiogram/issues/26

Venue Message consists of location and venue fields. 
If you check location first - you always set message type = location