### PR TITLE
Fix CommandStart filter

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -180,7 +180,7 @@ class CommandStart(Command):
                 return {'deep_link': match}
             return False
 
-        return False
+        return check
 
 
 class CommandHelp(Command):


### PR DESCRIPTION
# Description

Bug fix when CommansStart filter does not work on /start.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
