### PR TITLE
fix: builtin command filter args (#556)

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -4,7 +4,7 @@ import typing
 import warnings
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from babel.support import LazyProxy
 
@@ -111,6 +111,7 @@ class Command(Filter):
             return False
 
         full_command = text.split()[0]
+        args = text.split()[1:]
         prefix, (command, _, mention) = full_command[0], full_command[1:].partition('@')
 
         if not ignore_mention and mention and (await message.bot.me).username.lower() != mention.lower():
@@ -120,7 +121,7 @@ class Command(Filter):
         if (command.lower() if ignore_case else command) not in commands:
             return False
 
-        return {'command': cls.CommandObj(command=command, prefix=prefix, mention=mention)}
+        return {'command': cls.CommandObj(command=command, prefix=prefix, mention=mention, args=args)}
 
     @dataclass
     class CommandObj:
@@ -137,7 +138,7 @@ class Command(Filter):
         """Mention (if available)"""
         mention: str = None
         """Command argument"""
-        args: str = field(repr=False, default=None)
+        args: List[str] = field(repr=False, default_factory=list)
 
         @property
         def mentioned(self) -> bool:
@@ -159,7 +160,7 @@ class Command(Filter):
             if self.mentioned:
                 line += '@' + self.mention
             if self.args:
-                line += ' ' + self.args
+                line += ' ' + ' '.join(self.args)
             return line
 
 

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -160,7 +160,7 @@ class Command(Filter):
             if self.mentioned:
                 line += '@' + self.mention
             if self.args:
-                line += ' ' + ' '.join(self.args)
+                line += ' ' + self.args
             return line
 
 

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -110,8 +110,8 @@ class Command(Filter):
         if not text:
             return False
 
-        full_command = text.split()[0]
-        args = text.split()[1:]
+        full_command, *args_list = text.split(maxsplit=1)
+        args = args_list[0] if args_list else None
         prefix, (command, _, mention) = full_command[0], full_command[1:].partition('@')
 
         if not ignore_mention and mention and (await message.bot.me).username.lower() != mention.lower():
@@ -138,7 +138,7 @@ class Command(Filter):
         """Mention (if available)"""
         mention: str = None
         """Command argument"""
-        args: List[str] = field(repr=False, default_factory=list)
+        args: str = field(repr=False, default=None)
 
         @property
         def mentioned(self) -> bool:


### PR DESCRIPTION
# Description

Fixes #556 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Parse command with no argument
- [x] Parse command with one argument
- [x] Parse command with more than one arguments
- [x] Print `CommandObj.text`

* Operating System: Windows 10
* Python version: 3.8.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
