### PR TITLE
tell mypy that this library is typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     author_email='jroot.junior@gmail.com',
     description='Is a pretty simple and fully asynchronous framework for Telegram Bot API',
     long_description=get_description(),
+    package_data={"aiogram": ["py.typed"]},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
# Description

Install a `py.typed` file so that mypy will know and won't complain.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Run mypy against my bot and verify that I no longer get:

```
xxx: error: Skipping analyzing 'aiogram': found module but no type hints or library stubs
xxx: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

**Test Configuration**:
* Operating System: Arch Linux
* Python version: 3.8.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
