### PR TITLE
Closes #138

### DIFF
--- a/aiogram/contrib/fsm_storage/files.py
+++ b/aiogram/contrib/fsm_storage/files.py
@@ -20,7 +20,8 @@ class _FileStorage(MemoryStorage):
             pass
 
     async def close(self):
-        self.write(self.path)
+        if self.data:
+            self.write(self.path)
         await super(_FileStorage, self).close()
 
     def read(self, path: pathlib.Path):


### PR DESCRIPTION
# Description

There is a bug that the file storages doesn't save the data after stop. [Here](https://github.com/aiogram/aiogram/issues/138#issuecomment-504660606) I described why it happens in details. In 2 words, the storages try to save data 2 times, and because of clearing after the first writing, the empty state is being saved on the disk. The solution I came up with is to perform writing only if the `self.data` is not empty. What's the reason to write if we have nothing to be stored? 

Fixes #138 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I tested it manually. Run [this](https://gist.github.com/Birdi7/ffb3077b89d81f897df0d51072a8dbbd) gist to ensure that my solution works.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation. (No need of changes)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
