### PR TITLE
Fix HTML characters escaping

### DIFF
--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -159,7 +159,7 @@ class HtmlDecoration(TextDecoration):
         return f"<s>{value}</s>"
 
     def quote(self, value: str) -> str:
-        return html.escape(value)
+        return html.escape(value, quote=False)
 
 
 class MarkdownDecoration(TextDecoration):


### PR DESCRIPTION
# Description

html.escape replaces " and ' characters by default which is **NOT** required by Telegram and causes unexpected behavior with single quotes. `quote=False` argument fixes that.
![image](https://user-images.githubusercontent.com/40635760/91634314-b3368c80-ea19-11ea-933d-5d07d4c19a65.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings