### PR TITLE
fix: markdown escape functions

### DIFF
--- a/aiogram/utils/markdown.py
+++ b/aiogram/utils/markdown.py
@@ -70,7 +70,7 @@ def bold(*content, sep=" "):
     :return:
     """
     return markdown_decoration.bold.format(
-        value=html_decoration.quote(_join(*content, sep=sep))
+        value=markdown_decoration.quote(_join(*content, sep=sep))
     )
 
 
@@ -96,7 +96,7 @@ def italic(*content, sep=" "):
     :return:
     """
     return markdown_decoration.italic.format(
-        value=html_decoration.quote(_join(*content, sep=sep))
+        value=markdown_decoration.quote(_join(*content, sep=sep))
     )
 
 
@@ -122,7 +122,7 @@ def code(*content, sep=" "):
     :return:
     """
     return markdown_decoration.code.format(
-        value=html_decoration.quote(_join(*content, sep=sep))
+        value=markdown_decoration.quote(_join(*content, sep=sep))
     )
 
 
@@ -148,7 +148,7 @@ def pre(*content, sep="\n"):
     :return:
     """
     return markdown_decoration.pre.format(
-        value=html_decoration.quote(_join(*content, sep=sep))
+        value=markdown_decoration.quote(_join(*content, sep=sep))
     )
 
 


### PR DESCRIPTION
# Description

Some markdown functions are using wrong escape functions.

Fixes # (issue): -

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Current behavior (HTML quote):
```
>>> md.text('Type: /book ', md.italic('<code>'))
'Type: /book  _&lt;code&gt;_\r'
```
Expected  (Markdown quote):
```
>>> md.text('Type: /book ', md.italic('<code>'))
'Type: /book  _<code\\>_\r'
```

**Test Configuration**:
* Operating System: Ubuntu 18.04
* Python version: Python 3.7.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
