### PR TITLE
fix: send_copy for poll: missed attribute getting

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -1654,7 +1654,7 @@ class Message(base.TelegramObject):
         elif self.poll:
             kwargs.pop("parse_mode")
             return await self.bot.send_poll(
-                question=self.poll.question, options=self.poll.options, **kwargs
+                question=self.poll.question, options=[option.text for option in self.poll.options], **kwargs
             )
         else:
             raise TypeError("This type of message can't be copied.")


### PR DESCRIPTION
# Description

Fixed error: sending `PollOption` instead of `str`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By sending poll
