### PR TITLE
Fix behavior when a single string is passed as ID

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -15,14 +15,14 @@ from aiogram.types import CallbackQuery, Message, InlineQuery, Poll, ChatType
 ChatIDArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
 
 
-def extract_chat_ids(id_filter_argument: ChatIDArgumentType) -> typing.Set[int]:
+def extract_chat_ids(chat_id: ChatIDArgumentType) -> typing.Set[int]:
     # since "str" is also an "Iterable", we have to check for it first
-    if isinstance(id_filter_argument, str):
-        return {int(id_filter_argument),}
-    if isinstance(id_filter_argument, Iterable):
-        return {int(item) for (item) in id_filter_argument}
+    if isinstance(chat_id, str):
+        return {int(chat_id), }
+    if isinstance(chat_id, Iterable):
+        return {int(item) for (item) in chat_id}
     # the last possible type is a single "int"
-    return {id_filter_argument,}
+    return {chat_id, }
 
 
 class Command(Filter):
@@ -622,22 +622,20 @@ class AdminFilter(Filter):
     is_chat_admin is required for InlineQuery.
     """
 
-    def __init__(self, is_chat_admin: Optional[Union[Iterable[Union[int, str]], str, int, bool]] = None):
+    def __init__(self, is_chat_admin: Optional[Union[ChatIDArgumentType, bool]] = None):
         self._check_current = False
         self._chat_ids = None
 
         if is_chat_admin is False:
             raise ValueError("is_chat_admin cannot be False")
 
-        if is_chat_admin:
-            if isinstance(is_chat_admin, bool):
-                self._check_current = is_chat_admin
-            if isinstance(is_chat_admin, Iterable):
-                self._chat_ids = list(is_chat_admin)
-            else:
-                self._chat_ids = [is_chat_admin]
-        else:
+        if not is_chat_admin:
             self._check_current = True
+            return
+
+        if isinstance(is_chat_admin, bool):
+            self._check_current = is_chat_admin
+        self._chat_ids = extract_chat_ids(is_chat_admin)
 
     @classmethod
     def validate(cls, full_config: typing.Dict[str, typing.Any]) -> typing.Optional[typing.Dict[str, typing.Any]]:

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -556,8 +556,8 @@ class ExceptionsFilter(BoundFilter):
         except:
             return False
 
-class IDFilter(Filter):
 
+class IDFilter(Filter):
     def __init__(self,
                  user_id: Optional[ChatIDArgumentType] = None,
                  chat_id: Optional[ChatIDArgumentType] = None,

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -12,10 +12,10 @@ from aiogram.dispatcher.filters.filters import BoundFilter, Filter
 from aiogram.types import CallbackQuery, Message, InlineQuery, Poll, ChatType
 
 
-IDFilterArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
+ChatIDArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
 
 
-def extract_filter_ids(id_filter_argument: IDFilterArgumentType) -> typing.Set[int]:
+def extract_chat_ids(id_filter_argument: ChatIDArgumentType) -> typing.Set[int]:
     # since "str" is also an "Iterable", we have to check for it first
     if isinstance(id_filter_argument, str):
         return {int(id_filter_argument),}
@@ -559,8 +559,8 @@ class ExceptionsFilter(BoundFilter):
 class IDFilter(Filter):
 
     def __init__(self,
-                 user_id: Optional[IDFilterArgumentType] = None,
-                 chat_id: Optional[IDFilterArgumentType] = None,
+                 user_id: Optional[ChatIDArgumentType] = None,
+                 chat_id: Optional[ChatIDArgumentType] = None,
                  ):
         """
         :param user_id:
@@ -573,10 +573,10 @@ class IDFilter(Filter):
         self.chat_id: Optional[typing.Set[int]] = None
 
         if user_id:
-            self.user_id = extract_filter_ids(user_id)
+            self.user_id = extract_chat_ids(user_id)
 
         if chat_id:
