### PR TITLE
Fix unsupported parse_mode

### DIFF
--- a/aiogram/api/methods/edit_message_text.py
+++ b/aiogram/api/methods/edit_message_text.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..types import UNSET, InlineKeyboardMarkup, Message
-from .base import Request, TelegramMethod
+from .base import Request, TelegramMethod, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -37,5 +37,6 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict()
+        prepare_parse_mode(bot, data)
 
         return Request(method="editMessageText", data=data)

--- a/aiogram/api/methods/send_animation.py
+++ b/aiogram/api/methods/send_animation.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -66,6 +66,7 @@ class SendAnimation(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"animation", "thumb"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="animation", value=self.animation)

--- a/aiogram/api/methods/send_audio.py
+++ b/aiogram/api/methods/send_audio.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -66,6 +66,7 @@ class SendAudio(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"audio", "thumb"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="audio", value=self.audio)

--- a/aiogram/api/methods/send_document.py
+++ b/aiogram/api/methods/send_document.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -59,6 +59,7 @@ class SendDocument(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"document", "thumb"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="document", value=self.document)

--- a/aiogram/api/methods/send_photo.py
+++ b/aiogram/api/methods/send_photo.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -50,6 +50,7 @@ class SendPhoto(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"photo"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="photo", value=self.photo)

--- a/aiogram/api/methods/send_video.py
+++ b/aiogram/api/methods/send_video.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -67,6 +67,7 @@ class SendVideo(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"video", "thumb"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="video", value=self.video)

--- a/aiogram/api/methods/send_voice.py
+++ b/aiogram/api/methods/send_voice.py
@@ -11,7 +11,7 @@ from ..types import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
-from .base import Request, TelegramMethod, prepare_file
+from .base import Request, TelegramMethod, prepare_file, prepare_parse_mode
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..client.bot import Bot
@@ -56,6 +56,7 @@ class SendVoice(TelegramMethod[Message]):
 
     def build_request(self, bot: Bot) -> Request:
         data: Dict[str, Any] = self.dict(exclude={"voice"})
+        prepare_parse_mode(bot, data)
 
         files: Dict[str, InputFile] = {}
         prepare_file(data=data, files=files, name="voice", value=self.voice)


### PR DESCRIPTION
## Summary
Fixed `Bad Request: unsupported parse_mode` error due to missing `prepare_parse_mode` line

P.S. Do I have to cover this case by tests?

UPD. Might be a bit related to #387 