### PR TITLE
fix get_full_command for messages with caption

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -194,7 +194,8 @@ class Message(base.TelegramObject):
 
         :return: bool
         """
-        return self.text and self.text.startswith("/")
+        return self.text and self.text.startswith("/") \
+               or self.caption and self.caption.startswith("/")
 
     def get_full_command(self) -> typing.Optional[typing.Tuple[str, str]]:
         """
@@ -203,8 +204,9 @@ class Message(base.TelegramObject):
         :return: tuple of (command, args)
         """
         if self.is_command():
-            command, *args = self.text.split(maxsplit=1)
-            args = args[-1] if args else ""
+            command, *args = (self.text if self.text
+                              else self.caption).split(maxsplit=1)
+            args = args[0] if args else ""
             return command, args
 
     def get_command(self, pure=False) -> typing.Optional[str]:
@@ -271,7 +273,7 @@ class Message(base.TelegramObject):
 
         :return: str
         """
-        
+
         if self.chat.type == ChatType.PRIVATE:
             raise TypeError("Invalid chat type!")
         url = "https://t.me/"
@@ -1420,7 +1422,7 @@ class Message(base.TelegramObject):
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,
         )
-    
+
     async def answer_chat_action(
         self,
         action: base.String,

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -194,8 +194,8 @@ class Message(base.TelegramObject):
 
         :return: bool
         """
-        return self.text and self.text.startswith("/") \
-               or self.caption and self.caption.startswith("/")
+        text = self.text or self.caption
+        return text and text.startswith("/")
 
     def get_full_command(self) -> typing.Optional[typing.Tuple[str, str]]:
         """
@@ -204,8 +204,8 @@ class Message(base.TelegramObject):
         :return: tuple of (command, args)
         """
         if self.is_command():
-            command, *args = (self.text if self.text
-                              else self.caption).split(maxsplit=1)
+            text = self.text or self.caption
+            command, *args = text.split(maxsplit=1)
             args = args[0] if args else ""
             return command, args
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
```python
@dispatcher.message_handler(commands=["command"], commands_ignore_caption=False, content_types=types.ContentType.ANY)
async def message_handler(message: types.Message):
    print( message.get_full_command() )    
```

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8
