### PR TITLE
Fix syntax bug in message.py

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -2933,7 +2933,7 @@ class Message(base.TelegramObject):
                 question=self.poll.question,
                 options=[option.text for option in self.poll.options],
                 is_anonymous=self.poll.is_anonymous,
-                allows_multiple_answers=self.poll.allows_multiple_answers
+                allows_multiple_answers=self.poll.allows_multiple_answers,
                 **kwargs,
             )
         elif self.dice:


### PR DESCRIPTION
Fixed syntax bug, added comma

# Description

Just added a comma, the absence of which the interpreter did not take as a syntax error 

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