-            self.chat_id = extract_filter_ids(chat_id)
+            self.chat_id = extract_chat_ids(chat_id)
 
     @classmethod
     def validate(cls, full_config: typing.Dict[str, typing.Any]) -> typing.Optional[typing.Dict[str, typing.Any]]:

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -15,14 +15,14 @@ from aiogram.types import CallbackQuery, Message, InlineQuery, Poll, ChatType
 IDFilterArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
 
 
-def extract_filter_ids(id_filter_argument: IDFilterArgumentType) -> typing.List[int]:
+def extract_filter_ids(id_filter_argument: IDFilterArgumentType) -> typing.Set[int]:
     # since "str" is also an "Iterable", we have to check for it first
     if isinstance(id_filter_argument, str):
-        return [int(id_filter_argument)]
+        return {int(id_filter_argument),}
     if isinstance(id_filter_argument, Iterable):
-        return [int(item) for (item) in id_filter_argument]
+        return {int(item) for (item) in id_filter_argument}
     # the last possible type is a single "int"
-    return [id_filter_argument]
+    return {id_filter_argument,}
 
 
 class Command(Filter):
@@ -569,8 +569,8 @@ class IDFilter(Filter):
         if user_id is None and chat_id is None:
             raise ValueError("Both user_id and chat_id can't be None")
 
-        self.user_id: Optional[IDFilterArgumentType] = None
-        self.chat_id: Optional[IDFilterArgumentType] = None
+        self.user_id: Optional[typing.Set[int]] = None
+        self.chat_id: Optional[typing.Set[int]] = None
 
         if user_id:
             self.user_id = extract_filter_ids(user_id)

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -12,6 +12,19 @@ from aiogram.dispatcher.filters.filters import BoundFilter, Filter
 from aiogram.types import CallbackQuery, Message, InlineQuery, Poll, ChatType
 
 
+IDFilterArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
+
+
+def extract_filter_ids(id_filter_argument: IDFilterArgumentType) -> typing.List[int]:
+    # since "str" is also an "Iterable", we have to check for it first
+    if isinstance(id_filter_argument, str):
+        return [int(id_filter_argument)]
+    if isinstance(id_filter_argument, Iterable):
+        return [int(item) for (item) in id_filter_argument]
+    # the last possible type is a single "int"
+    return [id_filter_argument]
+
+
 class Command(Filter):
     """
     You can handle commands by using this filter.
@@ -543,12 +556,11 @@ class ExceptionsFilter(BoundFilter):
         except:
             return False
 
-
 class IDFilter(Filter):
 
     def __init__(self,
-                 user_id: Optional[Union[Iterable[Union[int, str]], str, int]] = None,
-                 chat_id: Optional[Union[Iterable[Union[int, str]], str, int]] = None,
+                 user_id: Optional[IDFilterArgumentType] = None,
+                 chat_id: Optional[IDFilterArgumentType] = None,
                  ):
         """
         :param user_id:
@@ -557,18 +569,14 @@ class IDFilter(Filter):
         if user_id is None and chat_id is None:
             raise ValueError("Both user_id and chat_id can't be None")
 
-        self.user_id = None
-        self.chat_id = None
+        self.user_id: Optional[IDFilterArgumentType] = None
+        self.chat_id: Optional[IDFilterArgumentType] = None
+
         if user_id:
-            if isinstance(user_id, Iterable):
-                self.user_id = list(map(int, user_id))
-            else:
-                self.user_id = [int(user_id), ]
+            self.user_id = extract_filter_ids(user_id)
+
         if chat_id:
-            if isinstance(chat_id, Iterable):
-                self.chat_id = list(map(int, chat_id))
-            else:
-                self.chat_id = [int(chat_id), ]
+            self.chat_id = extract_filter_ids(chat_id)
 
     @classmethod
     def validate(cls, full_config: typing.Dict[str, typing.Any]) -> typing.Optional[typing.Dict[str, typing.Any]]:

