### PR TITLE
fix(aiohttp-session): respect UNSET sentinel

### DIFF
--- a/aiogram/api/client/session/aiohttp.py
+++ b/aiogram/api/client/session/aiohttp.py
@@ -19,7 +19,7 @@ from aiohttp import BasicAuth, ClientSession, FormData, TCPConnector
 
 from aiogram.api.methods import Request, TelegramMethod
 
-from .base import BaseSession
+from .base import BaseSession, UNSET
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..bot import Bot
@@ -121,7 +121,7 @@ class AiohttpSession(BaseSession):
     def build_form_data(self, request: Request) -> FormData:
         form = FormData(quote_fields=False)
         for key, value in request.data.items():
-            if value is None:
+            if value is None or value is UNSET:
                 continue
             form.add_field(key, self.prepare_value(value))
         if request.files:

--- a/tests/test_api/test_client/test_session/test_aiohttp_session.py
+++ b/tests/test_api/test_client/test_session/test_aiohttp_session.py
@@ -8,7 +8,7 @@ from aresponses import ResponsesMockServer
 from aiogram import Bot
 from aiogram.api.client.session.aiohttp import AiohttpSession
 from aiogram.api.methods import Request, TelegramMethod
-from aiogram.api.types import InputFile
+from aiogram.api.types import InputFile, UNSET
 from tests.mocked_bot import MockedBot
 
 try:
@@ -117,6 +117,7 @@ class TestAiohttpSession:
                 "str": "value",
                 "int": 42,
                 "bool": True,
+                "unset": UNSET,
                 "null": None,
                 "list": ["foo"],
                 "dict": {"bar": "baz"},


### PR DESCRIPTION
# Description

check if value is `UNSET` while building http request.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
