### PR TITLE
fix bug in getting user_id, chat_id from context

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -1136,8 +1136,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current()
-            chat_id = types.Chat.get_current()
+            user_id = types.User.get_current().id
+            chat_id = types.Chat.get_current().id
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         data = bucket.get(key, {})
@@ -1158,8 +1158,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current()
-            chat_id = types.Chat.get_current()
+            user_id = types.User.get_current().id
+            chat_id = types.Chat.get_current().id
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         if bucket and key in bucket:

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -1084,8 +1084,11 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         if rate is None:
             rate = self.throttling_rate_limit
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current().id
-            chat_id = types.Chat.get_current().id
+            chat_obj = types.Chat.get_current()
+            chat_id = chat_obj.id if chat_obj else None
+
+            user_obj = types.User.get_current()
+            user_id = user_obj.id if user_obj else None
 
         # Detect current time
         now = time.time()
@@ -1136,8 +1139,11 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current().id
-            chat_id = types.Chat.get_current().id
+            chat_obj = types.Chat.get_current()
+            chat_id = chat_obj.id if chat_obj else None
+
+            user_obj = types.User.get_current()
+            user_id = user_obj.id if user_obj else None
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         data = bucket.get(key, {})
@@ -1158,8 +1164,11 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             raise RuntimeError('This storage does not provide Leaky Bucket')
 
         if user_id is None and chat_id is None:
-            user_id = types.User.get_current().id
-            chat_id = types.Chat.get_current().id
+            chat_obj = types.Chat.get_current()
+            chat_id = chat_obj.id if chat_obj else None
+
+            user_obj = types.User.get_current()
+            user_id = user_obj.id if user_obj else None
 
         bucket = await self.storage.get_bucket(chat=chat_id, user=user_id)
         if bucket and key in bucket:


### PR DESCRIPTION
 in Dispatcher check_key and release_key functions
(need User.id for future use, not User object)

# Description

there was a bug in check_key and release_key functions.
When we call these functions with no chat_id or user_id argument, they cannot set user_id and chat id variable correctly, becouse this code:

user_id = types.User.get_current()
chat_id = types.Chat.get_current()

return User/Chat object, not user/chat id


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Run aiogram tests
- [x] Run bot with these changes

**Test Configuration**:
* Operating System: Windows 10 | Linux Manjaro
* Python version: 3.7.10 |  3.9.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ]  I have added tests that prove my fix is effective or that my feature works

