### PR TITLE
New markdown method - hide_link

### DIFF
--- a/aiogram/utils/markdown.py
+++ b/aiogram/utils/markdown.py
@@ -185,3 +185,14 @@ def escape_md(*content, sep=' '):
     :return:
     """
     return _escape(_join(*content, sep=sep))
+
+
+def hide_link(url):
+    """
+    Hide URL (HTML only)
+    Can be used for adding an image to a text message
+
+    :param url:
+    :return:
+    """
+    return f'<a href="{url}">&#8203;</a>'


### PR DESCRIPTION
can be used to add images to text posts as preview