### PR TITLE
Fix missing InlineQueryResultPhoto parse_mode field

### DIFF
--- a/aiogram/types/inline_query_result.py
+++ b/aiogram/types/inline_query_result.py
@@ -92,12 +92,13 @@ class InlineQueryResultPhoto(InlineQueryResult):
                  title: typing.Optional[base.String] = None,
                  description: typing.Optional[base.String] = None,
                  caption: typing.Optional[base.String] = None,
+                 parse_mode: typing.Optional[base.String] = None,
                  reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
                  input_message_content: typing.Optional[InputMessageContent] = None):
         super(InlineQueryResultPhoto, self).__init__(id=id, photo_url=photo_url, thumb_url=thumb_url,
                                                      photo_width=photo_width, photo_height=photo_height, title=title,
                                                      description=description, caption=caption,
-                                                     reply_markup=reply_markup,
+                                                     parse_mode=parse_mode, reply_markup=reply_markup,
                                                      input_message_content=input_message_content)
 
 


### PR DESCRIPTION
# Description

Object `InlineQueryResultPhoto` did not have field `parse_mode` while it is present in the api object description (https://core.telegram.org/bots/api#inlinequeryresultphoto).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

**Test Configuration**:
* Operating System: Ubuntu 20.04
* Python version: 3.8.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
