### PR TITLE
enable syntax 'key in dispatcher', issue #233

### DIFF
--- a/aiogram/utils/mixins.py
+++ b/aiogram/utils/mixins.py
@@ -22,6 +22,9 @@ class DataMixin:
     def __delitem__(self, key):
         del self.data[key]
 
+    def __contains__(self, key):
+        return key in self.data
+
     def get(self, key, default=None):
         return self.data.get(key, default)
 


### PR DESCRIPTION
# Description

enable use syntax 'key in Obj' for objects who inherits from DataMixin

Fixes #233 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


**Test Configuration**:
* Operating System: darwin, ubuntu
* Python version: 3.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
