### PR TITLE
Add multiple text filter

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -213,11 +213,12 @@ class Text(Filter):
                  ignore_case=False):
         """
         Check text for one of pattern. Only one mode can be used in one filter.
+        In every pattern, a single string is treated as a list with 1 element.
 
-        :param equals:
-        :param contains:
-        :param startswith:
-        :param endswith:
+        :param equals: True if object text in the list
+        :param contains: True if object text contains all strings from the list
+        :param startswith: True if object text startswith any of strings from the list
+        :param endswith: True if object text endswith any of strings from the list
         :param ignore_case: case insensitive
         """
         # Only one mode can be used. check it.

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -274,7 +274,7 @@ class Text(Filter):
             return text in self.equals
         elif self.contains is not None:
             self.contains = list(map(lambda s: str(s).lower() if self.ignore_case else str(s), self.contains))
-            return any(map(text.__contains__, self.contains))
+            return all(map(text.__contains__, self.contains))
         elif self.startswith is not None:
             self.startswith = list(map(lambda s: str(s).lower() if self.ignore_case else str(s), self.startswith))
             return any(map(text.startswith, self.startswith))

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -215,10 +215,10 @@ class Text(Filter):
         Check text for one of pattern. Only one mode can be used in one filter.
         In every pattern, a single string is treated as a list with 1 element.
 
