### PR TITLE
Add caption_entities in InputMedia base class

### DIFF
--- a/aiogram/types/input_media.py
+++ b/aiogram/types/input_media.py
@@ -28,6 +28,7 @@ class InputMedia(base.TelegramObject):
     thumb: typing.Union[base.InputFile, base.String] = fields.Field(alias='thumb', on_change='_thumb_changed')
     caption: base.String = fields.Field()
     parse_mode: base.String = fields.Field()
+    caption_entities: typing.List[MessageEntity] = fields.ListField(base=MessageEntity)
 
     def __init__(self, *args, **kwargs):
         self._thumb_file = None


### PR DESCRIPTION
# Description
Add `caption_entities` field in `InputMedia` base class.

Fixes #575

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
