### PR TITLE
Add support for third-party logger classes

### DIFF
--- a/aiogram/contrib/middlewares/logging.py
+++ b/aiogram/contrib/middlewares/logging.py
@@ -10,7 +10,7 @@ HANDLED_STR = ['Unhandled', 'Handled']
 
 class LoggingMiddleware(BaseMiddleware):
     def __init__(self, logger=__name__):
-        if not isinstance(logger, logging.Logger):
+        if isinstance(logger, str):
             logger = logging.getLogger(logger)
 
         self.logger = logger


### PR DESCRIPTION
# Description
Change in behavior in `LoggingMiddleware `
Get embedded logger by name only if `str` is passed, else use the provided one.

Fixes #483

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

PyTest re-run and manual testing with loguru

**Test Configuration**:
* Operating System: MacOS 11.1
* Python version: 3.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
