### PR TITLE
FIX TelegramObject.__setitem__

### DIFF
--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import typing
-import warnings
 from asyncio.log import logger
 from typing import TypeVar
 
@@ -228,8 +227,7 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
             return self.props[key].set_value(self, value, self.conf.get('parent', None))
         self.values[key] = value
 
-        # Show and log a warning when Telegram silently adds new Fields
-        warnings.warn(f"Field '{key}' doesn't exist in {self.__class__}")
+        # Log warning when Telegram silently adds new Fields
         logger.warning(f"Field '{key}' doesn't exist in {self.__class__}")
 
     def __contains__(self, item: str) -> bool:

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import io
+import logging
 import typing
-from asyncio.log import logger
 from typing import TypeVar
 
 from babel.support import LazyProxy
@@ -26,6 +26,9 @@ Integer = TypeVar('Integer', bound=int)
 Float = TypeVar('Float', bound=float)
 Boolean = TypeVar('Boolean', bound=bool)
 T = TypeVar('T')
+
+# Main aiogram logger
+log = logging.getLogger('aiogram')
 
 
 class MetaTelegramObject(type):
@@ -228,7 +231,7 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         self.values[key] = value
 
         # Log warning when Telegram silently adds new Fields
-        logger.warning(f"Field '{key}' doesn't exist in {self.__class__}")
+        log.warning(f"Field '%s' doesn't exist in %s", key, self.__class__)
 
     def __contains__(self, item: str) -> bool:
         """

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -231,7 +231,7 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         self.values[key] = value
 
         # Log warning when Telegram silently adds new Fields
-        log.warning(f"Field '%s' doesn't exist in %s", key, self.__class__)
+        log.warning("Field '%s' doesn't exist in %s", key, self.__class__)
 
     def __contains__(self, item: str) -> bool:
         """

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -225,7 +225,6 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         if key in self.props:
             return self.props[key].set_value(self, value, self.conf.get('parent', None))
         self.values[key] = value
-        raise KeyError(key)
 
     def __contains__(self, item: str) -> bool:
         """

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import typing
+import warnings
+from asyncio.log import logger
 from typing import TypeVar
 
 from babel.support import LazyProxy
@@ -225,6 +227,10 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         if key in self.props:
             return self.props[key].set_value(self, value, self.conf.get('parent', None))
         self.values[key] = value
+
+        # Show and log a warning when Telegram silently adds new Fields
+        warnings.warn(f"Field '{key}' doesn't exist in {self.__class__}")
+        logger.warning(f"Field '{key}' doesn't exist in {self.__class__}")
 
     def __contains__(self, item: str) -> bool:
         """


### PR DESCRIPTION
Removed 'raise KeyError(key)'

# Description

Fix error:
```
  File "/usr/local/lib/python3.8/dist-packages/aiogram/types/chat.py", line 112, in get_url
    await self.update_chat()
  File "/usr/local/lib/python3.8/dist-packages/aiogram/types/chat.py", line 124, in update_chat
    self[key] = value
  File "/usr/local/lib/python3.8/dist-packages/aiogram/types/base.py", line 228, in __setitem__
    raise KeyError(key)
KeyError: 'message_auto_delete_time'
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test with Update that raises this error
- [x] Test using `await msg.chat.update_chat()`

**Test Configuration**:
* Operating System: Windows 10, Ubuntu 20.04.2 LTS
* Python version: 3.8.5, 3.8.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
