### PR TITLE
Fix FileStorage data reading

### DIFF
--- a/aiogram/contrib/fsm_storage/files.py
+++ b/aiogram/contrib/fsm_storage/files.py
@@ -15,7 +15,7 @@ class _FileStorage(MemoryStorage):
         path = self.path = pathlib.Path(path)
 
         try:
-            self._data = self.read(path)
+            self.data = self.read(path)
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
# Description

JSONStorage isn't functioning properly at this moment. Once bot restarted, it doesn't consume info that was read during initialization: MemoryStorage is operating with "data" variable, but _FileStorage class puts loaded state to "_data".

## Type of change

- [+] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Simple example without _FileStorage class in the middle solves the issue:

```
class JSONStorage(MemoryStorage):
    def __init__(self, path: typing.Union[pathlib.Path, str]):
        """
        :param path: file path
        """
        super(JSONStorage, self).__init__()
        path = self.path = pathlib.Path(path)

        try:
            self.data = self.read(path)
        except FileNotFoundError:
            pass

    async def close(self):
        self.write(self.path)
        await super(JSONStorage, self).close()

    def read(self, path: pathlib.Path):
        with path.open('r') as f:
            return json.load(f)

    def write(self, path: pathlib.Path):
        with path.open('w') as f:
            return json.dump(self.data, f, indent=4)
```
