### PR TITLE
Add GitHub Actions workflow to publish packages

### DIFF
--- a/.github/workflows/aur/Dockerfile
+++ b/.github/workflows/aur/Dockerfile
@@ -1,0 +1,31 @@
+FROM archlinux/base
+ENV LC_ALL=C
+ARG AUR_SSH_KEY
+ARG GIT_EMAIL
+ARG GIT_NAME
+ARG aiogram_ver
+ENV AIOGRAM_VERSION=${aiogram_ver}
+
+RUN mkdir -p /etc/sudoers.d \
+    && echo "makepkg ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/01_makepkg \
+    && useradd -d /var/build -g users -mNrs /bin/bash makepkg
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh \
+    && pacman -Syu base-devel pacman-contrib git openssh --noconfirm --needed \
+    && rm -rf /var/cache/pacman/pkg/*
+
+WORKDIR /var/build
+USER makepkg
+
+RUN mkdir /var/build/.ssh \
+    && echo "${AUR_SSH_KEY}" >/var/build/.ssh/id_rsa \
+    && chmod 400 /var/build/.ssh/id_rsa \
+    && echo "aur.archlinux.org,5.9.250.164 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOZAVWmj2k+dHTfyum7FyIivGcVUkDFHaXmPNxDwF7l8TvkAN8VDQJHEEGJhALMYtNsQ+kt0gksSh4HZqj9n5hI=" >/var/build/.ssh/known_hosts \
+    && git config --global user.email ${GIT_EMAIL} \
+    && git config --global user.name "${GIT_NAME}"
+
+COPY --chown=makepkg:users PKGBUILD ./PKGBUILD
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/aur/PKGBUILD
+++ b/.github/workflows/aur/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Evgeniy Filimonov <evgfilim1@gmail.com>
+
+_pyname='aiogram'
+pkgname="python-${_pyname}"
+pkgver=
+pkgrel=1
+pkgdesc="Modern and fully asynchronous library for Telegram Bot API written in Python 3.7 with asyncio and aiohttp"
+arch=('any')
+url="https://github.com/${_pyname}/${_pyname}"
+license=('MIT')
+depends=(
+    'python>=3.7' 'python<4.0'
+    'python-aiohttp>=3.6' 'python-aiohttp<4.0'
+    'python-pydantic>=1.2' 'python-pydantic<2.0'
+    'python-babel>=2.7' 'python-babel<3.0'
+    'python-aiofiles>=0.4.0' 'python-aiofiles<1.0'
+    'python-async_lru>=1.0' 'python-async_lru<2.0'
+)
+makedepends=(
+    'python-pip'
+)
+optdepends=(
+    'python-uvloop: fast, drop-in replacement of the built-in asyncio event loop'
+    'python-aiohttp-socks: SOCKS4(a) and SOCKS5 proxy support'
+)
+source=("${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "$srcdir/${_pyname}-${pkgver}"
+    PIP_CONFIG_FILE=/dev/null pip wheel --isolated --no-deps .
+}
+
+package() {
+    cd "$srcdir/${_pyname}-${pkgver}"
+    PIP_CONFIG_FILE=/dev/null pip install --isolated --ignore-installed --no-deps --root="$pkgdir" "aiogram-${pkgver}-py3-none-any.whl"
+
+    install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}
+
+# vim: ft=sh ts=4 sw=4 et

--- a/.github/workflows/aur/entrypoint.sh
+++ b/.github/workflows/aur/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+main() {
+    case "${1:-}" in
+        build)
+            build
+            ;;
+        commit)
+            prepublish
+            git diff origin/master
+            git log --oneline | head -n5
+            ;;
+        publish)
+            prepublish
+            publish
+            ;;
+        shell)
+            exec /bin/bash -
+            ;;
+        *)
+            echo "No such command!" >&2
+            exit 127
+            ;;
+    esac
+}
+
+prepare_pkgbuild() {
+    sed -Ei "s/^pkgver=$/pkgver=${AIOGRAM_VERSION}/" PKGBUILD
+    updpkgsums
+}
+
+build() {
+    prepare_pkgbuild
+    makepkg -sicC --noconfirm --noprogressbar
+}
+
+prepare_git() {
+    mkdir dist && cd dist
+    git init
+    git remote add origin ssh://aur@aur.archlinux.org/python-aiogram.git
+    git pull origin master
+}
+
+commit() {
+    git add PKGBUILD .SRCINFO
+    git commit -m 'New version: v'"${AIOGRAM_VERSION}"
+}
+
+prepublish() {
+    prepare_pkgbuild
+    prepare_git
+    cp ../PKGBUILD ./
+    makepkg --printsrcinfo >.SRCINFO
+    commit
+}
+
+publish() {
+    git push -u origin master
+}
+
+# check whether running as script or sourced by another shell (not reliable)
+if [[ "$(basename $0)" = "entrypoint.sh" ]]; then
+    set -euo pipefail
+    main $@
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Publish packages
+
+on:
+    push:
+        branches:
+          - 'releases/**'
+        tags:
+          - v3
+          - v3.*
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout repo
+            uses: actions/checkout@v2
+          - name: Set up Python 3.7
+            uses: actions/setup-python@v1
+            with:
+                python-version: 3.7
+          - name: Install dependencies
+            run: |
+                python -m pip install --upgrade pip poetry==1.0
+          - name: Build wheel
+            run: |
+                poetry build
+          - name: Publish to PyPI
+            env:
+                POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+            run: |
+                poetry publish
+          - name: Prepare AUR package
+            env:
+                AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+                GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+                GIT_NAME: ${{ secrets.GIT_NAME }}
+            run: >
+                docker build
+                  ./.github/workflows/aur
+                  --build-arg AUR_SSH_KEY
+                  --build-arg aiogram_ver="$(git describe --tags ${GITHUB_REF}
+                                             | sed -E 's/^v//')"
+                  --build-arg GIT_EMAIL
+                  --build-arg GIT_NAME
+                  -t aiogram/aur
+          - name: Build and publish AUR package
+            run: |
+                docker run aiogram/aur build && docker run aiogram/aur publish


### PR DESCRIPTION
## Description
Add GitHub Actions workflow to publish packages to [PyPI][pypi] and [AUR][aur] (Fixes #235)

To make this work, you must create these secrets:
- `PYPI_TOKEN` — PyPI token which is used to publish packages
- `AUR_SSH_KEY` — **private** SSH key configured to access AUR
- `GIT_EMAIL` — email of git committer (will be shown in AUR-git repo)
- `GIT_NAME` — name of git committer (will be shown in AUR-git repo)

## Type of change
- New feature (non-breaking change which adds functionality)

## How has this been tested?
It was tested with some changes in my fork with GitHub Actions, but _this_ version wasn't tested as it requires aiogram 3.x to be released.

[pypi]: https://pypi.org/project/aiogram/
[aur]: https://aur.archlinux.org/packages/python-aiogram/
