### PR TITLE
Fixed docs Quick start page code blocks

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -28,13 +28,13 @@ If you want to handle all messages in the chat simply add handler without filter
 
 .. literalinclude:: ../../examples/echo_bot.py
     :language: python
-    :lines: 35-37
+    :lines: 44-49
 
 Last step: run long polling.
 
 .. literalinclude:: ../../examples/echo_bot.py
     :language: python
-    :lines: 40-41
+    :lines: 52-53
 
 Summary
 -------
@@ -42,4 +42,4 @@ Summary
 .. literalinclude:: ../../examples/echo_bot.py
     :language: python
     :linenos:
-    :lines: -19,27-
+    :lines: -27,43-


### PR DESCRIPTION
# Description
Quick Start documentation example has invalid code blocks. Fixed it.

## Type of change

- [x] Documentation (typos, code examples or any documentation update)
- [x] This change requires a documentation update

# How Has This Been Tested?

Not tested
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
