### PR TITLE
fix: add support init fields from parent object in KeyboardButton

### DIFF
--- a/aiogram/types/reply_keyboard.py
+++ b/aiogram/types/reply_keyboard.py
@@ -111,11 +111,13 @@ class KeyboardButton(base.TelegramObject):
     def __init__(self, text: base.String,
                  request_contact: base.Boolean = None,
                  request_location: base.Boolean = None,
-                 request_poll: KeyboardButtonPollType = None):
+                 request_poll: KeyboardButtonPollType = None,
+                 **kwargs):
         super(KeyboardButton, self).__init__(text=text,
                                              request_contact=request_contact,
                                              request_location=request_location,
-                                             request_poll=request_poll)
+                                             request_poll=request_poll,
+                                             **kwargs)
 
 
 class ReplyKeyboardRemove(base.TelegramObject):

--- a/tests/types/dataset.py
+++ b/tests/types/dataset.py
@@ -457,3 +457,8 @@ WEBHOOK_INFO = {
     "has_custom_certificate": False,
     "pending_update_count": 0,
 }
+
+REPLY_KEYBOARD_MARKUP = {
+    "keyboard": [[{"text": "something here"}]],
+    "resize_keyboard": True,
+}

--- a/tests/types/test_reply_keyboard.py
+++ b/tests/types/test_reply_keyboard.py
@@ -1,0 +1,12 @@
+from aiogram import types
+from .dataset import REPLY_KEYBOARD_MARKUP
+
+reply_keyboard = types.ReplyKeyboardMarkup(**REPLY_KEYBOARD_MARKUP)
+
+
+def test_serialize():
+    assert reply_keyboard.to_python() == REPLY_KEYBOARD_MARKUP
+
+
+def test_deserialize():
+    assert reply_keyboard.to_object(reply_keyboard.to_python()) == reply_keyboard


### PR DESCRIPTION
# Description

Fixes #343 

The KeyboardButton object couldn't be deserialized because of no support of `conf` parameter(which is inherited from TelegramObject) in `__init__` method

Code snippet which produces the error:
```python3
from aiogram.types import ReplyKeyboardMarkup, KeyboardButton

markup = ReplyKeyboardMarkup(row_width=4, resize_keyboard=True)
markup.add(KeyboardButton('something here'))
dict_kb = markup.to_python()
assert ReplyKeyboardMarkup.to_object(dict_kb) == markup
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I ran code snippet, which I included above. In addition, I added several unit tests to verify this behavior. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
