### PR TITLE
feat(Router): Ability to modify routers' level in update hierarchy.

### DIFF
--- a/docs/dispatcher/router.md
+++ b/docs/dispatcher/router.md
@@ -9,6 +9,7 @@ Imports:
 | Argument | Type | Description |
 | - | - | - |
 | `use_builtin_filters` | `#!python3 bool` | Register builtin filters in filters factory. Has no effect when filters is already registered in parent router. (default: `#!python3 True`) | 
+| `level` | `#!python3 int` | Determines the level of Router in update hierarchy, The least level recieves update first than the highest. (default: `#!python3 0`)
 
 Example:
 ```python3

--- a/tests/test_dispatcher/test_router.py
+++ b/tests/test_dispatcher/test_router.py
@@ -466,3 +466,12 @@ class TestRouter:
 
         response = await root_router.update.trigger(update)
         assert response == "KABOOM"
+
+    @pytest.mark.asyncio
+    async def test_router_level_hierarchy(self):
+        root_router = Router()
+        list_of_routers = [Router(level=3), Router(level=2), Router()]
+        for i in list_of_routers:
+            root_router.include_router(i)
+
+        assert root_router.sub_routers == list(reversed(list_of_routers))

--- a/tests/test_dispatcher/test_router.py
+++ b/tests/test_dispatcher/test_router.py
@@ -475,3 +475,19 @@ class TestRouter:
             root_router.include_router(i)
 
         assert root_router.sub_routers == list(reversed(list_of_routers))
+
+        # test level comparisons
+        assert (Router(level=1) > Router()) is True
+        assert (Router(level=1) < Router(level=2)) is True
+
+        with pytest.raises(ValueError, match="Expected Integer got str"):
+            Router(level="cat")
+
+        with pytest.raises(ValueError, match="Router levels must be positive integer."):
+            Router(level=-1)
+
+        with pytest.raises(TypeError, match="'>' not supported between instances of 'router' and 'type'"):
+            _ = Router(level=1) > object
+
+        with pytest.raises(TypeError, match="'<' not supported between instances of 'router' and 'type'"):
+            _ = Router(level=1) < object


### PR DESCRIPTION
# Description

Although aiogram v3 has better control over update propagation than aiogram v2, it still lacks absolute control (As propagation order through `sub_routers` depend upon the order of _including them_ in root router). Most developers prefer dynamic loading of modules (`Router`) thus having least control over _order of insertion_. Similar implementation has done in _PTB_, _Pyrogram_, etc..

Fixes #410 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

See tests :)

**Test Configuration**:
* Operating System:  Ubuntu 20.04 (WSL2)
* Python version: Python 3.8.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
