### PR TITLE
I18n example patch (added docs and fixed typos)

### DIFF
--- a/aiogram/contrib/middlewares/i18n.py
+++ b/aiogram/contrib/middlewares/i18n.py
@@ -59,13 +59,13 @@ class I18nMiddleware(BaseMiddleware):
                 with open(mo_path, 'rb') as fp:
                     translations[name] = gettext.GNUTranslations(fp)
             elif os.path.exists(mo_path[:-2] + 'po'):
-                raise RuntimeError(f"Found locale '{name} but this language is not compiled!")
+                raise RuntimeError(f"Found locale '{name}' but this language is not compiled!")
 
         return translations
 
     def reload(self):
         """
-        Hot reload locles
+        Hot reload locales
         """
         self.locales = self.find_locales()
 

--- a/examples/i18n_example.py
+++ b/examples/i18n_example.py
@@ -1,5 +1,5 @@
 """
-Internalize your bot
+Internationalize your bot
 
 Step 1: extract texts
     # pybabel extract --input-dirs=. -o locales/mybot.pot

--- a/examples/i18n_example.py
+++ b/examples/i18n_example.py
@@ -2,7 +2,7 @@
 Internalize your bot
 
 Step 1: extract texts
-    # pybabel extract i18n_example.py -o locales/mybot.pot
+    # pybabel extract --input-dirs=. -o locales/mybot.pot
 
     Some useful options:
     - Extract texts with pluralization support
@@ -16,9 +16,14 @@ Step 1: extract texts
     - Set version
     # --version=2.2
 
-Step 2: create *.po files. For e.g. create en, ru, uk locales.
-    # echo {en,ru,uk} | xargs -n1 pybabel init -i locales/mybot.pot -d locales -D mybot -l
-Step 3: translate texts
+Step 2: create *.po files. E.g. create en, ru, uk locales.
+    # pybabel init -i locales/mybot.pot -d locales -D mybot -l en
+    # pybabel init -i locales/mybot.pot -d locales -D mybot -l ru
+    # pybabel init -i locales/mybot.pot -d locales -D mybot -l uk
+    
+Step 3: translate texts located in locales/{language}/LC_MESSAGES/mybot.po
+    To open .po file you can use basic text editor or any PO editor, e.g. https://poedit.net/
+
 Step 4: compile translations
     # pybabel compile -d locales -D mybot
 
@@ -27,7 +32,8 @@ Step 5: When you change the code of your bot you need to update po & mo files.
         command from step 1
     Step 5.2: update po files
         # pybabel update -d locales -D mybot -i locales/mybot.pot
-    Step 5.3: update your translations
+    Step 5.3: update your translations 
+        location and tools you know from step 3
     Step 5.4: compile mo files
         command from step 4
 """
@@ -92,5 +98,6 @@ async def cmd_like(message: types.Message, locale):
     # NOTE: This is comment for a translator
     await message.reply(__('Aiogram has {number} like!', 'Aiogram has {number} likes!', likes).format(number=likes))
 
+    
 if __name__ == '__main__':
     executor.start_polling(dp, skip_updates=True)


### PR DESCRIPTION
# Description

1. Replaced one file translation to all project folder translation. It's more usable case. 
2. `For e.g.` --> `E.g.`. E.g. is short for `exempli gratia` which means simply `for example`. So if you write `for e.g.`, you are in effect writing `for for example`. 
3. `xargs` replased with serveral lines, `xargs` is not appliable for Microsoft Windows users. 
4. Added info about translation tools and `.po` files location.
5. Minor typo edits.


## Type of change
- [x] Documentation (typos, code examples or any documentation update)
- [x] This change requires a documentation update
