### PR TITLE
Add missed answer_poll and reply_poll methods to Message

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -886,6 +886,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         Use this method to send a native poll. A native poll can't be sent to a private chat.
         On success, the sent Message is returned.
 
+        Source: https://core.telegram.org/bots/api#sendpoll
+
         :param chat_id: Unique identifier for the target chat
             or username of the target channel (in the format @channelusername).
             A native poll can't be sent to a private chat.

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -935,6 +935,85 @@ class Message(base.TelegramObject):
             reply_markup=reply_markup,
         )
 
+    async def answer_poll(
+        self,
+        question: base.String,
+        options: typing.List[base.String],
+        is_anonymous: typing.Optional[base.Boolean] = None,
+        type: typing.Optional[base.String] = None,
+        allows_multiple_answers: typing.Optional[base.Boolean] = None,
+        correct_option_id: typing.Optional[base.Integer] = None,
+        explanation: typing.Optional[base.String] = None,
+        explanation_parse_mode: typing.Optional[base.String] = None,
+        open_period: typing.Union[base.Integer, None] = None,
+        close_date: typing.Union[base.Integer, datetime.datetime, datetime.timedelta, None] = None,
+        is_closed: typing.Optional[base.Boolean] = None,
+        disable_notification: typing.Optional[base.Boolean] = None,
+        reply_markup: typing.Union[
+            InlineKeyboardMarkup,
+            ReplyKeyboardMarkup,
+            ReplyKeyboardRemove,
+            ForceReply,
+            None,
+        ] = None,
+        reply: base.Boolean = False,
+    ) -> Message:
+        """
+        Use this method to send a native poll. A native poll can't be sent to a private chat.
+        On success, the sent Message is returned.
+
+        Source: https://core.telegram.org/bots/api#sendpoll
+
+        :param question: Poll question, 1-255 characters
+        :type question: :obj:`base.String`
+        :param options: List of answer options, 2-10 strings 1-100 characters each
+        :type options: :obj:`typing.List[base.String]`
+        :param is_anonymous: True, if the poll needs to be anonymous, defaults to True
+        :type is_anonymous: :obj:`typing.Optional[base.Boolean]`
+        :param type: Poll type, “quiz” or “regular”, defaults to “regular”
+        :type type: :obj:`typing.Optional[base.String]`
+        :param allows_multiple_answers: True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+        :type allows_multiple_answers: :obj:`typing.Optional[base.Boolean]`
+        :param correct_option_id: 0-based identifier of the correct answer option, required for polls in quiz mode
+        :type correct_option_id: :obj:`typing.Optional[base.Integer]`
+        :param explanation: Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+        :type explanation: :obj:`typing.Optional[base.String]`
+        :param explanation_parse_mode: Mode for parsing entities in the explanation. See formatting options for more details.
+        :type explanation_parse_mode: :obj:`typing.Optional[base.String]`
+        :param open_period: Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+        :type open_period: :obj:`typing.Union[base.Integer, None]`
+        :param close_date: Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
+        :type close_date: :obj:`typing.Union[base.Integer, datetime.datetime, datetime.timedelta, None]`
+        :param is_closed: Pass True, if the poll needs to be immediately closed
+        :type is_closed: :obj:`typing.Optional[base.Boolean]`
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
+        :type disable_notification: :obj:`typing.Optional[Boolean]`
+        :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard,
+            custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
+        :type reply_markup: :obj:`typing.Union[types.InlineKeyboardMarkup,
+            types.ReplyKeyboardMarkup, types.ReplyKeyboardRemove, types.ForceReply, None]`
+        :param reply: fill 'reply_to_message_id'
+        :return: On success, the sent Message is returned
+        :rtype: :obj:`types.Message`
+        """
+        return await self.bot.send_poll(
+            chat_id=self.chat.id,
+            question=question,
+            options=options,
+            is_anonymous=is_anonymous,
+            type=type,
+            allows_multiple_answers=allows_multiple_answers,
+            correct_option_id=correct_option_id,
+            explanation=explanation,
+            explanation_parse_mode=explanation_parse_mode,
+            open_period=open_period,
+            close_date=close_date,
+            is_closed=is_closed,
+            disable_notification=disable_notification,
+            reply_to_message_id=self.message_id if reply else None,
+            reply_markup=reply_markup,
+        )
+
     async def answer_dice(
         self,
         emoji: typing.Union[base.String, None] = None,
@@ -1599,6 +1678,85 @@ class Message(base.TelegramObject):
             phone_number=phone_number,
             first_name=first_name,
             last_name=last_name,
+            disable_notification=disable_notification,
+            reply_to_message_id=self.message_id if reply else None,
+            reply_markup=reply_markup,
+        )
+
+    async def reply_poll(
+        self,
+        question: base.String,
+        options: typing.List[base.String],
+        is_anonymous: typing.Optional[base.Boolean] = None,
+        type: typing.Optional[base.String] = None,
+        allows_multiple_answers: typing.Optional[base.Boolean] = None,
+        correct_option_id: typing.Optional[base.Integer] = None,
+        explanation: typing.Optional[base.String] = None,
+        explanation_parse_mode: typing.Optional[base.String] = None,
+        open_period: typing.Union[base.Integer, None] = None,
+        close_date: typing.Union[base.Integer, datetime.datetime, datetime.timedelta, None] = None,
+        is_closed: typing.Optional[base.Boolean] = None,
+        disable_notification: typing.Optional[base.Boolean] = None,
+        reply_markup: typing.Union[
+            InlineKeyboardMarkup,
+            ReplyKeyboardMarkup,
+            ReplyKeyboardRemove,
+            ForceReply,
+            None,
+        ] = None,
+        reply: base.Boolean = True,
+    ) -> Message:
+        """
+        Use this method to send a native poll. A native poll can't be sent to a private chat.
+        On success, the sent Message is returned.
+
+        Source: https://core.telegram.org/bots/api#sendpoll
+
+        :param question: Poll question, 1-255 characters
+        :type question: :obj:`base.String`
+        :param options: List of answer options, 2-10 strings 1-100 characters each
+        :type options: :obj:`typing.List[base.String]`
+        :param is_anonymous: True, if the poll needs to be anonymous, defaults to True
+        :type is_anonymous: :obj:`typing.Optional[base.Boolean]`
+        :param type: Poll type, “quiz” or “regular”, defaults to “regular”
+        :type type: :obj:`typing.Optional[base.String]`
+        :param allows_multiple_answers: True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+        :type allows_multiple_answers: :obj:`typing.Optional[base.Boolean]`
+        :param correct_option_id: 0-based identifier of the correct answer option, required for polls in quiz mode
+        :type correct_option_id: :obj:`typing.Optional[base.Integer]`
+        :param explanation: Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+        :type explanation: :obj:`typing.Optional[base.String]`
+        :param explanation_parse_mode: Mode for parsing entities in the explanation. See formatting options for more details.
+        :type explanation_parse_mode: :obj:`typing.Optional[base.String]`
+        :param open_period: Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+        :type open_period: :obj:`typing.Union[base.Integer, None]`
+        :param close_date: Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
+        :type close_date: :obj:`typing.Union[base.Integer, datetime.datetime, datetime.timedelta, None]`
+        :param is_closed: Pass True, if the poll needs to be immediately closed
+        :type is_closed: :obj:`typing.Optional[base.Boolean]`
+        :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
+        :type disable_notification: :obj:`typing.Optional[Boolean]`
+        :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard,
+            custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
+        :type reply_markup: :obj:`typing.Union[types.InlineKeyboardMarkup,
+            types.ReplyKeyboardMarkup, types.ReplyKeyboardRemove, types.ForceReply, None]`
+        :param reply: fill 'reply_to_message_id'
+        :return: On success, the sent Message is returned
+        :rtype: :obj:`types.Message`
+        """
+        return await self.bot.send_poll(
+            chat_id=self.chat.id,
+            question=question,
+            options=options,
+            is_anonymous=is_anonymous,
+            type=type,
+            allows_multiple_answers=allows_multiple_answers,
+            correct_option_id=correct_option_id,
+            explanation=explanation,
+            explanation_parse_mode=explanation_parse_mode,
+            open_period=open_period,
+            close_date=close_date,
+            is_closed=is_closed,
             disable_notification=disable_notification,
             reply_to_message_id=self.message_id if reply else None,
             reply_markup=reply_markup,


### PR DESCRIPTION
# Description

Add missed answer_poll and reply_poll methods to Message

## Type of change

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

On own bot with `pip install -e`
