### PR TITLE
Add venv/ directory in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ env/
 build/
 dist/
 site/
+venv/
 *.egg-info/
 *.egg
 aiogram/_meta.py


### PR DESCRIPTION
Added venv/ directory in the .gitignore.
It will be useful for PyCharm users and for other users which uses virtualenv