### PR TITLE
Add '=' to characters reserved in markdown

### DIFF
--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -163,7 +163,7 @@ class HtmlDecoration(TextDecoration):
 
 
 class MarkdownDecoration(TextDecoration):
-    MARKDOWN_QUOTE_PATTERN: Pattern[str] = re.compile(r"([_*\[\]()~`>#+\-|{}.!])")
+    MARKDOWN_QUOTE_PATTERN: Pattern[str] = re.compile(r"([_*\[\]()~`>#+\-=|{}.!])")
 
     def link(self, value: str, link: str) -> str:
         return f"[{value}]({link})"


### PR DESCRIPTION
# Description

From [API](https://core.telegram.org/bots/api#markdownv2-style):
>In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\\'.

From these characters '=' is not in MARKDOWN_QUOTE_PATTERN so isn't escaped by `utils.markdown.escape_md`, leading to `CantParseEntities` exception when sending message containing '='.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
