### PR TITLE
Change how executor.start work

### DIFF
--- a/aiogram/utils/executor.py
+++ b/aiogram/utils/executor.py
@@ -98,22 +98,16 @@ def start_webhook(dispatcher, webhook_path, *, loop=None, skip_updates=None,
     executor.run_app(**kwargs)
 
 
-def start(dispatcher, future, *, loop=None, skip_updates=None,
-          on_startup=None, on_shutdown=None):
+def start(dispatcher, future, *, loop=None):
     """
     Execute Future.
 
     :param dispatcher: instance of Dispatcher
     :param future: future
     :param loop: instance of AbstractEventLoop
-    :param skip_updates:
-    :param on_startup:
-    :param on_shutdown:
     :return:
     """
-    executor = Executor(dispatcher, skip_updates=skip_updates, loop=loop)
-    _setup_callbacks(executor, on_startup, on_shutdown)
-
+    executor = Executor(dispatcher, loop=loop)
     return executor.start(future)
 
 
@@ -326,14 +320,12 @@ class Executor:
         loop: asyncio.AbstractEventLoop = self.loop
 
         try:
-            loop.run_until_complete(self._startup_polling())
             result = loop.run_until_complete(future)
         except (KeyboardInterrupt, SystemExit):
             result = None
             loop.stop()
         finally:
-            loop.run_until_complete(self._shutdown_polling())
-            log.warning("Goodbye!")
+            log.warning("Future received")
         return result
 
     async def _skip_updates(self):


### PR DESCRIPTION
# Description

Remove unnecessary polling actions on executor so executor.start can be run multiple times without issuing aiohttp error "Session is closed"

Use-cases before:
Single run of coroutine after which bot and dispatcher can't be used again.

Use-cases after:
Multiple runs of coroutines which does not interfere with polling and webhook usage.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Sample code:

```
import asyncio
import aiogram
from aiogram.contrib.fsm_storage.memory import MemoryStorage
from aiogram.utils import executor

TELEGRAM_TOKEN = ""
BOT_PROXY = ""
loop = asyncio.get_event_loop()
bot = aiogram.Bot(TELEGRAM_TOKEN, proxy=BOT_PROXY)
storage = MemoryStorage()
dp = aiogram.Dispatcher(bot, loop=loop, storage=storage)

OWNER_ID:int = 0

async def send_stuff():
    await bot.send_message(OWNER_ID,"STUFF")

@dp.message_handler()
async def handler(message:aiogram.types.Message):
    await bot.send_message(message.chat.id,message.text)

executor.start(dp,send_stuff())
executor.start(dp,send_stuff()) # This does not cause errors
executor.start_polling(dp)  # This does not cause errors
```

**Test Configuration**: 
* Operating System: Windows 8.1 (9600)
* Python version: Python 3.7.3 x64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
