### PR TITLE
DNS over socks proxy

### DIFF
--- a/aiogram/bot/base.py
+++ b/aiogram/bot/base.py
@@ -72,7 +72,7 @@ class BaseBot:
             connector = SocksConnector(socks_ver=socks_ver, host=host, port=port,
                                        username=username, password=password,
                                        limit=connections_limit, ssl_context=ssl_context,
-                                       loop=self.loop)
+                                       rdns=True, loop=self.loop)
 
             self.proxy = None
             self.proxy_auth = None


### PR DESCRIPTION
# Description

Fixes issue when domain name api.telegram.org rewritten on provider's DNS service.

Fixes #97 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

