### PR TITLE
Add to ChatMemberOwner new default fields

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -2129,7 +2129,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         return types.Chat(**result)
 
     async def get_chat_administrators(self, chat_id: typing.Union[base.Integer, base.String]
-                                      ) -> typing.List[types.ChatMember]:
+                                      ) -> typing.List[typing.Union[types.ChatMemberOwner, types.ChatMemberAdministrator]]:
+
         """
         Use this method to get a list of administrators in a chat.
 

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -7,7 +7,7 @@ import typing
 from . import base, fields
 from .chat_invite_link import ChatInviteLink
 from .chat_location import ChatLocation
-from .chat_member import ChatMember
+from .chat_member import ChatMember, ChatMemberAdministrator, ChatMemberOwner
 from .chat_permissions import ChatPermissions
 from .chat_photo import ChatPhoto
 from .input_file import InputFile
@@ -470,7 +470,7 @@ class Chat(base.TelegramObject):
         """
         return await self.bot.leave_chat(self.id)
 
-    async def get_administrators(self) -> typing.List[ChatMember]:
+    async def get_administrators(self) -> typing.List[typing.Union[ChatMemberOwner, ChatMemberAdministrator]]:
         """
         Use this method to get a list of administrators in a chat.
 
@@ -480,7 +480,7 @@ class Chat(base.TelegramObject):
             chat administrators except other bots.
             If the chat is a group or a supergroup and no administrators were appointed,
             only the creator will be returned.
-        :rtype: :obj:`typing.List[types.ChatMember]`
+        :rtype: :obj:`typing.List[typing.Union[types.ChatMemberOwner, types.ChatMemberAdministrator]]`
         """
         return await self.bot.get_chat_administrators(self.id)
 

--- a/aiogram/types/chat_member.py
+++ b/aiogram/types/chat_member.py
@@ -69,7 +69,9 @@ class ChatMember(base.TelegramObject):
         return self.user.id
 
     @classmethod
-    def resolve(cls, **kwargs) -> "ChatMember":
+    def resolve(cls, **kwargs) -> typing.Union["ChatMemberOwner", "ChatMemberAdministrator",
+                                               "ChatMemberMember", "ChatMemberRestricted",
+                                               "ChatMemberLeft", "ChatMemberBanned"]:
         status = kwargs.get("status")
         mapping = {
             ChatMemberStatus.OWNER: ChatMemberOwner,
@@ -89,8 +91,10 @@ class ChatMember(base.TelegramObject):
     def to_object(cls,
                   data: typing.Dict[str, typing.Any],
                   conf: typing.Dict[str, typing.Any] = None
-                  ) -> "ChatMember":
-        return cls.resolve(**data)
+                  ) -> typing.Union["ChatMemberOwner", "ChatMemberAdministrator",
+                                    "ChatMemberMember", "ChatMemberRestricted",
+                                    "ChatMemberLeft", "ChatMemberBanned"]:
+        return cls.resolve(conf=conf, **data)
 
     def is_chat_creator(self) -> bool:
         return ChatMemberStatus.is_chat_creator(self.status)

--- a/aiogram/types/chat_member.py
+++ b/aiogram/types/chat_member.py
@@ -28,6 +28,8 @@ class ChatMemberStatus(helper.Helper):
     def is_chat_creator(cls, role: str) -> bool:
         return role == cls.CREATOR
 
+    is_chat_owner = is_chat_creator
+
     @classmethod
     def is_chat_admin(cls, role: str) -> bool:
         return role in (cls.ADMINISTRATOR, cls.CREATOR)
@@ -97,6 +99,8 @@ class ChatMember(base.TelegramObject):
 
     def is_chat_creator(self) -> bool:
         return ChatMemberStatus.is_chat_creator(self.status)
+
+    is_chat_owner = is_chat_creator
 
     def is_chat_admin(self) -> bool:
         return ChatMemberStatus.is_chat_admin(self.status)

--- a/aiogram/types/chat_member.py
+++ b/aiogram/types/chat_member.py
@@ -1,6 +1,5 @@
 import datetime
 import typing
-from typing import Optional
 
 from . import base, fields
 from .user import User
@@ -38,7 +37,7 @@ class ChatMemberStatus(helper.Helper):
         return role in (cls.MEMBER, cls.ADMINISTRATOR, cls.CREATOR, cls.RESTRICTED)
 
     @classmethod
