### PR TITLE
fix redis pool connection closing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/html
 
 # i18n/l10n
 *.mo
+
+# pynev
+.python-version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,35 @@
-# pytest_plugins = "pytest_asyncio.plugin"
+import pytest
+from _pytest.config import UsageError
+import aioredis.util
+
+
+def pytest_addoption(parser):
+    parser.addoption("--redis", default=None,
+                     help="run tests which require redis connection")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "redis: marked tests require redis connection to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    redis_uri = config.getoption("--redis")
+    if redis_uri is None:
+        skip_redis = pytest.mark.skip(reason="need --redis option with redis URI to run")
+        for item in items:
+            if "redis" in item.keywords:
+                item.add_marker(skip_redis)
+        return
+    try:
+        address, options = aioredis.util.parse_url(redis_uri)
+        assert isinstance(address, tuple), "Only redis and rediss schemas are supported, eg redis://foo."
+    except AssertionError as e:
+        raise UsageError(f"Invalid redis URI {redis_uri!r}: {e}")
+
+
+@pytest.fixture(scope='session')
+def redis_options(request):
+    redis_uri = request.config.getoption("--redis")
+    (host, port), options = aioredis.util.parse_url(redis_uri)
+    options.update({'host': host, 'port': port})
+    return options

--- a/tests/contrib/fsm_storage/test_redis.py
+++ b/tests/contrib/fsm_storage/test_redis.py
@@ -1,0 +1,33 @@
+import pytest
+
+from aiogram.contrib.fsm_storage.redis import RedisStorage2
+
+
+@pytest.fixture()
+async def store(redis_options):
+    s = RedisStorage2(**redis_options)
+    try:
+        yield s
+    finally:
+        conn = await s.redis()
+        await conn.flushdb()
+        await s.close()
+        await s.wait_closed()
+
+
+@pytest.mark.redis
+class TestRedisStorage2:
+    @pytest.mark.asyncio
+    async def test_set_get(self, store):
+        assert await store.get_data(chat='1234') == {}
+        await store.set_data(chat='1234', data={'foo': 'bar'})
+        assert await store.get_data(chat='1234') == {'foo': 'bar'}
+
+    @pytest.mark.asyncio
+    async def test_close_and_open_connection(self, store):
+        await store.set_data(chat='1234', data={'foo': 'bar'})
+        assert await store.get_data(chat='1234') == {'foo': 'bar'}
+        pool_id = id(store._redis)
+        await store.close()
+        assert await store.get_data(chat='1234') == {'foo': 'bar'}  # new pool was opened at this point
+        assert id(store._redis) != pool_id


### PR DESCRIPTION
# Description

Don't remove reference to the pool in the `close()` method and when new connection is made simply check if old one is closed.
These changes will fix the problem with pending redis pool closing tasks.

close #275 

## Type of change

Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Described in #275 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
