### PR TITLE
Added SUPERGROUP chat type

### DIFF
--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -494,6 +494,7 @@ class ChatType(helper.Helper):
     :key: PRIVATE
     :key: GROUP
     :key: SUPER_GROUP
+    :key: SUPERGROUP
     :key: CHANNEL
     """
 
@@ -502,6 +503,7 @@ class ChatType(helper.Helper):
     PRIVATE = helper.Item()  # private
     GROUP = helper.Item()  # group
     SUPER_GROUP = helper.Item()  # supergroup
+    SUPERGROUP = helper.Item()  # supergroup
     CHANNEL = helper.Item()  # channel
 
     @staticmethod
@@ -543,7 +545,7 @@ class ChatType(helper.Helper):
         :param obj:
         :return:
         """
-        return cls._check(obj, [cls.SUPER_GROUP])
+        return cls._check(obj, [cls.SUPER_GROUP, cls.SUPERGROUP])
 
     @classmethod
     @deprecated("This filter was moved to ChatTypeFilter, and will be removed in aiogram v3.0")
@@ -554,7 +556,7 @@ class ChatType(helper.Helper):
         :param obj:
         :return:
         """
-        return cls._check(obj, [cls.GROUP, cls.SUPER_GROUP])
+        return cls._check(obj, [cls.GROUP, cls.SUPER_GROUP, cls.SUPERGROUP])
 
     @classmethod
     @deprecated("This filter was moved to ChatTypeFilter, and will be removed in aiogram v3.0")

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -10,7 +10,7 @@ from .chat_member import ChatMember
 from .chat_permissions import ChatPermissions
 from .chat_photo import ChatPhoto
 from .input_file import InputFile
-from ..utils.deprecated import deprecated
+from ..utils.deprecated import deprecated, DeprecatedReadOnlyClassVar
 
 
 class Chat(base.TelegramObject):
@@ -502,9 +502,13 @@ class ChatType(helper.Helper):
 
     PRIVATE = helper.Item()  # private
     GROUP = helper.Item()  # group
-    SUPER_GROUP = helper.Item()  # supergroup
     SUPERGROUP = helper.Item()  # supergroup
     CHANNEL = helper.Item()  # channel
+
+    SUPER_GROUP: DeprecatedReadOnlyClassVar[ChatType, helper.Item] \
+        = DeprecatedReadOnlyClassVar(
+        "SUPER_GROUP chat type is deprecated, use SUPERGROUP instead.",
+        new_value_getter=lambda cls: cls.SUPERGROUP)
 
     @staticmethod
     def _check(obj, chat_types) -> bool:


### PR DESCRIPTION
Added SUPERGROUP chat type, because SUPER_GROUP is incorrect and confusing.
Even [Telegram API](https://core.telegram.org/api/channel) calls this type of chats "supergroups" and not "super groups", so using underscore if needless.


# Description

Added ChatType.SUPERGROUP, which may replace SUPER_GROUP in future. For now, both types will present.

Fixes #356 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No tests except one manual test case:
```python
@dp.message_handler(chat_type=[types.ChatType.SUPERGROUP])
async def get_data(message: types.Message):
    await message.answer("Oh, hi, Mark!")
```

You can still use `SUPER_GROUP`, but it will raise DeprecationWarning.
This works fine on my local setup

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8.5

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
