### PR TITLE
Add setting current context of types

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -209,39 +209,50 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
         try:
             if update.message:
+                types.Message.set_current(update.message)
                 types.User.set_current(update.message.from_user)
                 types.Chat.set_current(update.message.chat)
                 return await self.message_handlers.notify(update.message)
             if update.edited_message:
+                types.Message.set_current(update.edited_message)
                 types.User.set_current(update.edited_message.from_user)
                 types.Chat.set_current(update.edited_message.chat)
                 return await self.edited_message_handlers.notify(update.edited_message)
             if update.channel_post:
+                types.Message.set_current(update.channel_post)
                 types.Chat.set_current(update.channel_post.chat)
                 return await self.channel_post_handlers.notify(update.channel_post)
             if update.edited_channel_post:
+                types.Message.set_current(update.edited_channel_post)
                 types.Chat.set_current(update.edited_channel_post.chat)
                 return await self.edited_channel_post_handlers.notify(update.edited_channel_post)
             if update.inline_query:
+                types.InlineQuery.set_current(update.inline_query)
                 types.User.set_current(update.inline_query.from_user)
                 return await self.inline_query_handlers.notify(update.inline_query)
             if update.chosen_inline_result:
+                types.ChosenInlineResult.set_current(update.chosen_inline_result)
                 types.User.set_current(update.chosen_inline_result.from_user)
                 return await self.chosen_inline_result_handlers.notify(update.chosen_inline_result)
             if update.callback_query:
+                types.CallbackQuery.set_current(update.callback_query)
                 if update.callback_query.message:
                     types.Chat.set_current(update.callback_query.message.chat)
                 types.User.set_current(update.callback_query.from_user)
                 return await self.callback_query_handlers.notify(update.callback_query)
             if update.shipping_query:
+                types.ShippingQuery.set_current(update.shipping_query)
                 types.User.set_current(update.shipping_query.from_user)
                 return await self.shipping_query_handlers.notify(update.shipping_query)
             if update.pre_checkout_query:
+                types.PreCheckoutQuery.set_current(update.pre_checkout_query)
                 types.User.set_current(update.pre_checkout_query.from_user)
                 return await self.pre_checkout_query_handlers.notify(update.pre_checkout_query)
             if update.poll:
+                types.Poll.set_current(update.poll)
                 return await self.poll_handlers.notify(update.poll)
             if update.poll_answer:
+                types.PollAnswer.set_current(update.poll_answer)
                 types.User.set_current(update.poll_answer.user)
                 return await self.poll_answer_handlers.notify(update.poll_answer)
         except Exception as e:


### PR DESCRIPTION
# Description
If we try to get the current update from context, we get `None`:
``` python3
from aiogram import Bot, Dispatcher, executor
from aiogram.types import Message

bot = Bot("...")
dispatcher = Dispatcher(bot)

@dispatcher.message_handler()
async def handle_message(message):
    current_message = Message.get_current()
    print(current_message)  # None

executor.start_polling(dispatcher)
```
After the changes presented in PR, we get the current update without errors:
``` python3
@dispatcher.message_handler()
async def handle_message(message):
    current_message = Message.get_current()
    print(current_message)  # {"message_id": 1206, "from": {"id": 650535775, ...
    print(message is current_message)  # True
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code