### PR TITLE
Revert "Send data from middlewares to filters "

### DIFF
--- a/aiogram/dispatcher/handler.py
+++ b/aiogram/dispatcher/handler.py
@@ -105,7 +105,7 @@ class Handler:
         try:
             for handler_obj in self.handlers:
                 try:
-                    data.update(await check_filters(handler_obj.filters, args + (data,)))
+                    data.update(await check_filters(handler_obj.filters, args))
                 except FilterNotPassed:
                     continue
                 else:


### PR DESCRIPTION
Reverts aiogram/aiogram#140

https://pastebin.com/6V75nkTp

``` python3 
future: <Task finished coro=<Dispatcher._process_polling_updates() done, defined at C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\dispatcher.py:274> exception=TypeError('check() takes 2 positional arguments but 3 were given')>
Traceback (most recent call last):
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\dispatcher.py", line 282, in _process_polling_updates
    for responses in itertools.chain.from_iterable(await self.process_updates(updates, fast)):
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\dispatcher.py", line 142, in process_updates
    return await asyncio.gather(*tasks)
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\handler.py", line 117, in notify
    response = await handler_obj.handler(*args, **partial_data)
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\dispatcher.py", line 162, in process_update
    return await self.message_handlers.notify(update.message)
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\handler.py", line 108, in notify
    data.update(await check_filters(handler_obj.filters, args + (data,)))
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\filters\filters.py", line 72, in check_filters
    f = await execute_filter(filter_, args)
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\filters\filters.py", line 56, in execute_filter
    return await filter_.filter(*args, **filter_.kwargs)
  File "C:\Users\Nike\AppData\Local\Programs\Python\Python37\lib\site-packages\aiogram\dispatcher\filters\filters.py", line 161, in __call__
    return await self.check(*args)
TypeError: check() takes 2 positional arguments but 3 were given
```