### PR TITLE
Send data from middlewares to filters 

### DIFF
--- a/aiogram/dispatcher/handler.py
+++ b/aiogram/dispatcher/handler.py
@@ -105,7 +105,7 @@ class Handler:
         try:
             for handler_obj in self.handlers:
                 try:
-                    data.update(await check_filters(handler_obj.filters, args))
+                    data.update(await check_filters(handler_obj.filters, args + (data,)))
                 except FilterNotPassed:
                     continue
                 else:


### PR DESCRIPTION
# Description

Send data from middlewares to filters
In middleware, I get a user object from the database, but it is not passed to filters.
Replaced
```data.update(await check_filters(handler_obj.filters, args))```
with
```data.update(await check_filters(handler_obj.filters, args + (data,)))```
as have suggested @gabbhack 

Fixes #124

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
