### PR TITLE
Replace deprecated 'is_private' method

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -267,7 +267,8 @@ class Message(base.TelegramObject):
 
         :return: str
         """
-        if ChatType.is_private(self.chat):
+        
+        if self.chat.type == ChatType.PRIVATE:
             raise TypeError("Invalid chat type!")
         url = "https://t.me/"
         if self.chat.username:


### PR DESCRIPTION
# Description

Property types.Message.url uses deprecated method 'is_private' when checks chat type. I've replaced it

Fixes #552 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Checked that property no longer raise DeprecationWarning

Operating System: Win10
Python version: 3.9.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
