### PR TITLE
fix(BaseBot): remove __del__ method from BaseBot

### DIFF
--- a/tests/test_bot/test_session.py
+++ b/tests/test_bot/test_session.py
@@ -1,0 +1,61 @@
+import aiohttp
+import aiohttp_socks
+import pytest
+
+from aiogram.bot.base import BaseBot
+
+try:
+    from asynctest import CoroutineMock, patch
+except ImportError:
+    from unittest.mock import AsyncMock as CoroutineMock, patch  # type: ignore
+
+
+class TestAiohttpSession:
+    @pytest.mark.asyncio
+    async def test_create_bot(self):
+        bot = BaseBot(token="42:correct")
+
+        assert bot._session is None
+        assert isinstance(bot._connector_init, dict)
+        assert all(key in {"limit", "ssl", "loop"} for key in bot._connector_init)
+        assert isinstance(bot._connector_class, type)
+        assert issubclass(bot._connector_class, aiohttp.TCPConnector)
+
+        assert bot._session is None
+
+        assert isinstance(bot.session, aiohttp.ClientSession)
+        assert bot.session == bot._session
+
+    @pytest.mark.asyncio
+    async def test_create_proxy_bot(self):
+        socks_ver, host, port, username, password = (
+            "socks5", "124.90.90.90", 9999, "login", "password"
+        )
+
+        bot = BaseBot(
+            token="42:correct",
+            proxy=f"{socks_ver}://{host}:{port}/",
+            proxy_auth=aiohttp.BasicAuth(username, password, "encoding"),
+        )
+
+        assert bot._connector_class == aiohttp_socks.SocksConnector
+
+        assert isinstance(bot._connector_init, dict)
+
+        init_kwargs = bot._connector_init
+        assert init_kwargs["username"] == username
+        assert init_kwargs["password"] == password
+        assert init_kwargs["host"] == host
+        assert init_kwargs["port"] == port
+
+    @pytest.mark.asyncio
+    async def test_close_session(self):
+        bot = BaseBot(token="42:correct",)
+        aiohttp_client_0 = bot.session
+
+        with patch("aiohttp.ClientSession.close", new=CoroutineMock()) as mocked_close:
+            await aiohttp_client_0.close()
+            mocked_close.assert_called_once()
+
+        await aiohttp_client_0.close()
+        assert aiohttp_client_0 != bot.session  # will create new session


### PR DESCRIPTION
implement "lazy" session property getter and new get_new_session for BaseBot

Fixes #314 #305 

## Type of change

- [x] Bug fix
- [x] New feature
- [x] ? Breaking change

# How Has This Been Tested?
```python
if __name__ == '__main__':
    import asyncio

    async def main():
        from aiogram.bot.bot import Bot

        bot = Bot(">.<")
        await bot.send_message(124191486, "sup!")
        await bot.close()
        await bot.send_message(124191486, "sup! 2")
        await bot.close()

    asyncio.run(main())
```

**Test Configuration**:
* Python version: 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
