### PR TITLE
Added alias to from_user field, fixed TypeError

### DIFF
--- a/aiogram/types/chat_member_updated.py
+++ b/aiogram/types/chat_member_updated.py
@@ -15,7 +15,7 @@ class ChatMemberUpdated(base.TelegramObject):
     https://core.telegram.org/bots/api#chatmemberupdated
     """
     chat: Chat = fields.Field(base=Chat)
-    from_user: User = fields.Field(base=User)
+    from_user: User = fields.Field(alias="from", base=User)
     date: datetime.datetime = fields.DateTimeField()
     old_chat_member: ChatMember = fields.Field(base=ChatMember)
     new_chat_member: ChatMember = fields.Field(base=ChatMember)


### PR DESCRIPTION
# Description

This fixes `TypeError: Value should be instance of 'User' not 'NoneType'`

Related: https://t.me/aiogram_ru/489310

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Desperate Times Call for Desperate Measures, so no tests, except running bot once. You can test it yourself by blocking and unblocking your bot.

**Test Configuration**:
* Operating System: Manjaro
* Python version: 3.9

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
