### PR TITLE
Add football & slot machine dice

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -954,7 +954,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         :param chat_id: Unique identifier for the target chat or username of the target channel
         :type chat_id: :obj:`typing.Union[base.Integer, base.String]`
-        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲” or “🎯”. Defauts to “🎲”
+        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, "🏀", "⚽️" or "🎰". Defauts to “🎲”
         :type emoji: :obj:`typing.Union[base.String, None]`
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound
         :type disable_notification: :obj:`typing.Union[base.Boolean, None]`

--- a/aiogram/types/dice.py
+++ b/aiogram/types/dice.py
@@ -17,3 +17,5 @@ class DiceEmoji:
     DICE = '🎲'
     DART = '🎯'
     BASKETBALL = '🏀'
+    SOCCER = '⚽️'
+    SLOT_MACHINE = '🎰'

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -1043,7 +1043,7 @@ class Message(base.TelegramObject):
 
         Source: https://core.telegram.org/bots/api#senddice
 
-        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲” or “🎯”. Defauts to “🎲”
+        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, "🏀", "⚽️" or "🎰". Defauts to “🎲”
         :type emoji: :obj:`typing.Union[base.String, None]`
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`typing.Union[base.Boolean, None]`
@@ -1829,7 +1829,7 @@ class Message(base.TelegramObject):
 
         Source: https://core.telegram.org/bots/api#senddice
 
-        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲” or “🎯”. Defauts to “🎲”
+        :param emoji: Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, "🏀", "⚽️" or "🎰". Defauts to “🎲”
         :type emoji: :obj:`typing.Union[base.String, None]`
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound.
         :type disable_notification: :obj:`typing.Union[base.Boolean, None]`


### PR DESCRIPTION
# Description

[Bot API 5.0](https://core.telegram.org/bots/api-changelog#November-4-2020) has been released.

This version supports new football animations and slot machines for random dice.
I added these random dice to the aiogram code.

I am not a professional programmer. I tested the code I added. I hope to be useful and add other features added to bot API 5.0 to aiogram in the future.

## Type of change

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
1. Apply new code.
2. `python setup.py install`
3. Test new code with simple bot


**Test Configuration**:
* Operating System: Manjaro Linux x86_64
* Python version: Python 3.8.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
