### PR TITLE
HandlerObject: Unwrap handler before awaitable check

### DIFF
--- a/aiogram/dispatcher/event/handler.py
+++ b/aiogram/dispatcher/event/handler.py
@@ -62,7 +62,7 @@ class HandlerObject(CallableMixin):
     def __post_init__(self) -> None:
         super(HandlerObject, self).__post_init__()
         callback = inspect.unwrap(self.callback)
-        if inspect.isclass(callback) and issubclass(callback, BaseHandler):  # type: ignore
+        if inspect.isclass(callback) and issubclass(callback, BaseHandler):
             self.awaitable = True
 
     async def check(self, *args: Any, **kwargs: Any) -> Tuple[bool, Dict[str, Any]]:

--- a/aiogram/dispatcher/event/handler.py
+++ b/aiogram/dispatcher/event/handler.py
@@ -61,7 +61,8 @@ class HandlerObject(CallableMixin):
 
     def __post_init__(self) -> None:
         super(HandlerObject, self).__post_init__()
-        if inspect.isclass(self.callback) and issubclass(self.callback, BaseHandler):  # type: ignore
+        callback = inspect.unwrap(self.callback)
+        if inspect.isclass(callback) and issubclass(callback, BaseHandler):  # type: ignore
             self.awaitable = True
 
     async def check(self, *args: Any, **kwargs: Any) -> Tuple[bool, Dict[str, Any]]:

--- a/tests/test_dispatcher/test_handler/test_base.py
+++ b/tests/test_dispatcher/test_handler/test_base.py
@@ -1,11 +1,13 @@
 import asyncio
 import datetime
+from functools import wraps
 from typing import Any
 
 import pytest
 
 from aiogram import Bot
 from aiogram.api.types import Chat, Message, Update
+from aiogram.dispatcher.event.handler import HandlerObject
 from aiogram.dispatcher.handler.base import BaseHandler
 
 
@@ -56,3 +58,9 @@ class TestBaseClassBasedHandler:
 
         assert handler.event == event
         assert handler.update == update
+
+    @pytest.mark.asyncio
+    async def test_wrapped_handler(self):
+        # wrap the handler on dummy function
+        handler = wraps(MyHandler)(lambda: None)
+        assert HandlerObject(handler).awaitable is True


### PR DESCRIPTION
# Description

Unwraps the callback before awaitable check

Fixes #434 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