-        :param equals: True if object text in the list
-        :param contains: True if object text contains all strings from the list
-        :param startswith: True if object text startswith any of strings from the list
-        :param endswith: True if object text endswith any of strings from the list
+        :param equals: True if object's text in the list
+        :param contains: True if object's text contains all strings from the list
+        :param startswith: True if object's text starts with any of strings from the list
+        :param endswith: True if object's text ends with any of strings from the list
         :param ignore_case: case insensitive
         """
         # Only one mode can be used. check it.

--- a/examples/text_filter_example.py
+++ b/examples/text_filter_example.py
@@ -1,0 +1,50 @@
+"""
+This is a bot to show the usage of the builtin Text filter
+Instead of a list, a single element can be passed to any filter, it will be treated as list with an element
+"""
+
+import logging
+
+from aiogram import Bot, Dispatcher, executor, types
+
+API_TOKEN = 'API_TOKEN_HERE'
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
+# Initialize bot and dispatcher
+bot = Bot(token=API_TOKEN)
+dp = Dispatcher(bot)
+
+# if the text from user in the list
+@dp.message_handler(text=['text1', 'text2'])
+async def text_in_handler(message: types.Message):
+    await message.answer("The message text is in the list!")
+
+# if the text contains any string
+@dp.message_handler(text_contains='example1')
+@dp.message_handler(text_contains='example2')
+async def text_contains_any_handler(message: types.Message):
+    await message.answer("The message text contains any of strings")
+
+
+# if the text contains all the strings from the list
+@dp.message_handler(text_contains=['str1', 'str2'])
+async def text_contains_all_handler(message: types.Message):
+    await message.answer("The message text contains all strings from the list")
+
+
+# if the text starts with any string from the list
+@dp.message_handler(text_startswith=['prefix1', 'prefix2'])
+async def text_startswith_handler(message: types.Message):
+    await message.answer("The message text starts with any of prefixes")
+
+
+# if the text ends with any string from the list
+@dp.message_handler(text_endswith=['postfix1', 'postfix2'])
+async def text_endswith_handler(message: types.Message):
+    await message.answer("The message text ends with any of postfixes")
+
+
+if __name__ == '__main__':
+    executor.start_polling(dp, skip_updates=True)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -195,3 +195,60 @@ class TestTextFilter:
         assert await check(CallbackQuery(data=test_text))
         assert await check(InlineQuery(query=test_text))
         assert await check(Poll(question=test_text))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_filter_list, test_text, ignore_case",
+                             [(['', 'new_string'], '', True),
+                              (['new_string', ''], 'exAmple_string', True),
+                              (['new_string', ''], '', False),
+                              (['', 'new_string'], 'exAmple_string', False),
+
+                              (['example_string'], 'example_string', True),
+                              (['example_string'], 'exAmple_string', True),
+                              (['exAmple_string'], 'example_string', True),
+
+                              (['example_string'], 'example_string', False),
+                              (['example_string'], 'exAmple_string', False),
+                              (['exAmple_string'], 'example_string', False),
+
+                              (['example_string'], 'not_example_string', True),
+                              (['example_string'], 'not_eXample_string', True),
+                              (['EXample_string'], 'not_eXample_string', True),
+
+                              (['example_string'], 'not_example_string', False),
+                              (['example_string'], 'not_eXample_string', False),
+                              (['EXample_string'], 'not_example_string', False),
+
+                              (['example_string', 'new_string'], 'example_string', True),
+                              (['new_string', 'example_string'], 'exAmple_string', True),
+                              (['exAmple_string', 'new_string'], 'example_string', True),
+
+                              (['example_string', 'new_string'], 'example_string', False),
+                              (['new_string', 'example_string'], 'exAmple_string', False),
+                              (['exAmple_string', 'new_string'], 'example_string', False),
+
+                              (['example_string', 'new_string'], 'not_example_string', True),
+                              (['new_string', 'example_string'], 'not_eXample_string', True),
+                              (['EXample_string', 'new_string'], 'not_eXample_string', True),
+
+                              (['example_string', 'new_string'], 'not_example_string', False),
+                              (['new_string', 'example_string'], 'not_eXample_string', False),
+                              (['EXample_string', 'new_string'], 'not_example_string', False),
+                              ])
+    async def test_equals_list(self, test_filter_list, test_text, ignore_case):
+        test_filter = Text(equals=test_filter_list, ignore_case=ignore_case)
+
+        async def check(obj):
+            result = await test_filter.check(obj)
+            if ignore_case:
+                _test_filter_list = list(map(str.lower, test_filter_list))
+                _test_text = test_text.lower()
+            else:
+                _test_filter_list = test_filter_list
+                _test_text = test_text
+            assert result is (_test_text in _test_filter_list)
+
+        await check(Message(text=test_text))
+        await check(CallbackQuery(data=test_text))
+        await check(InlineQuery(query=test_text))
+        await check(Poll(question=test_text))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -56,6 +56,56 @@ class TestTextFilter:
         assert await check(Poll(question=test_text))
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_prefix_list, test_text, ignore_case",
+                             [(['not_example', ''], '', True),
+                              (['', 'not_example'], 'exAmple_string', True),
+                              (['not_example', ''], '', False),
+                              (['', 'not_example'], 'exAmple_string', False),
+
+                              (['example_string', 'not_example'], 'example_string', True),
+                              (['not_example', 'example_string'], 'exAmple_string', True),
+                              (['exAmple_string', 'not_example'], 'example_string', True),
+
+                              (['not_example', 'example_string'], 'example_string', False),
+                              (['example_string', 'not_example'], 'exAmple_string', False),
+                              (['not_example', 'exAmple_string'], 'example_string', False),
+
+                              (['example_string', 'not_example'], 'example_string_dsf', True),
+                              (['not_example', 'example_string'], 'example_striNG_dsf', True),
+                              (['example_striNG', 'not_example'], 'example_string_dsf', True),
+
+                              (['not_example', 'example_string'], 'example_string_dsf', False),
+                              (['example_string', 'not_example'], 'example_striNG_dsf', False),
+                              (['not_example', 'example_striNG'], 'example_string_dsf', False),
+
+                              (['example_string', 'not_example'], 'not_example_string', True),
+                              (['not_example', 'example_string'], 'not_eXample_string', True),
+                              (['EXample_string', 'not_example'], 'not_example_string', True),
+
+                              (['not_example', 'example_string'], 'not_example_string', False),
+                              (['example_string', 'not_example'], 'not_eXample_string', False),
+                              (['not_example', 'EXample_string'], 'not_example_string', False),
+                              ])
+    async def test_startswith_list(self, test_prefix_list, test_text, ignore_case):
+        test_filter = Text(startswith=test_prefix_list, ignore_case=ignore_case)
+
+        async def check(obj):
+            result = await test_filter.check(obj)
+            if ignore_case:
+                _test_prefix_list = map(str.lower, test_prefix_list)
+                _test_text = test_text.lower()
+            else:
+                _test_prefix_list = test_prefix_list
+                _test_text = test_text
+
+            return result is any(map(_test_text.startswith, _test_prefix_list))
+
+        assert await check(Message(text=test_text))
+        assert await check(CallbackQuery(data=test_text))
+        assert await check(InlineQuery(query=test_text))
+        assert await check(Poll(question=test_text))
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("test_postfix, test_text, ignore_case",
                              [('', '', True),
                               ('', 'exAmple_string', True),
@@ -106,6 +156,55 @@ class TestTextFilter:
         assert await check(Poll(question=test_text))
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_postfix_list, test_text, ignore_case",
+                             [(['', 'not_example'], '', True),
+                              (['not_example', ''], 'exAmple_string', True),
+                              (['', 'not_example'], '', False),
+                              (['not_example', ''], 'exAmple_string', False),
+
+                              (['example_string', 'not_example'], 'example_string', True),
+                              (['not_example', 'example_string'], 'exAmple_string', True),
+                              (['exAmple_string', 'not_example'], 'example_string', True),
+
+                              (['example_string', 'not_example'], 'example_string', False),
+                              (['not_example', 'example_string'], 'exAmple_string', False),
+                              (['exAmple_string', 'not_example'], 'example_string', False),
+
+                              (['example_string', 'not_example'], 'example_string_dsf', True),
+                              (['not_example', 'example_string'], 'example_striNG_dsf', True),
+                              (['example_striNG', 'not_example'], 'example_string_dsf', True),
+
+                              (['not_example', 'example_string'], 'example_string_dsf', False),
+                              (['example_string', 'not_example'], 'example_striNG_dsf', False),
+                              (['not_example', 'example_striNG'], 'example_string_dsf', False),
+
+                              (['not_example', 'example_string'], 'not_example_string', True),
+                              (['example_string', 'not_example'], 'not_eXample_string', True),
+                              (['not_example', 'EXample_string'], 'not_eXample_string', True),
+
+                              (['not_example', 'example_string'], 'not_example_string', False),
+                              (['example_string', 'not_example'], 'not_eXample_string', False),
+                              (['not_example', 'EXample_string'], 'not_example_string', False),
+                              ])
+    async def test_endswith_list(self, test_postfix_list, test_text, ignore_case):
+        test_filter = Text(endswith=test_postfix_list, ignore_case=ignore_case)
+
+        async def check(obj):
+            result = await test_filter.check(obj)
+            if ignore_case:
+                _test_postfix_list = map(str.lower, test_postfix_list)
+                _test_text = test_text.lower()
+            else:
+                _test_postfix_list = test_postfix_list
+                _test_text = test_text
+
+            return result is any(map(_test_text.endswith, _test_postfix_list))
+        assert await check(Message(text=test_text))
+        assert await check(CallbackQuery(data=test_text))
+        assert await check(InlineQuery(query=test_text))
+        assert await check(Poll(question=test_text))
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("test_string, test_text, ignore_case",
                              [('', '', True),
                               ('', 'exAmple_string', True),
@@ -149,6 +248,37 @@ class TestTextFilter:
                 _test_text = test_text
 
             return result is (_test_string in _test_text)
+
+        assert await check(Message(text=test_text))
+        assert await check(CallbackQuery(data=test_text))
+        assert await check(InlineQuery(query=test_text))
+        assert await check(Poll(question=test_text))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_filter_list, test_text, ignore_case",
+                             [(['a', 'ab', 'abc'], 'A', True),
+                              (['a', 'ab', 'abc'], 'ab', True),
+                              (['a', 'ab', 'abc'], 'aBc', True),
+                              (['a', 'ab', 'abc'], 'd', True),
+
+                              (['a', 'ab', 'abc'], 'A', False),
+                              (['a', 'ab', 'abc'], 'ab', False),
+                              (['a', 'ab', 'abc'], 'aBc', False),
+                              (['a', 'ab', 'abc'], 'd', False),
+                              ])
+    async def test_contains_list(self, test_filter_list, test_text, ignore_case):
+        test_filter = Text(contains=test_filter_list, ignore_case=ignore_case)
+
+        async def check(obj):
+            result = await test_filter.check(obj)
+            if ignore_case:
+                _test_filter_list = list(map(str.lower, test_filter_list))
+                _test_text = test_text.lower()
+            else:
+                _test_filter_list = test_filter_list
+                _test_text = test_text
+
+            return result is all(map(_test_text.__contains__, _test_filter_list))
 
         assert await check(Message(text=test_text))
         assert await check(CallbackQuery(data=test_text))


### PR DESCRIPTION
# Description

Add the multiple text filter as required at #151, `Multiple text filter (aiogram_ru#73126)`.
The following patterns are applied for comparison methods: 
- equals - **True** if **any** of strings in the list is equal to the text
- contains - **True** if the text contains **all** strings from the list. Reason: There is no way to do such comparison right now (except using custom filters), while the condition "if the text contains any string" can be implemented with a bunch of `register_message_handler`
- startswith - **True** if text starts with **any** string from the list. Reason: There is no need to implement "if text starts with all strings from the list" as all prefixes can be mixed in one 
- endswith - **True** if text ends with **any** string from the list. Reason: There is no need to implement "if text ends with all strings from the list" as all postfixes can be mixed in one

Tests are included for all methods. An example of usage was added.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
