### PR TITLE
Add emoji to send_dice method

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -918,6 +918,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
     async def send_dice(self, chat_id: typing.Union[base.Integer, base.String],
                         disable_notification: typing.Union[base.Boolean, None] = None,
+                        emoji: typing.Union[base.String, None] = None,
                         reply_to_message_id: typing.Union[base.Integer, None] = None,
                         reply_markup: typing.Union[types.InlineKeyboardMarkup,
                                                    types.ReplyKeyboardMarkup,
@@ -933,6 +934,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`typing.Union[base.Integer, base.String]`
+        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲” or “🎯”. Defauts to “🎲”
+        :type emoji: :obj:`typing.Union[base.String, None]`
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound
         :type disable_notification: :obj:`typing.Union[base.Boolean, None]`
         :param reply_to_message_id: If the message is a reply, ID of the original message


### PR DESCRIPTION
# Description

Supported the new darts animation for the dice mini-game in Bot API 4.8

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A

```await bot.send_dice(message.chat.id, emoji='🎯')```

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
