### PR TITLE
Replaced is_admin() with is_chat_admin() in filters example

### DIFF
--- a/docs/source/migration_1_to_2.rst
+++ b/docs/source/migration_1_to_2.rst
@@ -73,7 +73,7 @@ Also you can bind your own filters for using as keyword arguments:
             
         async def check(self, message: types.Message):
             member = await bot.get_chat_member(message.chat.id, message.from_user.id)
-            return member.is_admin()
+            return member.is_chat_admin()
 
     dp.filters_factory.bind(MyFilter)
 


### PR DESCRIPTION
# Description
As seed in [ChatMember](https://github.com/aiogram/aiogram/blob/dev-2.x/aiogram/types/chat_member.py#L36) description, there's no `is_admin()` function, but `is_chat_admin()`.

## Type of change
- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?
Tried once, worked for me
