### PR TITLE
Update json.py to fix pyCharm warning

### DIFF
--- a/aiogram/utils/json.py
+++ b/aiogram/utils/json.py
@@ -3,11 +3,10 @@ import json
 try:
     import ujson
 
-    _UJSON_IS_AVAILABLE = True
 except ImportError:
-    _UJSON_IS_AVAILABLE = False
+    ujson = None
 
-_use_ujson = _UJSON_IS_AVAILABLE
+_use_ujson = True if ujson else False
 
 
 def disable_ujson():


### PR DESCRIPTION
fix pyCharm warning
'ujson' in try block with 'except ImportError' should also be defined in except block
This inspection detects names that should resolve but don't. Due to dynamic dispatch and duck typing, this is possible in a limited but useful number of cases. Top-level and class-level items are supported better than instance items.