### PR TITLE
Allow empty and zero parts in CallbackData

### DIFF
--- a/aiogram/utils/callback_data.py
+++ b/aiogram/utils/callback_data.py
@@ -33,8 +33,6 @@ class CallbackData:
             raise ValueError("Prefix can't be empty")
         if sep in prefix:
             raise ValueError(f"Separator {sep!r} can't be used in prefix")
-        if not parts:
-            raise TypeError('Parts were not passed!')
 
         self.prefix = prefix
         self.sep = sep

--- a/aiogram/utils/callback_data.py
+++ b/aiogram/utils/callback_data.py
@@ -64,8 +64,6 @@ class CallbackData:
             if value is not None and not isinstance(value, str):
                 value = str(value)
 
-            if not value:
-                raise ValueError(f"Value for part {part!r} can't be empty!'")
             if self.sep in value:
                 raise ValueError(f"Symbol {self.sep!r} is defined as the separator and can't be used in parts' values")
 

--- a/tests/test_utils/test_callback_data.py
+++ b/tests/test_utils/test_callback_data.py
@@ -1,0 +1,39 @@
+import pytest
+
+from aiogram.types import CallbackQuery
+from aiogram.utils.callback_data import CallbackData
+
+
+class TestCallbackData:
+    @pytest.mark.asyncio
+    async def test_cb(self):
+        cb = CallbackData('simple', 'action')
+        assert cb.new('x') == 'simple:x'
+        assert cb.new(action='y') == 'simple:y'
+        assert cb.new('') == 'simple:'
+
+        assert (await cb.filter().check(CallbackQuery(data='simple:'))) == {'callback_data': {'@': 'simple', 'action': ''}}
+        assert (await cb.filter().check(CallbackQuery(data='simple:x'))) == {'callback_data': {'@': 'simple', 'action': 'x'}}
+        assert (await cb.filter(action='y').check(CallbackQuery(data='simple:x'))) is False
+
+    @pytest.mark.asyncio
+    async def test_cb_double(self):
+        cb = CallbackData('double', 'pid', 'action')
+        assert cb.new('123', 'x') == 'double:123:x'
+        assert cb.new(pid=456, action='y') == 'double:456:y'
+        assert cb.new('', 'z') == 'double::z'
+        assert cb.new('789', '') == 'double:789:'
+
+        assert (await cb.filter().check(CallbackQuery(data='double::'))) == {'callback_data': {'@': 'double', 'pid': '', 'action': ''}}
+        assert (await cb.filter().check(CallbackQuery(data='double:x:'))) == {'callback_data': {'@': 'double', 'pid': 'x', 'action': ''}}
+        assert (await cb.filter().check(CallbackQuery(data='double::y'))) == {'callback_data': {'@': 'double', 'pid': '', 'action': 'y'}}
+        assert (await cb.filter(action='x').check(CallbackQuery(data='double:123:x'))) == {'callback_data': {'@': 'double', 'pid': '123', 'action': 'x'}}
+
+    @pytest.mark.asyncio
+    async def test_cb_zero(self):
+        cb = CallbackData('zero')
+        assert cb.new() == 'zero'
+
+        assert (await cb.filter().check(CallbackQuery(data='zero'))) == {'callback_data': {'@': 'zero'}}
+        assert (await cb.filter().check(CallbackQuery(data='zero:'))) is False
+        assert (await cb.filter().check(CallbackQuery(data='bla'))) is False


### PR DESCRIPTION
# Description

- Allow to use `CallbackData` with zero parts, next code was raising `TypeError`:
```python3
cb = CallbackData('zero')
```

- Allow to parts to be empty, next code was raising `ValueError`:
```python3
cb = CallbackData('simple', 'action')
cb.new('')
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added three new tests to cover main usages of `CallbackData`

**Test Configuration**:
* Operating System: Windows 10
* Python version: Python 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
