### PR TITLE
update exception matcher and fix tests

### DIFF
--- a/aiogram/utils/exceptions.py
+++ b/aiogram/utils/exceptions.py
@@ -12,6 +12,7 @@ TelegramAPIError
             MessageCantBeEdited
             MessageCantBeDeleted
             MessageToEditNotFound
+            MessageToReplyNotFound
             ToMuchMessages
         PollError
             PollCantBeStopped
@@ -182,6 +183,13 @@ class MessageToDeleteNotFound(MessageError):
     match = 'message to delete not found'
 
 
+class MessageToReplyNotFound(MessageError):
+    """
+    Will be raised when you try to reply to very old or deleted or unknown message.
+    """
+    match = 'message to reply not found'
+
+
 class MessageIdentifierNotSpecified(MessageError):
     match = 'message identifier is not specified'
 
@@ -297,8 +305,7 @@ class ChatDescriptionIsNotModified(BadRequest):
 
 
 class InvalidQueryID(BadRequest):
-    match = 'QUERY_ID_INVALID'
-    text = 'Invalid query ID'
+    match = 'query is too old and response timeout expired or query id is invalid'
 
 
 class InvalidPeerID(BadRequest):

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@
 ujson>=1.35
 python-rapidjson>=0.7.0
 emoji>=0.5.2
-pytest>=4.4.1
+pytest>=4.4.1,<4.6
 pytest-asyncio>=0.10.0
 tox>=3.9.0
 aresponses>=1.1.1

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -185,7 +185,7 @@ async def test_send_location(bot: Bot, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_edit_message_live_location(bot: Bot, event_loop):
+async def test_edit_message_live_location_by_bot(bot: Bot, event_loop):
     """ editMessageLiveLocation method test """
     from .types.dataset import MESSAGE_WITH_LOCATION, LOCATION
     msg = types.Message(**MESSAGE_WITH_LOCATION)
@@ -197,6 +197,14 @@ async def test_edit_message_live_location(bot: Bot, event_loop):
                                                       latitude=location.latitude, longitude=location.longitude)
         assert result == msg
 
+
+@pytest.mark.asyncio
+async def test_edit_message_live_location_by_user(bot: Bot, event_loop):
+    """ editMessageLiveLocation method test """
+    from .types.dataset import MESSAGE_WITH_LOCATION, LOCATION
+    msg = types.Message(**MESSAGE_WITH_LOCATION)
+    location = types.Location(**LOCATION)
+
     # editing user's message
     async with FakeTelegram(message_dict=True, loop=event_loop):
         result = await bot.edit_message_live_location(chat_id=msg.chat.id, message_id=msg.message_id,
@@ -205,7 +213,7 @@ async def test_edit_message_live_location(bot: Bot, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_stop_message_live_location(bot: Bot, event_loop):
+async def test_stop_message_live_location_by_bot(bot: Bot, event_loop):
     """ stopMessageLiveLocation method test """
     from .types.dataset import MESSAGE_WITH_LOCATION
     msg = types.Message(**MESSAGE_WITH_LOCATION)
@@ -214,6 +222,13 @@ async def test_stop_message_live_location(bot: Bot, event_loop):
     async with FakeTelegram(message_dict=MESSAGE_WITH_LOCATION, loop=event_loop):
         result = await bot.stop_message_live_location(chat_id=msg.chat.id, message_id=msg.message_id)
         assert result == msg
+
+
+@pytest.mark.asyncio
+async def test_stop_message_live_location_by_user(bot: Bot, event_loop):
+    """ stopMessageLiveLocation method test """
+    from .types.dataset import MESSAGE_WITH_LOCATION
+    msg = types.Message(**MESSAGE_WITH_LOCATION)
 
     # stopping user's message
     async with FakeTelegram(message_dict=True, loop=event_loop):
@@ -509,7 +524,7 @@ async def test_answer_callback_query(bot: Bot, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_edit_message_text(bot: Bot, event_loop):
+async def test_edit_message_text_by_bot(bot: Bot, event_loop):
     """ editMessageText method test """
     from .types.dataset import EDITED_MESSAGE
     msg = types.Message(**EDITED_MESSAGE)
@@ -518,6 +533,13 @@ async def test_edit_message_text(bot: Bot, event_loop):
     async with FakeTelegram(message_dict=EDITED_MESSAGE, loop=event_loop):
         result = await bot.edit_message_text(text=msg.text, chat_id=msg.chat.id, message_id=msg.message_id)
         assert result == msg
+
+
+@pytest.mark.asyncio
+async def test_edit_message_text_by_user(bot: Bot, event_loop):
+    """ editMessageText method test """
+    from .types.dataset import EDITED_MESSAGE
+    msg = types.Message(**EDITED_MESSAGE)
 
     # message by user
     async with FakeTelegram(message_dict=True, loop=event_loop):


### PR DESCRIPTION
# Description

Makes InvalidQueryID conform to new telegram api responses
Adds new exception type MessageToReplyNotFound
Sets pytests `<4.6` according to https://github.com/pytest-dev/pytest/issues/5358
Splits FakeTelegram-based tests into parts (looks like they were failing because of context dirtying)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
