### PR TITLE
Command filter with forwarded messages check

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -163,7 +163,7 @@ class Message(base.TelegramObject):
 
     def is_forward(self) -> bool:
         """
-        Check message text is forward.
+        Check that the message is forwarded.
         Only `forward_date` is required to be in forwarded message.
 
         :return: bool

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -161,6 +161,15 @@ class Message(base.TelegramObject):
         """
         return self.text and self.text.startswith("/")
 
+    def is_forward(self):
+        """
+        Check message text is forward.
+        Only `forward_date` is required to be in forwarded message.
+
+        :return: bool
+        """
+        return bool(self.forward_date)
+
     def get_full_command(self):
         """
         Split command and args

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -153,14 +153,6 @@ class Message(base.TelegramObject):
 
         return ContentType.UNKNOWN
 
-    def is_command(self) -> bool:
-        """
-        Check message text is command
-
-        :return: bool
-        """
-        return self.text and self.text.startswith("/")
-
     def is_forward(self) -> bool:
         """
         Check that the message is forwarded.
@@ -169,6 +161,14 @@ class Message(base.TelegramObject):
         :return: bool
         """
         return bool(self.forward_date)
+
+    def is_command(self) -> bool:
+        """
+        Check message text is command
+
+        :return: bool
+        """
+        return self.text and self.text.startswith("/")
 
     def get_full_command(self) -> typing.Optional[typing.Tuple[str, str]]:
         """

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -153,7 +153,7 @@ class Message(base.TelegramObject):
 
         return ContentType.UNKNOWN
 
-    def is_command(self):
+    def is_command(self) -> bool:
         """
         Check message text is command
 
@@ -161,7 +161,7 @@ class Message(base.TelegramObject):
         """
         return self.text and self.text.startswith("/")
 
-    def is_forward(self):
+    def is_forward(self) -> bool:
         """
         Check message text is forward.
         Only `forward_date` is required to be in forwarded message.
@@ -170,7 +170,7 @@ class Message(base.TelegramObject):
         """
         return bool(self.forward_date)
 
-    def get_full_command(self):
+    def get_full_command(self) -> typing.Optional[typing.Tuple[str, str]]:
         """
         Split command and args
 
@@ -181,7 +181,7 @@ class Message(base.TelegramObject):
             args = args[-1] if args else ""
             return command, args
 
-    def get_command(self, pure=False):
+    def get_command(self, pure=False) -> typing.Optional[str]:
         """
         Get command from message
 
@@ -194,7 +194,7 @@ class Message(base.TelegramObject):
                 command, _, _ = command[1:].partition("@")
             return command
 
-    def get_args(self):
+    def get_args(self) -> typing.Optional[str]:
         """
         Get arguments
 
@@ -204,7 +204,7 @@ class Message(base.TelegramObject):
         if command:
             return command[1]
 
-    def parse_entities(self, as_html=True):
+    def parse_entities(self, as_html=True) -> str:
         """
         Text or caption formatted as HTML or Markdown.
 


### PR DESCRIPTION
# Command filter with caption check

Add possibility to skip forwarded messages. This change does not break backward compatibility.

Example usage:
```python3
@dp.message_handler(commands=['my_command'], commands_ignore_forward=True)
```

_Note_: this PR should be merged after https://github.com/aiogram/aiogram/pull/390.

## Type of change

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on own bot.
