### PR TITLE
Check whether Python is 3.7+

### DIFF
--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -1,3 +1,8 @@
+import sys
+if sys.version_info < (3, 7):
+    raise ImportError('Your Python version {0} is not supported by aiogram, please install '
+                      'Python 3.7+'.format('.'.join(map(str, sys.version_info[:3]))))
+
 import asyncio
 import os
 


### PR DESCRIPTION
# Description
Raise an `ImportError` when the user tries to use `aiogram` on Python version <3.7

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?
```
~/vendor/aiogram> docker run -it --rm -v "$PWD/aiogram:/app/aiogram" python:3.6-slim /bin/bash
root@09f76f31ae9f:/# cd app
root@09f76f31ae9f:/app# cp aiogram/tmpbot.py ./
root@09f76f31ae9f:/app# python tmpbot.py 
Traceback (most recent call last):
  File "tmpbot.py", line 1, in <module>
    from aiogram import Bot, Dispatcher, types, executor
  File "/app/aiogram/__init__.py", line 4, in <module>
    'Python 3.7+'.format('.'.join(map(str, sys.version_info[:3]))))
ImportError: Your Python version 3.6.10 is not supported by aiogram, please install Python 3.7+
```

**Test Configuration**:
* Operating System: Debian buster (inside Docker)
* Python version: 3.6.10

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
