### PR TITLE
emit warning if command starts with command prefix

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -51,19 +51,11 @@ class Command(Filter):
         self.prefixes = prefixes
         self.ignore_case = ignore_case
         self.ignore_mention = ignore_mention
-        for command in self.commands:
-            if not isinstance(self.prefixes, str):
-                for prefix in self.prefixes:
-                    if command.startswith(prefix):
-                        warn(
-                            f'command "{command}" starts with command prefix "{prefix}", so handler will trigger '
-                            f'only on "{prefix + command}" command. Remove leading command prefix to avoid this '
-                            f'behavior.', UserWarning)
-            else:
-                if command.startswith(self.prefixes):
-                    warn(f'command "{command}" starts with command prefix "{self.prefixes}", so handler will trigger '
-                         f'only on "{self.prefixes + command}" command. Remove leading command prefix to avoid this '
-                         f'behavior.', UserWarning)
+        _prefixes = [self.prefixes, ] if isinstance(self.prefixes, str) else self.prefixes
+        for _prefix in _prefixes:
+            if any(command.startswith(_prefix) for command in self.commands):
+                warn(f'One or more commands start with command prefix "{_prefix}" '
+                     f'Remove leading command prefix to avoid this behavior.', UserWarning)
 
     @classmethod
     def validate(cls, full_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -4,6 +4,7 @@ import typing
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Optional, Union
+from warnings import warn
 
 from babel.support import LazyProxy
 
@@ -50,6 +51,19 @@ class Command(Filter):
         self.prefixes = prefixes
         self.ignore_case = ignore_case
         self.ignore_mention = ignore_mention
+        for command in self.commands:
+            if not isinstance(self.prefixes, str):
+                for prefix in self.prefixes:
+                    if command.startswith(prefix):
+                        warn(
+                            f'command "{command}" starts with command prefix "{prefix}", so handler will trigger '
+                            f'only on "{prefix + command}" command. Remove leading command prefix to avoid this '
+                            f'behavior.', UserWarning)
+            else:
+                if command.startswith(self.prefixes):
+                    warn(f'command "{command}" starts with command prefix "{self.prefixes}", so handler will trigger '
+                         f'only on "{self.prefixes + command}" command. Remove leading command prefix to avoid this '
+                         f'behavior.', UserWarning)
 
     @classmethod
     def validate(cls, full_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
# Description

Added feature from https://github.com/aiogram/aiogram/issues/206
which emits a warning when command starts with command prefix.

Fixes # 206

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Just running following code: https://gist.github.com/LuckCky/0b8dd8d7f930a6c0abe394ffb7a862ac

**Test Configuration**:
* Operating System: Ubuntu 18.04.3 LTS
* Python version: 3.7.4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
