### PR TITLE
I18n fix

### DIFF
--- a/aiogram/contrib/middlewares/i18n.py
+++ b/aiogram/contrib/middlewares/i18n.py
@@ -135,6 +135,8 @@ class I18nMiddleware(BaseMiddleware):
         if locale:
             *_, data = args
             language = data['locale'] = locale.language
+            if language not in self.locales.keys():
+                return self.default
             return language
         return None
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     ],
     extras_require={
         'proxy': [
-            'aiohttp-socks>=0.3.4,<0.4.0',
+            'aiohttp-socks>=0.5.3,<0.6.0',
         ],
         'fast': [
             'uvloop>=0.14.0,<0.15.0',


### PR DESCRIPTION
# Description

Default language was unused. So when translating the string value of key was used, but not the default language

Fixes # (issue)

Added a check if there is a translation corresponding to the user's language, if there is none, then the default language is returned

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


