### PR TITLE
fix get_full_command

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -167,7 +167,7 @@ class Message(base.TelegramObject):
         :return: tuple of (command, args)
         """
         if self.is_command():
-            command, _, args = self.text.partition(' ')
+            command, args = self.text.split(maxsplit=1)
             return command, args
 
     def get_command(self, pure=False):
@@ -191,7 +191,7 @@ class Message(base.TelegramObject):
         """
         command = self.get_full_command()
         if command:
-            return command[1].strip()
+            return command[1]
 
     def parse_entities(self, as_html=True):
         """


### PR DESCRIPTION
# Description

The reason is that .partition() doesn't have a default param as .split has, and default split param gives possibility to split not only by whitespaces, but also whitespace consequences (so the .strip() in get_args() not needed) and newlines.
It's called "fix", because without it, commands like this:
'''/command
arg
arg1'''
are resulting with ('/command\narg\narg1', '', '')

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] print('''/command
arg
arg1'''.partition(' '))
- [x] print('''/command
arg
arg1'''.split(maxsplit=1))

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.6.9

# Checklist:

- [1] My code follows the style guidelines of this project
- [1] I have performed a self-review of my own code
- [0] I have made corresponding changes to the documentation
- [1] My changes generate no new warnings
- [0] I have added tests that prove my fix is effective or that my feature works
- [1] New and existing unit tests pass locally with my changes

It's funny, how I was filling this for such small changes, neh?)0))