### PR TITLE
Fix: Class InputMediaAudio contains some fields from other class.

### DIFF
--- a/aiogram/types/input_media.py
+++ b/aiogram/types/input_media.py
@@ -137,8 +137,6 @@ class InputMediaAudio(InputMedia):
     https://core.telegram.org/bots/api#inputmediaanimation
     """
 
-    width: base.Integer = fields.Field()
-    height: base.Integer = fields.Field()
     duration: base.Integer = fields.Field()
     performer: base.String = fields.Field()
     title: base.String = fields.Field()
@@ -146,13 +144,12 @@ class InputMediaAudio(InputMedia):
     def __init__(self, media: base.InputFile,
                  thumb: typing.Union[base.InputFile, base.String] = None,
                  caption: base.String = None,
-                 width: base.Integer = None, height: base.Integer = None,
                  duration: base.Integer = None,
                  performer: base.String = None,
                  title: base.String = None,
                  parse_mode: base.String = None, **kwargs):
-        super(InputMediaAudio, self).__init__(type='audio', media=media, thumb=thumb, caption=caption,
-                                              width=width, height=height, duration=duration,
+        super(InputMediaAudio, self).__init__(type='audio', media=media, thumb=thumb,
+                                              caption=caption, duration=duration,
                                               performer=performer, title=title,
                                               parse_mode=parse_mode, conf=kwargs)
 

--- a/tests/types/test_input_media.py
+++ b/tests/types/test_input_media.py
@@ -1,0 +1,42 @@
+from aiogram import types
+from .dataset import AUDIO, ANIMATION, \
+    DOCUMENT, PHOTO, VIDEO
+
+
+WIDTH = 'width'
+HEIGHT = 'height'
+
+input_media_audio = types.InputMediaAudio(
+    types.Audio(**AUDIO))
+input_media_animation = types.InputMediaAnimation(
+    types.Animation(**ANIMATION))
+input_media_document = types.InputMediaDocument(
+    types.Document(**DOCUMENT))
+input_media_video = types.InputMediaVideo(
+    types.Video(**VIDEO))
+input_media_photo = types.InputMediaPhoto(
+    types.PhotoSize(**PHOTO))
+
+
+def test_field_width():
+    """
+    https://core.telegram.org/bots/api#inputmedia
+    """
+    assert not hasattr(input_media_audio, WIDTH)
+    assert not hasattr(input_media_document, WIDTH)
+    assert not hasattr(input_media_photo, WIDTH)
+
+    assert hasattr(input_media_animation, WIDTH)
+    assert hasattr(input_media_video, WIDTH)
+
+
+def test_field_height():
+    """
+    https://core.telegram.org/bots/api#inputmedia
+    """
+    assert not hasattr(input_media_audio, HEIGHT)
+    assert not hasattr(input_media_document, HEIGHT)
+    assert not hasattr(input_media_photo, HEIGHT)
+
+    assert hasattr(input_media_animation, HEIGHT)
+    assert hasattr(input_media_video, HEIGHT)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #320

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests to check whether `InputMediaAudio`, `InputMediaAnimation`, `InputMediaDocument`, `InputMediaPhoto`, `InputMediaVideo` have a `width` field.
- [x] Added tests to check whether `InputMediaAudio`, `InputMediaAnimation`, `InputMediaDocument`, `InputMediaPhoto`, `InputMediaVideo` have a `height` field.

**Test Configuration**:
* Operating System: Ubuntu 20.04 LTS
* Python version: Python 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
