### PR TITLE
Fix `Bot.*_chat_invite_link` not returning `ChatInviteLink` (#548)

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -1834,7 +1834,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         expire_date = prepare_arg(expire_date)
         payload = generate_payload(**locals())
 
-        return await self.request(api.Methods.CREATE_CHAT_INVITE_LINK, payload)
+        result = await self.request(api.Methods.CREATE_CHAT_INVITE_LINK, payload)
+        return types.ChatInviteLink(**result)
 
     async def edit_chat_invite_link(self,
                                     chat_id: typing.Union[base.Integer, base.String],
@@ -1870,7 +1871,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         expire_date = prepare_arg(expire_date)
         payload = generate_payload(**locals())
 
-        return await self.request(api.Methods.EDIT_CHAT_INVITE_LINK, payload)
+        result = await self.request(api.Methods.EDIT_CHAT_INVITE_LINK, payload)
+        return types.ChatInviteLink(**result)
 
     async def revoke_chat_invite_link(self,
                                       chat_id: typing.Union[base.Integer, base.String],
@@ -1891,7 +1893,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         payload = generate_payload(**locals())
 
-        return await self.request(api.Methods.REVOKE_CHAT_INVITE_LINK, payload)
+        result = await self.request(api.Methods.REVOKE_CHAT_INVITE_LINK, payload)
+        return types.ChatInviteLink(**result)
 
     async def set_chat_photo(self, chat_id: typing.Union[base.Integer, base.String],
                              photo: base.InputFile) -> base.Boolean:


### PR DESCRIPTION
Bot.create_chat_invite_link()
Bot.edit_chat_invite_link()
Bot.revoke_chat_invite_link()

need to return types.ChatInviteLink, not dict

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #548

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Maybe this fix be breaking if users use dicts that was returned by these methods

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Methods return types.ChatInviteLink objects

**Test Configuration**:
* Operating System: Win10
* Python version: 3.9.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
