### PR TITLE
fix(bot,dispatcher): do not use _MainThread event loop

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -27,10 +27,10 @@ log = logging.getLogger(__name__)
 DEFAULT_RATE_LIMIT = .1
 
 
-def _ensure_loop(x):
+def _ensure_loop(x: "asyncio.AbstractEventLoop"):
     assert isinstance(
         x, asyncio.AbstractEventLoop
-    ), f"Loop must the implementation of {asyncio.AbstractEventLoop!r}, " \
+    ), f"Loop must be the implementation of {asyncio.AbstractEventLoop!r}, " \
        f"not {type(x)!r}"
 
 

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -110,9 +110,11 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         self._setup_filters()
 
     @property
-    def loop(self) -> asyncio.AbstractEventLoop:
+    def loop(self) -> typing.Optional[asyncio.AbstractEventLoop]:
         # for the sake of backward compatibility
         # lib internally must delegate tasks with respect to _main_loop attribute
+        # however should never be used by the library itself
+        # use more generic approaches from asyncio's namespace
         return self._main_loop
 
     @property

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -34,9 +34,9 @@ def _ensure_loop(x):
        f"not {type(x)!r}"
 
 
-if callable(getattr(asyncio, "create_task")):
+try:
     _asyncio_create_task = asyncio.create_task
-else:
+except AttributeError:
     from asyncio import events as _asyncio_events
 
     def _asyncio_create_task(coro, *, name=None):
@@ -121,7 +121,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             if self._main_loop is not None:
                 self._dispatcher_close_waiter = self._main_loop.create_future()
             else:
-                self._dispatcher_close_waiter = asyncio.get_running_loop().create_future()
+                self._dispatcher_close_waiter = asyncio.get_event_loop().create_future()
         return self._dispatcher_close_waiter
 
     def _setup_filters(self):

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -34,25 +34,6 @@ def _ensure_loop(x):
        f"not {type(x)!r}"
 
 
-try:
-    _asyncio_create_task = asyncio.create_task
-except AttributeError:
-    from asyncio import events as _asyncio_events
-
-    def _asyncio_create_task(coro, *, name=None):
-        # ported and modified from asyncio-py38
-        loop = _asyncio_events.get_running_loop()
-        task = loop.create_task(coro)
-        if name is not None:
-            try:
-                set_name = task.set_name
-            except AttributeError:
-                pass
-            else:
-                set_name(name)
-        return task
-
-
 class Dispatcher(DataMixin, ContextInstanceMixin):
     """
     Simple Updates dispatcher
@@ -327,7 +308,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
     def _loop_create_task(self, coro):
         if self._main_loop is None:
-            return _asyncio_create_task(coro=coro)
+            return asyncio.create_task(coro)
         else:
             _ensure_loop(self._main_loop)
             return self._main_loop.create_task(coro)

--- a/aiogram/dispatcher/middlewares.py
+++ b/aiogram/dispatcher/middlewares.py
@@ -16,10 +16,13 @@ class MiddlewareManager:
         :param dispatcher: instance of Dispatcher
         """
         self.dispatcher = dispatcher
-        self.loop = dispatcher.loop
         self.bot = dispatcher.bot
         self.storage = dispatcher.storage
         self.applications = []
+
+    @property
+    def loop(self):
+        return self.dispatcher.loop
 
     def setup(self, middleware):
         """


### PR DESCRIPTION
# Description

 on ::Bot, ::Dispatcher initializators

Fixes #365

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Test:
The following should work

```python3
from aiogram import Bot, Dispatcher, types

bot = Bot(TOKEN)
dp = Dispatcher(bot=bot)


@dp.message_handler()
async def echo_processor(event: types.Message):
    await event.reply(event.html_text, parse_mode=types.ParseMode.HTML)


async def main():
    await bot.send_message(CHAT_ID, "Hi!")
    try:
        await dp.start_polling()
    finally:
        await bot.close()
        await dp.wait_closed()


if __name__ == '__main__':
    import asyncio
    asyncio.run(main())
```
