### PR TITLE
Fix ContentTypeFilter

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -444,6 +444,8 @@ class ContentTypeFilter(BoundFilter):
     default = types.ContentTypes.TEXT
 
     def __init__(self, content_types):
+        if isinstance(content_types, str):
+            content_types = (content_types,)
         self.content_types = content_types
 
     async def check(self, message):


### PR DESCRIPTION
Now the ContentTypeFilter  works correctly with single elements.

# Description

Almost all filters in aiogram can work with single elements, but ContentTypeFilter could not.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
