### PR TITLE
fix: pytest-asyncio version conflict

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,8 +3,8 @@
 ujson>=1.35
 python-rapidjson>=0.7.0
 emoji>=0.5.2
-pytest>=4.4.1,<4.6
-pytest-asyncio==0.10.0
+pytest>=5.4
+pytest-asyncio>=0.10.0
 tox>=3.9.0
 aresponses>=1.1.1
 uvloop>=0.12.2

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,7 @@ ujson>=1.35
 python-rapidjson>=0.7.0
 emoji>=0.5.2
 pytest>=4.4.1,<4.6
-pytest-asyncio>=0.10.0
+pytest-asyncio==0.10.0
 tox>=3.9.0
 aresponses>=1.1.1
 uvloop>=0.12.2


### PR DESCRIPTION
# Description

pytest-asyncio>=0.11 depends on Pytest 5.4.0 and up (details here https://github.com/pytest-dev/pytest-asyncio/pull/142), but requirements.txt states 
`pytest>=4.4.1,<4.6`

That is why `make test` failing after clonning.

Steps to reproduce:
```
git clone git@github.com:aiogram/aiogram.git temp_dir123
cd temp_dir123
python3.7 -m venv venv
. venv/bin/activate
pip install -r dev_requirements.txt
make test
```

This small fix solved it for me.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Operating System: Ubuntu 18.04
* Python version: Python 3.7.5

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
