### PR TITLE
Add enable_cache parameter to lazy_gettext

### DIFF
--- a/aiogram/contrib/middlewares/i18n.py
+++ b/aiogram/contrib/middlewares/i18n.py
@@ -107,7 +107,7 @@ class I18nMiddleware(BaseMiddleware):
         else:
             return translator.ngettext(singular, plural, n)
 
-    def lazy_gettext(self, singular, plural=None, n=1, locale=None) -> LazyProxy:
+    def lazy_gettext(self, singular, plural=None, n=1, locale=None, enable_cache=True) -> LazyProxy:
         """
         Lazy get text
 
@@ -115,9 +115,10 @@ class I18nMiddleware(BaseMiddleware):
         :param plural:
         :param n:
         :param locale:
+        :param enable_cache:
         :return:
         """
-        return LazyProxy(self.gettext, singular, plural, n, locale)
+        return LazyProxy(self.gettext, singular, plural, n, locale, enable_cache=enable_cache)
 
     # noinspection PyMethodMayBeStatic,PyUnusedLocal
     async def get_user_locale(self, action: str, args: Tuple[Any]) -> str:


### PR DESCRIPTION
# Description

Add new parameter `enable_cache` to `i18nMiddleware.lazy_gettext`. Specifies if the value is cached after the first call of .value of LazyProxy object. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
