### PR TITLE
fix: renamed_argument decorator error

### DIFF
--- a/aiogram/utils/deprecated.py
+++ b/aiogram/utils/deprecated.py
@@ -102,14 +102,18 @@ def renamed_argument(old_name: str, new_name: str, until_version: str, stackleve
         is_coroutine = asyncio.iscoroutinefunction(func)
 
         def _handling(kwargs):
+            """
+            Returns updated version of kwargs.
+            """
             routine_type = 'coroutine' if is_coroutine else 'function'
             if old_name in kwargs:
                 warn_deprecated(f"In {routine_type} '{func.__name__}' argument '{old_name}' "
                                 f"is renamed to '{new_name}' "
                                 f"and will be removed in aiogram {until_version}",
                                 stacklevel=stacklevel)
+                kwargs = kwargs.copy()
                 kwargs.update({new_name: kwargs.pop(old_name)})
-                return kwargs
+            return kwargs
 
         if is_coroutine:
             @functools.wraps(func)


### PR DESCRIPTION
Fix the error in the decorator. In theory, a lot of existing library code is affected by this bug. Also, I removed hidden mutation of input in _handling function. Here are the my explanations of the solution for the bug: https://t.me/aiogram_ru/139903

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
