### PR TITLE
Fix empty bucket return

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -1136,8 +1136,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current()
-            chat_id = types.Chat.get_current()
+            user_id = types.User.get_current().id
+            chat_id = types.Chat.get_current().id
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         data = bucket.get(key, {})
@@ -1158,8 +1158,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current()
-            chat_id = types.Chat.get_current()
+            user_id = types.User.get_current().id
+            chat_id = types.Chat.get_current().id
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         if bucket and key in bucket:


### PR DESCRIPTION
# Description

When trying to implement throttling for commands "hr = await dispatcher.check_key(key)" without other parameters - it couldn't find any bucket.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Implementing a simple middleware to throttle commands. Trying to get current Throttled object from bucket with: `thr = await dispatcher.check_key(key)` returns an empty Throttled (zero and None values). Checking this code it was found, that it should be `user_id` and `chat_id` parameters passed to `storage.get_bucket` method.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings