### PR TITLE
fix the #307

### DIFF
--- a/aiogram/types/fields.py
+++ b/aiogram/types/fields.py
@@ -1,5 +1,6 @@
 import abc
 import datetime
+import weakref
 
 __all__ = ('BaseField', 'Field', 'ListField', 'DateTimeField', 'TextField', 'ListOfLists')
 
@@ -109,7 +110,9 @@ class Field(BaseField):
                 and self.base_object is not None \
                 and not hasattr(value, 'base_object') \
                 and not hasattr(value, 'to_python'):
-            return self.base_object(conf={'parent': parent}, **value)
+            if not isinstance(parent, weakref.ReferenceType):
+                parent = weakref.ref(parent)
+            return self.base_object(conf={'parent':parent}, **value)
         return value
 
 


### PR DESCRIPTION
# Description

Fixes #307 

the functools.lru_cache() that used in `types.message.py` will affect the test. the result in #307 will be increase. if u want to test, better to set the maxsize of lru_cache to be a small number.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] test by hand, using the code that mention by #307 

1.to be test more convenient.  set maxsize=1 of the lru_cache in types.message.py
2.using the code mention by #307 to test. the result will not increase for several times comunicating to the bot.  (times > the maxsize)


**Test Configuration**:
* Operating System: Linux-4.15
* Python version: 3.7.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