-    def get_class_by_status(cls, status: str) -> Optional["ChatMember"]:
+    def get_class_by_status(cls, status: str) -> typing.Optional[typing.Type["ChatMember"]]:
         return {
             cls.OWNER: ChatMemberOwner,
             cls.ADMINISTRATOR: ChatMemberAdministrator,

--- a/aiogram/types/chat_member.py
+++ b/aiogram/types/chat_member.py
@@ -113,6 +113,22 @@ class ChatMemberOwner(ChatMember):
     custom_title: base.String = fields.Field()
     is_anonymous: base.Boolean = fields.Field()
 
+    # Next fields cannot be received from API but
+    # it useful for compatibility and cleaner code:
+    # >>> if member.is_admin() and member.can_promote_members:
+    # >>>     await message.reply('You can promote me')
+    can_be_edited: base.Boolean = fields.ConstField(False)
+    can_manage_chat: base.Boolean = fields.ConstField(True)
+    can_post_messages: base.Boolean = fields.ConstField(True)
+    can_edit_messages: base.Boolean = fields.ConstField(True)
+    can_delete_messages: base.Boolean = fields.ConstField(True)
+    can_manage_voice_chats: base.Boolean = fields.ConstField(True)
+    can_restrict_members: base.Boolean = fields.ConstField(True)
+    can_promote_members: base.Boolean = fields.ConstField(True)
+    can_change_info: base.Boolean = fields.ConstField(True)
+    can_invite_users: base.Boolean = fields.ConstField(True)
+    can_pin_messages: base.Boolean = fields.ConstField(True)
+
 
 class ChatMemberAdministrator(ChatMember):
     """

--- a/aiogram/types/fields.py
+++ b/aiogram/types/fields.py
@@ -2,7 +2,7 @@ import abc
 import datetime
 import weakref
 
-__all__ = ('BaseField', 'Field', 'ListField', 'DateTimeField', 'TextField', 'ListOfLists')
+__all__ = ('BaseField', 'Field', 'ListField', 'DateTimeField', 'TextField', 'ListOfLists', 'ConstField')
 
 
 class BaseField(metaclass=abc.ABCMeta):
@@ -192,5 +192,13 @@ class TextField(Field):
 
     def deserialize(self, value, parent=None):
         if value is not None and not isinstance(value, str):
-            raise TypeError(f"Field '{self.alias}' should be str not {type(value).__name__}")
+            raise TypeError(f"Field {self.alias!r} should be str not {type(value).__name__!r}")
         return value
+
+
+class ConstField(Field):
+    def __init__(self, default=None, **kwargs):
+        super(ConstField, self).__init__(default=default, **kwargs)
+
+    def __set__(self, instance, value):
+        raise TypeError(f"Field {self.alias!r} is not mutable")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -425,14 +425,19 @@ async def test_get_chat(bot: Bot):
 
 async def test_get_chat_administrators(bot: Bot):
     """ getChatAdministrators method test """
-    from .types.dataset import CHAT, CHAT_MEMBER
+    from .types.dataset import CHAT, CHAT_MEMBER, CHAT_MEMBER_OWNER
     chat = types.Chat(**CHAT)
     member = types.ChatMember.resolve(**CHAT_MEMBER)
+    owner = types.ChatMember.resolve(**CHAT_MEMBER_OWNER)
 
-    async with FakeTelegram(message_data=[CHAT_MEMBER, CHAT_MEMBER]):
+    async with FakeTelegram(message_data=[CHAT_MEMBER, CHAT_MEMBER_OWNER]):
         result = await bot.get_chat_administrators(chat_id=chat.id)
         assert result[0] == member
+        assert result[1] == owner
         assert len(result) == 2
+        for m in result:
+            assert m.is_chat_admin()
+            assert hasattr(m, "can_be_edited")
 
 
 async def test_get_chat_member_count(bot: Bot):

--- a/tests/types/dataset.py
+++ b/tests/types/dataset.py
@@ -44,12 +44,21 @@ CHAT_MEMBER = {
     "user": USER,
     "status": "administrator",
     "can_be_edited": False,
+    "can_manage_chat": True,
     "can_change_info": True,
     "can_delete_messages": True,
     "can_invite_users": True,
     "can_restrict_members": True,
     "can_pin_messages": True,
     "can_promote_members": False,
+    "can_manage_voice_chats": True,
+    "is_anonymous": False,
+}
+
+CHAT_MEMBER_OWNER = {
+    "user": USER,
+    "status": "creator",
+    "is_anonymous": False,
 }
 
 CONTACT = {


### PR DESCRIPTION
# Description

`ChatMemberOwner` and `ChatMemberAdministrator` now have similar fields to improve compatibility and simplify checks.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

On my bot, which often deal with promotions.
Also, I added a new test case.

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