--- a/tests/test_dispatcher/test_filters/test_builtin.py
+++ b/tests/test_dispatcher/test_filters/test_builtin.py
@@ -1,6 +1,12 @@
+from typing import Set
+
 import pytest
 
-from aiogram.dispatcher.filters.builtin import Text
+from aiogram.dispatcher.filters.builtin import (
+    Text,
+    extract_chat_ids,
+    ChatIDArgumentType,
+)
 
 
 class TestText:
@@ -16,3 +22,50 @@ class TestText:
         config = {param: value}
         res = Text.validate(config)
         assert res == {key: value}
+
+
+@pytest.mark.parametrize(
+    ('chat_id', 'expected'),
+    (
+        pytest.param('-64856280', {-64856280,}, id='single negative int as string'),
+        pytest.param('64856280', {64856280,}, id='single positive int as string'),
+        pytest.param(-64856280, {-64856280,}, id='single negative int'),
+        pytest.param(64856280, {64856280,}, id='single positive negative int'),
+        pytest.param(
+            ['-64856280'], {-64856280,}, id='list of single negative int as string'
+        ),
+        pytest.param([-64856280], {-64856280,}, id='list of single negative int'),
+        pytest.param(
+            ['-64856280', '-64856280'],
+            {-64856280,},
+            id='list of two duplicated negative ints as strings',
+        ),
+        pytest.param(
+            ['-64856280', -64856280],
+            {-64856280,},
+            id='list of one negative int as string and one negative int',
+        ),
+        pytest.param(
+            [-64856280, -64856280],
+            {-64856280,},
+            id='list of two duplicated negative ints',
+        ),
+        pytest.param(
+            iter(['-64856280']),
+            {-64856280,},
+            id='iterator from a list of single negative int as string',
+        ),
+        pytest.param(
+            [10000000, 20000000, 30000000],
+            {10000000, 20000000, 30000000},
+            id='list of several positive ints',
+        ),
+        pytest.param(
+            [10000000, '20000000', -30000000],
+            {10000000, 20000000, -30000000},
+            id='list of positive int, positive int as string, negative int',
+        ),
+    ),
+)
+def test_extract_chat_ids(chat_id: ChatIDArgumentType, expected: Set[int]):
+    assert extract_chat_ids(chat_id) == expected


### PR DESCRIPTION
# Description

If you pass a single string as ID (either user_id or chat_id) to IDFilter/AdminFilter - it will be treated as Iterable, as a result:
- if it is a group chat id (start with `-`) - error will be raised, since `-` can't be converted to `int`
- if it is a user_id or a personal chat (positive integer) - ID filter will not work, since string will be splitted into characters

`self.user_id` and `self.chat_id` are now `Set[int]`, since there's no point to allow passing non-unique IDs and order does not really matter.

**Examples:**
`IDFilter('-1234')` -> `ValueError: invalid literal for int() with base 10: '-'`
`IDFilter('1234')` -> filter will search for users/chats with ids `[1, 2, 3, 4]`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```python
@dp.message_handler(IDFilter('-64856280'))
@dp.message_handler(IDFilter('64856280'))
@dp.message_handler(IDFilter(-64856280))
@dp.message_handler(IDFilter(64856280))
@dp.message_handler(IDFilter(['-64856280']))
@dp.message_handler(IDFilter([-64856280]))
@dp.message_handler(IDFilter(['-64856280', '-64856280']))
@dp.message_handler(IDFilter(['-64856280', -64856280]))
@dp.message_handler(IDFilter([-64856280, -64856280]))
@dp.message_handler(IDFilter(iter(['-64856280'])))
async def id_filter_demo_handler(message: types.Message):
    await message.answer(f'User: {message.from_user.id}, Chat: {message.chat.id}')
```
All of the filters above work (use one at a time)
Added tests for cases I mentioned above

**Test Configuration**:
* Operating System: Windows 7 x64
* Python version: 3.7.5

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (it will be autogenerated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
