### PR TITLE
Add methods to register filters and middlewares

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -1240,7 +1240,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
     def unbind_filter(self, callback: typing.Union[typing.Callable, AbstractFilter]):
         """
-        Unregister callback
+        Unregister filter
 
         :param callback: callable of subclass of :obj:`AbstractFilter`
         """

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -10,7 +10,8 @@ from aiohttp.helpers import sentinel
 
 from aiogram.utils.deprecated import renamed_argument
 from .filters import Command, ContentTypeFilter, ExceptionsFilter, FiltersFactory, HashTag, Regexp, \
-    RegexpCommandsFilter, StateFilter, Text, IDFilter, AdminFilter, IsReplyFilter, ForwardedMessageFilter
+    RegexpCommandsFilter, StateFilter, Text, IDFilter, AdminFilter, IsReplyFilter, ForwardedMessageFilter, \
+    AbstractFilter
 from .filters.builtin import IsSenderContact
 from .handler import Handler
 from .middlewares import MiddlewareManager
@@ -1221,3 +1222,35 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             return wrapped
 
         return decorator
+
+    def bind_filter(self, callback: typing.Union[typing.Callable, AbstractFilter],
+                    validator: typing.Optional[typing.Callable] = None,
+                    event_handlers: typing.Optional[typing.List[Handler]] = None,
+                    exclude_event_handlers: typing.Optional[typing.Iterable[Handler]] = None):
+        """
+        Register filter
+
+        :param callback: callable or subclass of :obj:`AbstractFilter`
+        :param validator: custom validator.
+        :param event_handlers: list of instances of :obj:`Handler`
+        :param exclude_event_handlers: list of excluded event handlers (:obj:`Handler`)
+        """
+        self.filters_factory.bind(callback=callback, validator=validator, event_handlers=event_handlers,
+                                  exclude_event_handlers=exclude_event_handlers)
+
+    def unbind_filter(self, callback: typing.Union[typing.Callable, AbstractFilter]):
+        """
+        Unregister callback
+
+        :param callback: callable of subclass of :obj:`AbstractFilter`
+        """
+        self.filters_factory.unbind(callback=callback)
+
+    def setup_middleware(self, middleware):
+        """
+        Setup middleware
+
+        :param middleware:
+        :return:
+        """
+        self.middleware.setup(middleware)

--- a/aiogram/dispatcher/filters/factory.py
+++ b/aiogram/dispatcher/filters/factory.py
@@ -30,7 +30,7 @@ class FiltersFactory:
 
     def unbind(self, callback: typing.Union[typing.Callable, AbstractFilter]):
         """
-        Unregister callback
+        Unregister filter
 
         :param callback: callable of subclass of :obj:`AbstractFilter`
         """


### PR DESCRIPTION
# Description
PR adds public registration methods for filters and middlewares so that in addition to these methods:
``` python3
dispatcher.filters_factory.bind(SomeFilter)
dispatcher.filters_factory.unbind(SomeFilter)
dispatcher.middleware.setup(SomeMiddleware())
```
...there were these:
``` python3
dispatcher.bind_filter(SomeFilter)
dispatcher.unbind_filter(SomeFilter)
dispatcher.setup_middleware(SomeMiddleware())
```

## Type of change
- [x] Documentation (typos, code examples or any documentation update)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
