### PR TITLE
Fix stacklevel arguments in renamed arguments in the dispatcher

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -915,7 +915,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
         return FSMContext(storage=self.storage, chat=chat, user=user)
 
-    @renamed_argument(old_name='user', new_name='user_id', until_version='3.0', stacklevel=4)
+    @renamed_argument(old_name='user', new_name='user_id', until_version='3.0', stacklevel=3)
     @renamed_argument(old_name='chat', new_name='chat_id', until_version='3.0', stacklevel=4)
     async def throttle(self, key, *, rate=None, user_id=None, chat_id=None, no_error=None) -> bool:
         """
@@ -975,7 +975,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         return result
 
     @renamed_argument('user', 'user_id', '3.0')
-    @renamed_argument('chat', 'chat_id', '3.0')
+    @renamed_argument('chat', 'chat_id', '3.0', stacklevel=4)
     async def check_key(self, key, chat_id=None, user_id=None):
         """
         Get information about key in bucket
@@ -997,7 +997,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         return Throttled(key=key, chat=chat_id, user=user_id, **data)
 
     @renamed_argument('user', 'user_id', '3.0')
-    @renamed_argument('chat', 'chat_id', '3.0')
+    @renamed_argument('chat', 'chat_id', '3.0', stacklevel=4)
     async def release_key(self, key, chat_id=None, user_id=None):
         """
         Release blocked key

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -974,8 +974,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise Throttled(key=key, chat=chat_id, user=user_id, **data)
         return result
 
-    @renamed_argument('user', 'user_id', '3.0')
-    @renamed_argument('chat', 'chat_id', '3.0', stacklevel=4)
+    @renamed_argument(old_name='user', new_name='user_id', until_version='3.0', stacklevel=3)
+    @renamed_argument(old_name='chat', new_name='chat_id', until_version='3.0', stacklevel=4)
     async def check_key(self, key, chat_id=None, user_id=None):
         """
         Get information about key in bucket
@@ -996,8 +996,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         data = bucket.get(key, {})
         return Throttled(key=key, chat=chat_id, user=user_id, **data)
 
-    @renamed_argument('user', 'user_id', '3.0')
-    @renamed_argument('chat', 'chat_id', '3.0', stacklevel=4)
+    @renamed_argument(old_name='user', new_name='user_id', until_version='3.0', stacklevel=3)
+    @renamed_argument(old_name='chat', new_name='chat_id', until_version='3.0', stacklevel=4)
     async def release_key(self, key, chat_id=None, user_id=None):
         """
         Release blocked key


### PR DESCRIPTION
# Description

Fix the values of stack levels in 3 methods in the Dispatcher. 
Here is before: ![](https://i.ibb.co/g7ds9d9/before.png)
And this is after: ![](https://i.ibb.co/Y2rRKgF/after.png)
Used listing is [here](https://gist.github.com/Birdi7/61190b0543fa9e4d590cc811ea35a800)
The output points to the actual line where the function was invoked with the deprecated argument, so it will be easier to debug.
Also, I replaced the positional arguments to kwargs

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
