### PR TITLE
Typo: data -> bucket in update_bucket

### DIFF
--- a/aiogram/contrib/fsm_storage/redis.py
+++ b/aiogram/contrib/fsm_storage/redis.py
@@ -336,9 +336,9 @@ class RedisStorage2(BaseStorage):
                             bucket: typing.Dict = None, **kwargs):
         if bucket is None:
             bucket = {}
-        temp_bucket = await self.get_data(chat=chat, user=user)
+        temp_bucket = await self.get_bucket(chat=chat, user=user)
         temp_bucket.update(bucket, **kwargs)
-        await self.set_data(chat=chat, user=user, data=temp_bucket)
+        await self.set_bucket(chat=chat, user=user, data=temp_bucket)
 
     async def reset_all(self, full=True):
         """


### PR DESCRIPTION
# Description

Опечатка в RedisStorage2: вместо bucket функций вызывались data.
Это «Breaking change», поскольку меняет ключ обращения к редису, вероятно надо бы предупредить тех, кто пользуется и/или перенести на будущий релиз.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
