### PR TITLE
Fix showing thumb when sending document (#389)

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -398,6 +398,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         files = {}
         prepare_file(payload, files, 'document', document)
+        prepare_attachment(payload, files, 'thumb', thumb)
 
         result = await self.request(api.Methods.SEND_DOCUMENT, payload, files)
         return types.Message(**result)


### PR DESCRIPTION
# Description
``` python3
import asyncio
from aiogram import Bot
from aiogram.types import InputFile

BOT_TOKEN = "..."
CHAT_ID = ...

async def main():
    bot = Bot(token=BOT_TOKEN)
    await bot.send_document(chat_id=CHAT_ID,
                            document=InputFile("document.zip"),
                            thumb=InputFile("thumb.jpg"))
    await bot.close()

asyncio.run(main())
```
![image](https://user-images.githubusercontent.com/44748702/88468096-6f3bfd80-cf2a-11ea-9367-5ee1dd63ec89.png)

Fixes #389 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
