### PR TITLE
Add Chat.get_url() method

### DIFF
--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -64,6 +64,19 @@ class Chat(base.TelegramObject):
         if as_html:
             return markdown.hlink(name, self.user_url)
         return markdown.link(name, self.user_url)
+    
+    async def get_url(self):
+        """
+        Use this method to get chat link.
+        Private chat returns user link.
+        Other chat types return either username link (if they are public) or invite link (if they are private).
+        :return: link
+        :rtype: :obj:`base.String`
+        """
+        if self.type == ChatType.PRIVATE:
+            return f"tg://user?id={self.id}"
+
+        return f'https://t.me/{self.username}' if self.username else await self.export_invite_link()
 
     async def set_photo(self, photo):
         """


### PR DESCRIPTION
Use this method to get chat link.
Private chat returns user link.
Other chat types return either username link (if they are public) or invite link (if they are private).