### PR TITLE
Added always_private argument to url() method

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -228,22 +228,23 @@ class Message(base.TelegramObject):
         return self.parse_entities()
 
     @property
-    def url(self) -> str:
+    def url(self, always_private=False) -> str:
         """
         Get URL for the message
 
+        :param always_private: Force generate a private URL even when username is available
         :return: str
         """
         if ChatType.is_private(self.chat):
             raise TypeError('Invalid chat type!')
 
         url = 'https://t.me/'
-        if self.chat.username:
-            # Generates public link
-            url += f'{self.chat.username}/'
-        else:
+        if not self.chat.username or always_private:
             # Generates private link available for chat members
             url += f'c/{self.chat.shifted_id}/'
+        else:
+            # Generates public link
+            url += f'{self.chat.username}/'
         url += f'{self.message_id}'
 
         return url


### PR DESCRIPTION
# Description

There are some cases when you want to be sure that your link will work regardless of chat username. This change makes it so you can force creation of private link

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Not tested

# Checklist:

Lol no, I just edited on github

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
