### PR TITLE
Fixed BotKicked match text

### DIFF
--- a/aiogram/utils/exceptions.py
+++ b/aiogram/utils/exceptions.py
@@ -515,7 +515,7 @@ class Unauthorized(TelegramAPIError, _MatchErrorMixin):
 
 
 class BotKicked(Unauthorized):
-    match = 'bot was kicked from a chat'
+    match = 'bot was kicked from'
 
 
 class BotBlocked(Unauthorized):


### PR DESCRIPTION
Actual message after bot kicked:
`Forbidden: bot was kicked from the supergroup chat`
