### PR TITLE
Add `contains_any` parameter to `Text` filter

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -293,6 +293,12 @@ class Text(Filter):
         self.startswith = startswith
         self.ignore_case = ignore_case
 
+    @classmethod
+    def validate(cls, full_config: Dict[str, Any]):
+        for param, key in cls._default_params:
+            if param in full_config:
+                return {key: full_config.pop(param)}
+
     async def check(self, obj: Union[Message, CallbackQuery, InlineQuery, Poll]):
         if isinstance(obj, Message):
             text = obj.text or obj.caption or ''


### PR DESCRIPTION
# Description

Text filter extended with "contains_any" parameter. 
"contains" works for all values, "contains_any" for any of.

## New feature

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
