### PR TITLE
Data validity condition changed

### DIFF
--- a/aiogram/utils/callback_data.py
+++ b/aiogram/utils/callback_data.py
@@ -75,7 +75,7 @@ class CallbackData:
             raise TypeError('Too many arguments were passed!')
 
         callback_data = self.sep.join(data)
-        if len(callback_data) > 64:
+        if len(callback_data.encode()) > 64:
             raise ValueError('Resulted callback data is too long!')
 
         return callback_data


### PR DESCRIPTION
The Telegram Bot API documentation says that callback_data is of type String and has a size of 1-64 bytes. Therefore, in my opinion, it will be more correct to translate the resulting data into bytes, rather than counting the length of the string.

Such data will be verified:
```
from aiogram.utils.callback_data import CallbackData
cb_factory = CallbackData("pref", "name")
cb = cb_factory.new(name="абвгдеёжзийклмнопрстуфхцчшщъыьэюя")
# >>> cb
# 'pref:абвгдеёжзийклмнопрстуфхцчшщъыьэюя'
```
Although this should not be:
```
>>> len(cb)
38
>>> len(cb.encode())
71
```