### PR TITLE
hotfix(dispatcher): when DP.loop None

### DIFF
--- a/aiogram/contrib/middlewares/environment.py
+++ b/aiogram/contrib/middlewares/environment.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from aiogram.dispatcher.middlewares import BaseMiddleware
 
 
@@ -14,7 +16,7 @@ class EnvironmentMiddleware(BaseMiddleware):
         data.update(
             bot=dp.bot,
             dispatcher=dp,
-            loop=dp.loop
+            loop=dp.loop or asyncio.get_event_loop()
         )
         if self.context:
             data.update(self.context)

--- a/aiogram/dispatcher/webhook.py
+++ b/aiogram/dispatcher/webhook.py
@@ -169,7 +169,7 @@ class WebhookRequestHandler(web.View):
         :return:
         """
         dispatcher = self.get_dispatcher()
-        loop = dispatcher.loop
+        loop = dispatcher.loop or asyncio.get_event_loop()
 
         # Analog of `asyncio.wait_for` but without cancelling task
         waiter = loop.create_future()
@@ -209,7 +209,7 @@ class WebhookRequestHandler(web.View):
              TimeoutWarning)
 
         dispatcher = self.get_dispatcher()
-        loop = dispatcher.loop
+        loop = dispatcher.loop or asyncio.get_event_loop()
 
         try:
             results = task.result()

--- a/aiogram/utils/executor.py
+++ b/aiogram/utils/executor.py
@@ -123,13 +123,13 @@ class Executor:
     """
 
     def __init__(self, dispatcher, skip_updates=None, check_ip=False, retry_after=None, loop=None):
-        if loop is None:
-            loop = dispatcher.loop
+        if loop is not None:
+            self._loop = loop
+
         self.dispatcher = dispatcher
         self.skip_updates = skip_updates
         self.check_ip = check_ip
         self.retry_after = retry_after
-        self.loop = loop
 
         self._identity = secrets.token_urlsafe(16)
         self._web_app = None
@@ -144,6 +144,10 @@ class Executor:
         from aiogram import Bot, Dispatcher
         Bot.set_current(dispatcher.bot)
         Dispatcher.set_current(dispatcher)
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return getattr(self, "_loop", asyncio.get_event_loop())
 
     @property
     def frozen(self):


### PR DESCRIPTION
property DP.loop may be None, executor and webhook view should both respect that