### PR TITLE
fix for text decoration pre() bug

### DIFF
--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -185,7 +185,7 @@ class MarkdownDecoration(TextDecoration):
         return f"`{value}`"
 
     def pre(self, value: str) -> str:
-        return f"```{value}```"
+        return f"```\n{value}\n```"
 
     def pre_language(self, value: str, language: str) -> str:
         return f"```{language}\n{value}\n```"


### PR DESCRIPTION
# Description

This fix adds `'\n'` symbols at begin and end of inserted text to `pre()` formatter in Makdown(V2) style as it described in [official documentation](https://core.telegram.org/bots/api#formatting-options).

Fixes #596 
Fixes #481 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
