### PR TITLE
AIOG-T-25 refactor(handler): rename observers

### DIFF
--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -28,5 +28,5 @@ __all__ = (
     "handler",
 )
 
-__version__ = '3.0.0a4'
+__version__ = "3.0.0a4"
 __api_version__ = "4.8"

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -57,7 +57,7 @@ class Dispatcher(Router):
 
         Bot.set_current(bot)
         try:
-            async for result in self.update_handler.trigger(update, bot=bot, **kwargs):
+            async for result in self.update.trigger(update, bot=bot, **kwargs):
                 handled = True
                 yield result
         finally:

--- a/aiogram/dispatcher/router.py
+++ b/aiogram/dispatcher/router.py
@@ -24,31 +24,25 @@ class Router:
         self.sub_routers: List[Router] = []
 
         # Observers
-        self.update_handler = TelegramEventObserver(router=self, event_name="update")
-        self.message_handler = TelegramEventObserver(router=self, event_name="message")
-        self.edited_message_handler = TelegramEventObserver(
-            router=self, event_name="edited_message"
-        )
-        self.channel_post_handler = TelegramEventObserver(router=self, event_name="channel_post")
-        self.edited_channel_post_handler = TelegramEventObserver(
+        self.update = TelegramEventObserver(router=self, event_name="update")
+        self.message = TelegramEventObserver(router=self, event_name="message")
+        self.edited_message = TelegramEventObserver(router=self, event_name="edited_message")
+        self.channel_post = TelegramEventObserver(router=self, event_name="channel_post")
+        self.edited_channel_post = TelegramEventObserver(
             router=self, event_name="edited_channel_post"
         )
-        self.inline_query_handler = TelegramEventObserver(router=self, event_name="inline_query")
-        self.chosen_inline_result_handler = TelegramEventObserver(
+        self.inline_query = TelegramEventObserver(router=self, event_name="inline_query")
+        self.chosen_inline_result = TelegramEventObserver(
             router=self, event_name="chosen_inline_result"
         )
-        self.callback_query_handler = TelegramEventObserver(
-            router=self, event_name="callback_query"
-        )
-        self.shipping_query_handler = TelegramEventObserver(
-            router=self, event_name="shipping_query"
-        )
-        self.pre_checkout_query_handler = TelegramEventObserver(
+        self.callback_query = TelegramEventObserver(router=self, event_name="callback_query")
+        self.shipping_query = TelegramEventObserver(router=self, event_name="shipping_query")
+        self.pre_checkout_query = TelegramEventObserver(
             router=self, event_name="pre_checkout_query"
         )
-        self.poll_handler = TelegramEventObserver(router=self, event_name="poll")
-        self.poll_answer_handler = TelegramEventObserver(router=self, event_name="poll_answer")
-        self.errors_handler = TelegramEventObserver(router=self, event_name="error")
+        self.poll = TelegramEventObserver(router=self, event_name="poll")
+        self.poll_answer = TelegramEventObserver(router=self, event_name="poll_answer")
+        self.errors = TelegramEventObserver(router=self, event_name="error")
 
         self.middleware = MiddlewareManager(router=self)
 
@@ -56,23 +50,23 @@ class Router:
         self.shutdown = EventObserver()
 
         self.observers: Dict[str, TelegramEventObserver] = {
-            "update": self.update_handler,
-            "message": self.message_handler,
-            "edited_message": self.edited_message_handler,
-            "channel_post": self.channel_post_handler,
-            "edited_channel_post": self.edited_channel_post_handler,
-            "inline_query": self.inline_query_handler,
-            "chosen_inline_result": self.chosen_inline_result_handler,
-            "callback_query": self.callback_query_handler,
-            "shipping_query": self.shipping_query_handler,
-            "pre_checkout_query": self.pre_checkout_query_handler,
-            "poll": self.poll_handler,
-            "poll_answer": self.poll_answer_handler,
-            "error": self.errors_handler,
+            "update": self.update,
+            "message": self.message,
+            "edited_message": self.edited_message,
+            "channel_post": self.channel_post,
+            "edited_channel_post": self.edited_channel_post,
+            "inline_query": self.inline_query,
+            "chosen_inline_result": self.chosen_inline_result,
+            "callback_query": self.callback_query,
+            "shipping_query": self.shipping_query,
+            "pre_checkout_query": self.pre_checkout_query,
+            "poll": self.poll,
+            "poll_answer": self.poll_answer,
+            "error": self.errors,
         }
 
         # Root handler
-        self.update_handler.register(self._listen_update)
+        self.update.register(self._listen_update)
 
         # Builtin filters
         if use_builtin_filters:
@@ -299,7 +293,7 @@ class Router:
             raise
 
         except Exception as e:
-            async for result in self.errors_handler.trigger(e, **kwargs):
+            async for result in self.errors.trigger(e, **kwargs):
                 return result
             raise
 
@@ -336,3 +330,146 @@ class Router:
             pass
         for router in self.sub_routers:
             await router.emit_shutdown(*args, **kwargs)
+
+    @property
+    def update_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.update_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.update(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.update
+
+    @property
+    def message_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.message_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.message(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.message
+
+    @property
+    def edited_message_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.edited_message_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.edited_message(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.edited_message
+
+    @property
+    def channel_post_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.channel_post_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.channel_post(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.channel_post
+
+    @property
+    def edited_channel_post_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.edited_channel_post_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.edited_channel_post(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.edited_channel_post
+
+    @property
+    def inline_query_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.inline_query_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.inline_query(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.inline_query
+
+    @property
+    def chosen_inline_result_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.chosen_inline_result_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.chosen_inline_result(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.chosen_inline_result
+
+    @property
+    def callback_query_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.callback_query_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.callback_query(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.callback_query
+
+    @property
+    def shipping_query_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.shipping_query_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.shipping_query(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.shipping_query
+
+    @property
+    def pre_checkout_query_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.pre_checkout_query_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.pre_checkout_query(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.pre_checkout_query
+
+    @property
+    def poll_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.poll_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.poll(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.poll
+
+    @property
+    def poll_answer_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.poll_answer_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.poll_answer(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.poll_answer
+
+    @property
+    def errors_handler(self) -> TelegramEventObserver:
+        warnings.warn(
+            "`Router.errors_handler(...)` is deprecated and will be removed in version 3.2 "
+            "use `Router.errors(...)`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.errors

--- a/docs/dispatcher/class_based_handlers/callback_query.md
+++ b/docs/dispatcher/class_based_handlers/callback_query.md
@@ -8,7 +8,7 @@ from aiogram.handlers import CallbackQueryHandler
 
 ...
 
-@router.callback_query_handler()
+@router.callback_query()
 class MyHandler(CallbackQueryHandler):
     async def handle(self) -> Any: ...
 
@@ -26,4 +26,4 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [CallbackQuery](../../api/types/callback_query.md)
-- [Router.callback_query_handler](../router.md#callback-query)
+- [Router.callback_query](../router.md#callback-query)

--- a/docs/dispatcher/class_based_handlers/chosen_inline_result.md
+++ b/docs/dispatcher/class_based_handlers/chosen_inline_result.md
@@ -8,7 +8,7 @@ from aiogram.handlers import ChosenInlineResultHandler
 
 ...
 
-@router.chosen_inline_result_handler()
+@router.chosen_inline_result()
 class MyHandler(ChosenInlineResultHandler):
     async def handle(self) -> Any: ...
 
@@ -25,4 +25,4 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [ChosenInlineResult](../../api/types/chosen_inline_result.md)
-- [Router.chosen_inline_result_handler](../router.md#chosen-inline-query)
+- [Router.chosen_inline_result](../router.md#chosen-inline-query)

--- a/docs/dispatcher/class_based_handlers/error.md
+++ b/docs/dispatcher/class_based_handlers/error.md
@@ -8,7 +8,7 @@ from aiogram.handlers import ErrorHandler
 
 ...
 
-@router.errors_handler()
+@router.errors()
 class MyHandler(ErrorHandler):
     async def handle(self) -> Any:
         log.exception(
@@ -28,5 +28,5 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 ## Related pages
 
 - [BaseHandler](basics.md#basehandler)
-- [Router.errors_handler](../router.md#errors)
+- [Router.errors](../router.md#errors)
 - [Filters](../filters/exception.md)

--- a/docs/dispatcher/class_based_handlers/inline_query.md
+++ b/docs/dispatcher/class_based_handlers/inline_query.md
@@ -7,7 +7,7 @@ from aiogram.handlers import InlineQueryHandler
 
 ...
 
-@router.inline_query_handler()
+@router.inline_query()
 class MyHandler(InlineQueryHandler):
     async def handle(self) -> Any: ...
 

--- a/docs/dispatcher/class_based_handlers/message.md
+++ b/docs/dispatcher/class_based_handlers/message.md
@@ -8,7 +8,7 @@ from aiogram.handlers import MessageHandler
 
 ...
 
-@router.message_handler()
+@router.message()
 class MyHandler(MessageHandler):
     async def handle(self) -> Any:
         return SendMessage(chat_id=self.chat.id, text="PASS")
@@ -26,7 +26,7 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [Message](../../api/types/message.md)
-- [Router.message_handler](../router.md#message)
-- [Router.edited_message_handler](../router.md#edited-message)
-- [Router.channel_post_handler](../router.md#channel-post)
-- [Router.edited_channel_post_handler](../router.md#edited-channel-post)
+- [Router.message](../router.md#message)
+- [Router.edited_message](../router.md#edited-message)
+- [Router.channel_post](../router.md#channel-post)
+- [Router.edited_channel_post](../router.md#edited-channel-post)

--- a/docs/dispatcher/class_based_handlers/poll.md
+++ b/docs/dispatcher/class_based_handlers/poll.md
@@ -8,7 +8,7 @@ from aiogram.handlers import PollHandler
 
 ...
 
-@router.poll_handler()
+@router.poll()
 class MyHandler(PollHandler):
     async def handle(self) -> Any: ...
 
@@ -25,4 +25,4 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [Poll](../../api/types/poll.md)
-- [Router.poll_handler](../router.md#poll)
+- [Router.poll](../router.md#poll)

--- a/docs/dispatcher/class_based_handlers/pre_checkout_query.md
+++ b/docs/dispatcher/class_based_handlers/pre_checkout_query.md
@@ -8,7 +8,7 @@ from aiogram.handlers import PreCheckoutQueryHandler
 
 ...
 
-@router.pre_checkout_query_handler()
+@router.pre_checkout_query()
 class MyHandler(PreCheckoutQueryHandler):
     async def handle(self) -> Any: ...
 
@@ -24,4 +24,4 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [PreCheckoutQuery](../../api/types/pre_checkout_query.md)
-- [Router.pre_checkout_query_handler](../router.md#pre-checkout-query)
+- [Router.pre_checkout_query](../router.md#pre-checkout-query)

--- a/docs/dispatcher/class_based_handlers/shipping_query.md
+++ b/docs/dispatcher/class_based_handlers/shipping_query.md
@@ -8,7 +8,7 @@ from aiogram.handlers import ShippingQueryHandler
 
 ...
 
-@router.shipping_query_handler()
+@router.shipping_query()
 class MyHandler(ShippingQueryHandler):
     async def handle(self) -> Any: ...
 
@@ -24,4 +24,4 @@ This base handler is subclass of [BaseHandler](basics.md#basehandler) with some 
 
 - [BaseHandler](basics.md#basehandler)
 - [ShippingQuery](../../api/types/shipping_query.md)
-- [Router.shipping_query_handler](../router.md#shipping-query)
+- [Router.shipping_query](../router.md#shipping-query)

--- a/docs/dispatcher/dispatcher.md
+++ b/docs/dispatcher/dispatcher.md
@@ -21,7 +21,7 @@ Example:
 ```python3
 dp = Dispatcher()
 
-@dp.message_handler()
+@dp.message()
 async def message_handler(message: types.Message) -> None:
     await SendMessage(chat_id=message.from_user.id, text=message.text)
 ```

--- a/docs/dispatcher/filters/command.md
+++ b/docs/dispatcher/filters/command.md
@@ -19,7 +19,7 @@ Works only with [Message](../../api/types/message.md) events which have the `tex
 1. Handle command by regexp pattern: `#!python3 Command(commands=[re.compile(r"item_(\d+)")])`
 1. Match command by multiple variants: `#!python3 Command(commands=["item", re.compile(r"item_(\d+)")])`
 1. Handle commands in public chats intended for other bots: `#!python3 Command(commands=["command"], commands)`
-1. As keyword argument in registerer: `#!python3 @router.message_handler(commands=["help"])`
+1. As keyword argument in registerer: `#!python3 @router.message(commands=["help"])`
 
 !!! warning 
     Command cannot include spaces or any whitespace

--- a/docs/dispatcher/filters/index.md
+++ b/docs/dispatcher/filters/index.md
@@ -53,9 +53,9 @@ class MyText(BaseFilter):
         return message.text == self.my_text
 
 
-router.message_handler.bind_filter(MyText)
+router.message.bind_filter(MyText)
 
-@router.message_handler(my_text="hello")
+@router.message(my_text="hello")
 async def my_handler(message: Message): ...
 ``` 
 

--- a/docs/dispatcher/router.md
+++ b/docs/dispatcher/router.md
@@ -34,91 +34,91 @@ Here is list of available observers and examples how to register handlers (In ex
 
 ### Update
 ```python3
-@router.update_handler()
+@router.update()
 async def message_handler(update: types.Update) -> Any: pass
 ```
 Should be used for handling [updates](../api/types/update.md). By default Router is already have an update handler which route all event types to another observers.
 
 ### Message
 ```python3
-@router.message_handler()
+@router.message()
 async def message_handler(message: types.Message) -> Any: pass
 ```
 Is useful for handling [message](../api/types/message.md)
 
 ### Edited message
 ```python3
-@router.edited_message_handler()
+@router.edited_message()
 async def edited_message_handler(edited_message: types.Message) -> Any: pass
 ```
 Is useful for handling [edited messages](../api/types/message.md)
 
 ### Channel post
 ```python3
-@router.channel_post_handler()
+@router.channel_post()
 async def channel_post_handler(channel_post: types.Message) -> Any: pass
 ```
 Is useful for handling [channel posts](../api/types/message.md)
 
 ### Edited channel post
 ```python3
-@router.edited_channel_post_handler()
+@router.edited_channel_post()
 async def edited_channel_post_handler(edited_channel_post: types.Message) -> Any: pass
 ```
 Is useful for handling [edited channel posts](../api/types/message.md)
 
 ### Inline query
 ```python3
-@router.inline_query_handler()
+@router.inline_query()
 async def inline_query_handler(inline_query: types.Message) -> Any: pass
 ```
 Is useful for handling [inline query](../api/types/inline_query.md)
 
 ### Chosen inline query
 ```python3
-@router.chosen_inline_result_handler()
+@router.chosen_inline_result()
 async def chosen_inline_result_handler(chosen_inline_result: types.ChosenInlineResult) -> Any: pass
 ```
 Is useful for handling [chosen inline query](../api/types/chosen_inline_result.md)
 
 ### Callback query
 ```python3
-@router.callback_query_handler()
+@router.callback_query()
 async def callback_query_handler(callback_query: types.CallbackQuery) -> Any: pass
 ```
 Is useful for handling [callback query's](../api/types/callback_query.md)
 
 ### Shipping query
 ```python3
-@router.shipping_query_handler()
+@router.shipping_query()
 async def shipping_query_handler(shipping_query: types.ShippingQuery) -> Any: pass
 ```
 Is useful for handling [shipping query](../api/types/shipping_query.md)
 
 ### Pre checkout query
 ```python3
-@router.pre_checkout_query_handler()
+@router.pre_checkout_query()
 async def pre_checkout_query_handler(pre_checkout_query: types.PreCheckoutQuery) -> Any: pass
 ```
 Is useful for handling [pre-checkout query](../api/types/pre_checkout_query.md)
 
 ### Poll
 ```python3
-@router.poll_handler()
+@router.poll()
 async def poll_handler(poll: types.Poll) -> Any: pass
 ```
 Is useful for handling [polls](../api/types/poll.md)
 
 ### Poll answer
 ```python3
-@router.poll_answer_handler()
+@router.poll_answer()
 async def poll_answer_handler(poll_answer: types.PollAnswer) -> Any: pass
 ```
 Is useful for handling [polls answers](../api/types/poll_answer.md)
 
 ### Errors
 ```python3
-@router.errors_handler()
+@router.errors()
 async def error_handler(exception: Exception) -> Any: pass
 ```
 Is useful for handling errors from other handlers

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ TOKEN = "42:TOKEN"
 dp = Dispatcher()
 
 
-@dp.message_handler(commands=["start"])
+@dp.message(commands=["start"])
 class MyHandler(MessageHandler):
     """
     This handler receive messages with `/start` command
@@ -54,7 +54,7 @@ class MyHandler(MessageHandler):
         await self.event.answer(f"<b>Hello, {self.from_user.full_name}!</b>")
 
 
-@dp.message_handler(content_types=[types.ContentType.ANY])
+@dp.message(content_types=[types.ContentType.ANY])
 async def echo_handler(message: types.Message, bot: Bot):
     """
     Handler will forward received message back to the sender

--- a/poetry.lock
+++ b/poetry.lock
@@ -946,7 +946,7 @@ fast = ["uvloop"]
 proxy = ["aiohttp-socks"]
 
 [metadata]
-content-hash = "cd83723d922c4c0a645ef6f9f78447f83f2c1a933be928f8174ef897970acb2a"
+content-hash = "57137b60a539ba01e8df533db976e2f3eadec37e717cbefbe775dc021a8c2714"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1183,6 +1183,11 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ lxml = "^4.4"
 ipython = "^7.10"
 markdown-include = "^0.5.1"
 aiohttp-socks = "^0.3.4"
+packaging = "^20.3"
 
 [tool.poetry.extras]
 fast = ["uvloop"]

--- a/tests/deprecated.py
+++ b/tests/deprecated.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+from typing import Type
+
+import pytest
+from packaging import version
+
+import aiogram
+
+
+@contextmanager
+def check_deprecated(
+    max_version: str, exception: Type[Exception], warning: Type[Warning] = DeprecationWarning,
+) -> None:
+    """
+    Should be used for modules that are being deprecated or already removed from aiogram
+    """
+
+    parsed_max_version = version.parse(max_version)
+    current_version = version.parse(aiogram.__version__)
+
+    if parsed_max_version <= current_version:
+        with pytest.raises(exception):
+            yield
+    else:
+        with pytest.warns(warning, match=max_version):
+            yield

--- a/tests/test_api/test_types/test_reply_keyboard_remove.py
+++ b/tests/test_api/test_types/test_reply_keyboard_remove.py
@@ -1,4 +1,5 @@
 import pytest
+
 from aiogram.api.types import ReplyKeyboardRemove
 
 

--- a/tests/test_dispatcher/test_deprecated.py
+++ b/tests/test_dispatcher/test_deprecated.py
@@ -23,17 +23,14 @@ OBSERVERS = {
 def test_deprecated_handlers_name():
     from aiogram import __version__
 
-    minor_partial = int(__version__.split(".")[1])
+    major, minor = map(int, __version__.split(".")[:-1])
 
-    if minor_partial >= 2:
+    if minor >= 2 and major >= 3:  # version >=3.2.*
         do_assert = pytest.raises(AttributeError)
-    else:
+    else:  # for versions <=3.2.* (we don't care if major is lesser than `3`)
         do_assert = pytest.warns(DeprecationWarning)
 
     router = Router()
-
-    async def _(__):
-        ...
 
     with do_assert:
         for decor in OBSERVERS:

--- a/tests/test_dispatcher/test_deprecated.py
+++ b/tests/test_dispatcher/test_deprecated.py
@@ -29,4 +29,4 @@ def test_deprecated_handlers_name(observer_name: str):
 
     with check_deprecated("3.2", exception=AttributeError):
         observer = getattr(router, observer_name)
-        isinstance(observer, TelegramEventObserver)
+        assert isinstance(observer, TelegramEventObserver)

--- a/tests/test_dispatcher/test_deprecated.py
+++ b/tests/test_dispatcher/test_deprecated.py
@@ -1,0 +1,49 @@
+import pytest
+
+from aiogram.dispatcher.event.observer import TelegramEventObserver
+from aiogram.dispatcher.router import Router
+
+OBSERVERS = {
+    "callback_query",
+    "channel_post",
+    "chosen_inline_result",
+    "edited_channel_post",
+    "edited_message",
+    "errors",
+    "inline_query",
+    "message",
+    "poll",
+    "poll_answer",
+    "pre_checkout_query",
+    "shipping_query",
+    "update",
+}
+
+
+def test_deprecated_handlers_name():
+    from aiogram import __version__
+
+    minor_partial = int(__version__.split(".")[1])
+
+    if minor_partial >= 2:
+        do_assert = pytest.raises(AttributeError)
+    else:
+        do_assert = pytest.warns(DeprecationWarning)
+
+    router = Router()
+
+    async def _(__):
+        ...
+
+    with do_assert:
+        for decor in OBSERVERS:
+            getattr(router, decor + "_handler")
+
+        assert all(
+            isinstance(getattr(router, handler + "_handler"), TelegramEventObserver)
+            for handler in OBSERVERS
+        )
+
+    assert all(
+        isinstance(getattr(router, handler), TelegramEventObserver) for handler in OBSERVERS
+    )

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -55,7 +55,7 @@ class TestDispatcher:
         dp = Dispatcher()
         bot = Bot("42:TEST")
 
-        @dp.message_handler()
+        @dp.message()
         async def my_handler(message: Message, **kwargs):
             assert "bot" in kwargs
             assert isinstance(kwargs["bot"], Bot)
@@ -86,7 +86,7 @@ class TestDispatcher:
         dp = Dispatcher()
         bot = Bot("42:TEST")
 
-        @dp.message_handler()
+        @dp.message()
         async def my_handler(message: Message):
             assert message.text == "test"
             return message.text
@@ -142,7 +142,7 @@ class TestDispatcher:
     async def test_process_update_handled(self, bot: MockedBot):
         dispatcher = Dispatcher()
 
-        @dispatcher.update_handler()
+        @dispatcher.update()
         async def update_handler(update: Update):
             pass
 
@@ -152,7 +152,7 @@ class TestDispatcher:
     async def test_process_update_call_request(self, bot: MockedBot):
         dispatcher = Dispatcher()
 
-        @dispatcher.update_handler()
+        @dispatcher.update()
         async def update_handler(update: Update):
             return GetMe()
 
@@ -167,7 +167,7 @@ class TestDispatcher:
     async def test_process_update_exception(self, bot: MockedBot, caplog):
         dispatcher = Dispatcher()
 
-        @dispatcher.update_handler()
+        @dispatcher.update()
         async def update_handler(update: Update):
             raise Exception("Kaboom!")
 
@@ -229,7 +229,7 @@ class TestDispatcher:
     @pytest.mark.asyncio
     async def test_feed_webhook_update_fast_process(self, bot: MockedBot):
         dispatcher = Dispatcher()
-        dispatcher.message_handler.register(simple_message_handler)
+        dispatcher.message.register(simple_message_handler)
 
         response = await dispatcher.feed_webhook_update(bot, RAW_UPDATE, _timeout=2)
         assert isinstance(response, dict)
@@ -251,7 +251,7 @@ class TestDispatcher:
         warnings.simplefilter("always")
 
         dispatcher = Dispatcher()
-        dispatcher.message_handler.register(simple_message_handler)
+        dispatcher.message.register(simple_message_handler)
 
         with patch(
             "aiogram.dispatcher.dispatcher.Dispatcher._silent_call_request",
@@ -267,7 +267,7 @@ class TestDispatcher:
         warnings.simplefilter("always")
 
         dispatcher = Dispatcher()
-        dispatcher.message_handler.register(invalid_message_handler)
+        dispatcher.message.register(invalid_message_handler)
 
         response = await dispatcher.feed_webhook_update(bot, RAW_UPDATE, _timeout=1)
         assert response is None

--- a/tests/test_dispatcher/test_event/test_observer.py
+++ b/tests/test_dispatcher/test_event/test_observer.py
@@ -109,14 +109,14 @@ class TestTelegramEventObserver:
         router1.include_router(router2)
         router2.include_router(router3)
 
-        router1.message_handler.bind_filter(MyFilter1)
-        router1.message_handler.bind_filter(MyFilter2)
-        router2.message_handler.bind_filter(MyFilter2)
-        router3.message_handler.bind_filter(MyFilter3)
+        router1.message.bind_filter(MyFilter1)
+        router1.message.bind_filter(MyFilter2)
+        router2.message.bind_filter(MyFilter2)
+        router3.message.bind_filter(MyFilter3)
 
-        filters_chain1 = list(router1.message_handler._resolve_filters_chain())
-        filters_chain2 = list(router2.message_handler._resolve_filters_chain())
-        filters_chain3 = list(router3.message_handler._resolve_filters_chain())
+        filters_chain1 = list(router1.message._resolve_filters_chain())
+        filters_chain2 = list(router2.message._resolve_filters_chain())
+        filters_chain3 = list(router3.message._resolve_filters_chain())
 
         assert MyFilter1 in filters_chain1
         assert MyFilter1 in filters_chain2
@@ -128,7 +128,7 @@ class TestTelegramEventObserver:
 
     def test_resolve_filters(self):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
         observer.bind_filter(MyFilter1)
 
         resolved = observer.resolve_filters({"test": "PASS"})
@@ -149,7 +149,7 @@ class TestTelegramEventObserver:
 
     def test_register(self):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
         observer.bind_filter(MyFilter1)
 
         assert observer.register(my_handler) == my_handler
@@ -174,7 +174,7 @@ class TestTelegramEventObserver:
 
     def test_register_decorator(self):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
 
         @observer()
         async def my_handler(event: Any):
@@ -186,7 +186,7 @@ class TestTelegramEventObserver:
     @pytest.mark.asyncio
     async def test_trigger(self):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
         observer.bind_filter(MyFilter1)
         observer.register(my_handler, test="ok")
 
@@ -211,7 +211,7 @@ class TestTelegramEventObserver:
     )
     def test_register_filters_via_decorator(self, count, handler, filters):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
 
         for index in range(count):
             wrapped_handler = functools.partial(handler, index=index)
@@ -227,7 +227,7 @@ class TestTelegramEventObserver:
     @pytest.mark.asyncio
     async def test_trigger_right_context_in_handlers(self):
         router = Router(use_builtin_filters=False)
-        observer = router.message_handler
+        observer = router.message
         observer.register(
             pipe_handler, lambda event: {"a": 1}, lambda event: False
         )  # {"a": 1} should not be in result

--- a/tests/test_dispatcher/test_router.py
+++ b/tests/test_dispatcher/test_router.py
@@ -79,18 +79,18 @@ class TestRouter:
 
     def test_observers_config(self):
         router = Router()
-        assert router.update_handler.handlers
-        assert router.update_handler.handlers[0].callback == router._listen_update
-        assert router.observers["message"] == router.message_handler
-        assert router.observers["edited_message"] == router.edited_message_handler
-        assert router.observers["channel_post"] == router.channel_post_handler
-        assert router.observers["edited_channel_post"] == router.edited_channel_post_handler
-        assert router.observers["inline_query"] == router.inline_query_handler
-        assert router.observers["chosen_inline_result"] == router.chosen_inline_result_handler
-        assert router.observers["callback_query"] == router.callback_query_handler
-        assert router.observers["shipping_query"] == router.shipping_query_handler
-        assert router.observers["pre_checkout_query"] == router.pre_checkout_query_handler
-        assert router.observers["poll"] == router.poll_handler
+        assert router.update.handlers
+        assert router.update.handlers[0].callback == router._listen_update
+        assert router.observers["message"] == router.message
+        assert router.observers["edited_message"] == router.edited_message
+        assert router.observers["channel_post"] == router.channel_post
+        assert router.observers["edited_channel_post"] == router.edited_channel_post
+        assert router.observers["inline_query"] == router.inline_query
+        assert router.observers["chosen_inline_result"] == router.chosen_inline_result
+        assert router.observers["callback_query"] == router.callback_query
+        assert router.observers["shipping_query"] == router.shipping_query
+        assert router.observers["pre_checkout_query"] == router.pre_checkout_query
+        assert router.observers["poll"] == router.poll
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -341,7 +341,7 @@ class TestRouter:
         router3 = Router()
         router1.include_router(router2)
         router1.include_router(router3)
-        observer = router3.message_handler
+        observer = router3.message
 
         @observer()
         async def my_handler(event: Message, **kwargs: Any):
@@ -429,7 +429,7 @@ class TestRouter:
         router = Router()
         root_router.include_router(router)
 
-        @router.message_handler()
+        @router.message()
         async def message_handler(message: Message):
             raise Exception("KABOOM")
 
@@ -452,7 +452,7 @@ class TestRouter:
                 chat=update.message.chat,
             )
 
-        @root_router.errors_handler()
+        @root_router.errors()
         async def root_error_handler(exception: Exception):
             return exception
 
@@ -466,7 +466,7 @@ class TestRouter:
         assert isinstance(response, Exception)
         assert str(response) == "KABOOM"
 
-        @router.errors_handler()
+        @router.errors()
         async def error_handler(exception: Exception):
             return "KABOOM"
 


### PR DESCRIPTION
Rename observers but with backward compatibility, relevant documentation

## Type of change

- [x] Documentation
- [x] Breaking change
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Implementation

The reason I didn't use `aiogram.utils.deprecated::deprecated` is I didn't want to pollute property's lower decorator and make codebase "nasty" :-)
Deprecated properties are generated with pattern. Documentation/tests was checked by me. New test to check if function is deprecated or removed in older/newer versions was added too.