### PR TITLE
Fix empty text filter

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -221,13 +221,13 @@ class Text(Filter):
         :param ignore_case: case insensitive
         """
         # Only one mode can be used. check it.
-        check = sum(map(bool, (equals, contains, startswith, endswith)))
+        check = sum(map(lambda s: s is not None, (equals, contains, startswith, endswith)))
         if check > 1:
             args = "' and '".join([arg[0] for arg in [('equals', equals),
                                                       ('contains', contains),
                                                       ('startswith', startswith),
                                                       ('endswith', endswith)
-                                                      ] if arg[1]])
+                                                      ] if arg[1] is not None])
             raise ValueError(f"Arguments '{args}' cannot be used together.")
         elif check == 0:
             raise ValueError(f"No one mode is specified!")
@@ -266,22 +266,22 @@ class Text(Filter):
         if self.ignore_case:
             text = text.lower()
 
-        if self.equals:
+        if self.equals is not None:
             self.equals = str(self.equals)
             if self.ignore_case:
                 self.equals = self.equals.lower()
             return text == self.equals
-        elif self.contains:
+        elif self.contains is not None:
             self.contains = str(self.contains)
             if self.ignore_case:
                 self.contains = self.contains.lower()
             return self.contains in text
-        elif self.startswith:
+        elif self.startswith is not None:
             self.startswith = str(self.startswith)
             if self.ignore_case:
                 self.startswith = self.startswith.lower()
             return text.startswith(self.startswith)
-        elif self.endswith:
+        elif self.endswith is not None:
             self.endswith = str(self.endswith)
             if self.ignore_case:
                 self.endswith = self.endswith.lower()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,12 @@ from aiogram.types import Message, CallbackQuery, InlineQuery, Poll
 class TestTextFilter:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_prefix, test_text, ignore_case",
-                             [('example_string', 'example_string', True),
+                             [('', '', True),
+                              ('', 'exAmple_string', True),
+                              ('', '', False),
+                              ('', 'exAmple_string', False),
+
+                              ('example_string', 'example_string', True),
                               ('example_string', 'exAmple_string', True),
                               ('exAmple_string', 'example_string', True),
 
@@ -52,7 +57,12 @@ class TestTextFilter:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_postfix, test_text, ignore_case",
-                             [('example_string', 'example_string', True),
+                             [('', '', True),
+                              ('', 'exAmple_string', True),
+                              ('', '', False),
+                              ('', 'exAmple_string', False),
+
+                              ('example_string', 'example_string', True),
                               ('example_string', 'exAmple_string', True),
                               ('exAmple_string', 'example_string', True),
 
@@ -97,7 +107,12 @@ class TestTextFilter:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_string, test_text, ignore_case",
-                             [('example_string', 'example_string', True),
+                             [('', '', True),
+                              ('', 'exAmple_string', True),
+                              ('', '', False),
+                              ('', 'exAmple_string', False),
+
+                              ('example_string', 'example_string', True),
                               ('example_string', 'exAmple_string', True),
                               ('exAmple_string', 'example_string', True),
 
@@ -142,7 +157,12 @@ class TestTextFilter:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_filter_text, test_text, ignore_case",
-                             [('example_string', 'example_string', True),
+                             [('', '', True),
+                              ('', 'exAmple_string', True),
+                              ('', '', False),
+                              ('', 'exAmple_string', False),
+
+                              ('example_string', 'example_string', True),
                               ('example_string', 'exAmple_string', True),
                               ('exAmple_string', 'example_string', True),
 


### PR DESCRIPTION
# Description

The current implementation of the Text filter doesn't allow an empty string as a string to match to. But, as suggested in [aiogram_ru#79691](https://t.me/aiogram_ru/79691), in inline query handler the empty string can be a value we got from user. As @JrooTJunior suggested in [aiogram_ru#79697](https://t.me/aiogram_ru/79697), I replaced checking from `bool` to `is None`, and added tests to check it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added unit tests to every method of Text filter(equals, startswith, endswith, contains) to check for positive and negative results with ignore_case both `True` and `False`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
