### PR TITLE
fixed type hints of callback_data

### DIFF
--- a/examples/callback_data_factory.py
+++ b/examples/callback_data_factory.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import uuid
+import typing
 
 from aiogram import Bot, Dispatcher, executor, md, types
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
@@ -52,7 +53,7 @@ def format_post(post_id: str, post: dict) -> (str, types.InlineKeyboardMarkup):
         md.quote_html(post['body']),
         '',  # just new empty line
         f"Votes: {post['votes']}",
-        sep = '\n',
+        sep='\n',
     )
 
     markup = types.InlineKeyboardMarkup()
@@ -75,7 +76,7 @@ async def query_show_list(query: types.CallbackQuery):
 
 
 @dp.callback_query_handler(posts_cb.filter(action='view'))
-async def query_view(query: types.CallbackQuery, callback_data: dict):
+async def query_view(query: types.CallbackQuery, callback_data: typing.Dict[str, str]):
     post_id = callback_data['id']
 
     post = POSTS.get(post_id, None)
@@ -87,7 +88,7 @@ async def query_view(query: types.CallbackQuery, callback_data: dict):
 
 
 @dp.callback_query_handler(posts_cb.filter(action=['like', 'dislike']))
-async def query_post_vote(query: types.CallbackQuery, callback_data: dict):
+async def query_post_vote(query: types.CallbackQuery, callback_data: typing.Dict[str, str]):
     try:
         await dp.throttle('vote', rate=1)
     except Throttled:

--- a/examples/callback_data_factory_simple.py
+++ b/examples/callback_data_factory_simple.py
@@ -4,6 +4,7 @@ For more comprehensive example see callback_data_factory.py
 """
 
 import logging
+import typing
 
 from aiogram import Bot, Dispatcher, executor, types
 from aiogram.contrib.middlewares.logging import LoggingMiddleware
@@ -38,7 +39,7 @@ async def cmd_start(message: types.Message):
 
 
 @dp.callback_query_handler(vote_cb.filter(action=['up', 'down']))
-async def callback_vote_action(query: types.CallbackQuery, callback_data: dict):
+async def callback_vote_action(query: types.CallbackQuery, callback_data: typing.Dict[str, str]):
     logging.info('Got this callback data: %r', callback_data)  # callback_data contains all info from callback data
     await query.answer()  # don't forget to answer callback query as soon as possible
     callback_data_action = callback_data['action']


### PR DESCRIPTION
fixed type hints

# Description

its impotant to remeber all data saved in callback_data is text even if you pass to it integer
insofar as newbies often copy examples and modyfy this typing may help them make no mistake

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Operating System: Windows 10 x64
* Python version: 3.8.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
