### PR TITLE
Add aiogram.utils.executor.set_webhook

### DIFF
--- a/aiogram/dispatcher/webhook.py
+++ b/aiogram/dispatcher/webhook.py
@@ -21,6 +21,7 @@ from ..utils.exceptions import TimeoutWarning
 from ..utils.payload import prepare_arg
 
 DEFAULT_WEB_PATH = '/webhook'
+DEFAULT_ROUTE_NAME = 'webhook_handler'
 BOT_DISPATCHER_KEY = 'BOT_DISPATCHER'
 
 RESPONSE_TIMEOUT = 55
@@ -266,16 +267,17 @@ class GoneRequestHandler(web.View):
         raise HTTPGone()
 
 
-def configure_app(dispatcher, app: web.Application, path=DEFAULT_WEB_PATH):
+def configure_app(dispatcher, app: web.Application, path=DEFAULT_WEB_PATH, route_name=DEFAULT_ROUTE_NAME):
     """
     You can prepare web.Application for working with webhook handler.
 
     :param dispatcher: Dispatcher instance
     :param app: :class:`aiohttp.web.Application`
     :param path: Path to your webhook.
+    :param route_name: Name of webhook handler route
     :return:
     """
-    app.router.add_route('*', path, WebhookRequestHandler, name='webhook_handler')
+    app.router.add_route('*', path, WebhookRequestHandler, name=route_name)
     app[BOT_DISPATCHER_KEY] = dispatcher
 
 


### PR DESCRIPTION
# Description

Some applications already use `aiohttp.Application` in their code, so there is no need to create an additional application. This PR adds `aiogram.utils.executor.set_webhook` function that accepts `web_app` argument.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I used `aiogram.utils.executor.set_webhook` function in my bot KgJiraBot. You can reproduce my experience if you create an application of bot that creates `aiohttp.Application` and uses `aiogram.utils.executor.set_webhook`.

**Test Configuration**:
* Operating System: GNU/Linux 4.18.7-1-default, openSUSE Tumbleweed
* Python version: Python 3.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

I didn't include tests because `aiogram.utils.executor` don't have tests at all.