### PR TITLE
Private chat links

### DIFF
--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -63,6 +63,16 @@ class Chat(base.TelegramObject):
 
         return f"tg://user?id={self.id}"
 
+    @property
+    def shifted_id(self) -> int:
+        """
+        Get shifted id of chat, e.g. for private links
+
+        For example: -1001122334455 -> 1122334455
+        """
+        shift = -1000000000000
+        return shift - self.id
+
     def get_mention(self, name=None, as_html=False):
         if name is None:
             name = self.mention

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -70,6 +70,8 @@ class Chat(base.TelegramObject):
 
         For example: -1001122334455 -> 1122334455
         """
+        if self.type == ChatType.PRIVATE:
+            raise TypeError('`shifted_id` property is not available for private chats')
         shift = -1000000000000
         return shift - self.id
 

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -258,12 +258,19 @@ class Message(base.TelegramObject):
 
         :return: str
         """
-        if self.chat.type not in [ChatType.SUPER_GROUP, ChatType.CHANNEL]:
+        if ChatType.is_private(self.chat):
             raise TypeError('Invalid chat type!')
-        elif not self.chat.username:
-            raise TypeError('This chat does not have @username')
 
-        return f"https://t.me/{self.chat.username}/{self.message_id}"
+        url = 'https://t.me/'
+        if self.chat.username:
+            # Generates public link
+            url += f'{self.chat.username}/'
+        else:
+            # Generates private link available for chat members
+            url += f'c/{self.chat.shifted_id}/'
+        url += f'{self.message_id}'
+
+        return url
 
     def link(self, text, as_html=True) -> str:
         """


### PR DESCRIPTION
# Description

Support links for non-public chats from this update:
https://telegram.org/blog/archive-and-new-design#easier-forwarding-links-to-messages-online-badges

For example: `https://t.me/c/1122334455/1`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Via package tests

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
