### PR TITLE
Add football dice to DiceEmoji

### DIFF
--- a/aiogram/types/dice.py
+++ b/aiogram/types/dice.py
@@ -6,7 +6,7 @@ class Dice(base.TelegramObject):
     This object represents a dice with random value from 1 to 6.
     (Yes, we're aware of the “proper” singular of die.
     But it's awkward, and we decided to help it change. One dice at a time!)
-    
+
     https://core.telegram.org/bots/api#dice
     """
     emoji: base.String = fields.Field()
@@ -17,3 +17,4 @@ class DiceEmoji:
     DICE = '🎲'
     DART = '🎯'
     BASKETBALL = '🏀'
+    FOOTBALL = '⚽'


### PR DESCRIPTION
# Add football dice to DiceEmoji

Football dice not documented but already supported in Bot API:
```
 "dice": {
  "emoji": "⚽️",
  "value": 1
 }
```

For example you can check it with this request:
```
https://api.telegram.org/botBOT_TOKEN/sendDice?chat_id=TEST_CHAT_ID&emoji=⚽
```

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

On my bot
