### PR TITLE
Remove redundant pytest marks

### DIFF
--- a/tests/test_api/test_client/test_bot.py
+++ b/tests/test_api/test_client/test_bot.py
@@ -16,6 +16,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestBot:
     def test_init(self):
@@ -32,7 +34,6 @@ class TestBot:
         assert bot == Bot("42:TEST")
         assert bot != "42:TEST"
 
-    @pytest.mark.asyncio
     async def test_emit(self):
         bot = Bot("42:TEST")
 
@@ -45,7 +46,6 @@ class TestBot:
             await bot(method)
             mocked_make_request.assert_awaited_with(bot, method, timeout=None)
 
-    @pytest.mark.asyncio
     async def test_close(self):
         session = AiohttpSession()
         bot = Bot("42:TEST", session=session)
@@ -57,7 +57,6 @@ class TestBot:
             await bot.session.close()
             mocked_close.assert_awaited()
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("close", [True, False])
     async def test_context_manager(self, close: bool):
         with patch(
@@ -70,7 +69,6 @@ class TestBot:
             else:
                 mocked_close.assert_not_awaited()
 
-    @pytest.mark.asyncio
     async def test_download_file(self, aresponses: ResponsesMockServer):
         aresponses.add(
             aresponses.ANY, aresponses.ANY, "get", aresponses.Response(status=200, body=b"\f" * 10)
@@ -88,7 +86,6 @@ class TestBot:
             await bot.download_file("TEST", "file.png")
             mock_file.write.assert_called_once_with(b"\f" * 10)
 
-    @pytest.mark.asyncio
     async def test_download_file_default_destination(self, aresponses: ResponsesMockServer):
         bot = Bot("42:TEST")
 
@@ -101,7 +98,6 @@ class TestBot:
         assert isinstance(result, io.BytesIO)
         assert result.read() == b"\f" * 10
 
-    @pytest.mark.asyncio
     async def test_download_file_custom_destination(self, aresponses: ResponsesMockServer):
         bot = Bot("42:TEST")
 
@@ -117,7 +113,6 @@ class TestBot:
         assert result is custom
         assert result.read() == b"\f" * 10
 
-    @pytest.mark.asyncio
     async def test_download(self, bot: MockedBot, aresponses: ResponsesMockServer):
         bot.add_result_for(
             GetFile, ok=True, result=File(file_id="file id", file_unique_id="file id")

--- a/tests/test_api/test_client/test_session/test_aiohttp_session.py
+++ b/tests/test_api/test_client/test_session/test_aiohttp_session.py
@@ -20,6 +20,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 class BareInputFile(InputFile):
     async def read(self, chunk_size: int):
@@ -27,7 +29,6 @@ class BareInputFile(InputFile):
 
 
 class TestAiohttpSession:
-    @pytest.mark.asyncio
     async def test_create_session(self):
         session = AiohttpSession()
 
@@ -36,7 +37,6 @@ class TestAiohttpSession:
         assert session._session is not None
         assert isinstance(aiohttp_session, aiohttp.ClientSession)
 
-    @pytest.mark.asyncio
     async def test_create_proxy_session(self):
         session = AiohttpSession(
             proxy=("socks5://proxy.url/", aiohttp.BasicAuth("login", "password", "encoding"))
@@ -50,7 +50,6 @@ class TestAiohttpSession:
         aiohttp_session = await session.create_session()
         assert isinstance(aiohttp_session.connector, aiohttp_socks.ProxyConnector)
 
-    @pytest.mark.asyncio
     async def test_create_proxy_session_proxy_url(self):
         session = AiohttpSession(proxy="socks4://proxy.url/")
 
@@ -62,7 +61,6 @@ class TestAiohttpSession:
         aiohttp_session = await session.create_session()
         assert isinstance(aiohttp_session.connector, aiohttp_socks.ProxyConnector)
 
-    @pytest.mark.asyncio
     async def test_create_proxy_session_chained_proxies(self):
         session = AiohttpSession(
             proxy=[
@@ -89,7 +87,6 @@ class TestAiohttpSession:
         aiohttp_session = await session.create_session()
         assert isinstance(aiohttp_session.connector, aiohttp_socks.ChainProxyConnector)
 
-    @pytest.mark.asyncio
     async def test_reset_connector(self):
         session = AiohttpSession()
         assert session._should_reset_connector
@@ -105,7 +102,6 @@ class TestAiohttpSession:
         assert session._should_reset_connector is False
         await session.close()
 
-    @pytest.mark.asyncio
     async def test_close_session(self):
         session = AiohttpSession()
         await session.create_session()
@@ -153,7 +149,6 @@ class TestAiohttpSession:
         assert fields[1][0]["filename"] == "file.txt"
         assert isinstance(fields[1][2], BareInputFile)
 
-    @pytest.mark.asyncio
     async def test_make_request(self, bot: MockedBot, aresponses: ResponsesMockServer):
         aresponses.add(
             aresponses.ANY,
@@ -181,7 +176,6 @@ class TestAiohttpSession:
         assert result == 42
 
     @pytest.mark.parametrize("error", [ClientError("mocked"), asyncio.TimeoutError()])
-    @pytest.mark.asyncio
     async def test_make_request_network_error(self, error):
         bot = Bot("42:TEST")
 
@@ -196,7 +190,6 @@ class TestAiohttpSession:
             with pytest.raises(NetworkError):
                 await bot.get_me()
 
-    @pytest.mark.asyncio
     async def test_stream_content(self, aresponses: ResponsesMockServer):
         aresponses.add(
             aresponses.ANY, aresponses.ANY, "get", aresponses.Response(status=200, body=b"\f" * 10)
@@ -216,7 +209,6 @@ class TestAiohttpSession:
             size += chunk_size
         assert size == 10
 
-    @pytest.mark.asyncio
     async def test_context_manager(self):
         session = AiohttpSession()
         assert isinstance(session, AsyncContextManager)

--- a/tests/test_api/test_client/test_session/test_base_session.py
+++ b/tests/test_api/test_client/test_session/test_base_session.py
@@ -25,6 +25,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 class CustomSession(BaseSession):
     async def close(self):
@@ -195,13 +197,11 @@ class TestBaseSession:
             if error.url:
                 assert error.url in string
 
-    @pytest.mark.asyncio
     async def test_make_request(self):
         session = CustomSession()
 
         assert await session.make_request("42:TEST", GetMe()) is None
 
-    @pytest.mark.asyncio
     async def test_stream_content(self):
         session = CustomSession()
         stream = session.stream_content(
@@ -212,7 +212,6 @@ class TestBaseSession:
         async for chunk in stream:
             assert isinstance(chunk, bytes)
 
-    @pytest.mark.asyncio
     async def test_context_manager(self):
         session = CustomSession()
         assert isinstance(session, AsyncContextManager)
@@ -236,7 +235,6 @@ class TestBaseSession:
         assert my_middleware in session.middlewares
         assert len(session.middlewares) == 1
 
-    @pytest.mark.asyncio
     async def test_use_middleware(self, bot: MockedBot):
         flag_before = False
         flag_after = False

--- a/tests/test_api/test_methods/test_add_sticker_to_set.py
+++ b/tests/test_api/test_methods/test_add_sticker_to_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import AddStickerToSet, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAddStickerToSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AddStickerToSet, ok=True, result=True)
 
@@ -16,7 +17,6 @@ class TestAddStickerToSet:
         assert request.method == "addStickerToSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AddStickerToSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_answer_callback_query.py
+++ b/tests/test_api/test_methods/test_answer_callback_query.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import AnswerCallbackQuery, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAnswerCallbackQuery:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerCallbackQuery, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestAnswerCallbackQuery:
         assert request.method == "answerCallbackQuery"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerCallbackQuery, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_answer_inline_query.py
+++ b/tests/test_api/test_methods/test_answer_inline_query.py
@@ -5,9 +5,10 @@ from aiogram.methods import AnswerInlineQuery, Request
 from aiogram.types import InlineQueryResult, InlineQueryResultPhoto
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAnswerInlineQuery:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerInlineQuery, ok=True, result=True)
 
@@ -18,7 +19,6 @@ class TestAnswerInlineQuery:
         assert request.method == "answerInlineQuery"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerInlineQuery, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_answer_pre_checkout_query.py
+++ b/tests/test_api/test_methods/test_answer_pre_checkout_query.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import AnswerPreCheckoutQuery, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAnswerPreCheckoutQuery:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerPreCheckoutQuery, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestAnswerPreCheckoutQuery:
         assert request.method == "answerPreCheckoutQuery"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerPreCheckoutQuery, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_answer_shipping_query.py
+++ b/tests/test_api/test_methods/test_answer_shipping_query.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import AnswerShippingQuery, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAnswerShippingQuery:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerShippingQuery, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestAnswerShippingQuery:
         assert request.method == "answerShippingQuery"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(AnswerShippingQuery, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_ban_chat_member.py
+++ b/tests/test_api/test_methods/test_ban_chat_member.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import BanChatMember, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestKickChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(BanChatMember, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestKickChatMember:
         assert request.method == "banChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(BanChatMember, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_base.py
+++ b/tests/test_api/test_methods/test_base.py
@@ -6,6 +6,8 @@ from aiogram import Bot
 from aiogram.methods.base import prepare_parse_mode
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestPrepareFile:
     # TODO: Add tests
@@ -34,7 +36,6 @@ class TestPrepareParseMode:
             ["Markdown", {"parse_mode": "HTML"}, "HTML"],
         ],
     )
-    @pytest.mark.asyncio
     async def test_default_parse_mode(
         self, bot: MockedBot, parse_mode: str, data: Dict[str, str], result: Optional[str]
     ):
@@ -43,7 +44,6 @@ class TestPrepareParseMode:
             prepare_parse_mode(bot, data)
             assert data.get("parse_mode") == result
 
-    @pytest.mark.asyncio
     async def test_list(self):
         data = [{}] * 2
         data.append({"parse_mode": "HTML"})

--- a/tests/test_api/test_methods/test_close.py
+++ b/tests/test_api/test_methods/test_close.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Close, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestClose:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(Close, ok=True, result=True)
 
@@ -15,7 +16,6 @@ class TestClose:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(Close, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_copy_message.py
+++ b/tests/test_api/test_methods/test_copy_message.py
@@ -4,9 +4,10 @@ from aiogram.methods import CopyMessage, Request
 from aiogram.types import MessageId
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCopyMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(CopyMessage, ok=True, result=MessageId(message_id=42))
 
@@ -20,7 +21,6 @@ class TestCopyMessage:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(CopyMessage, ok=True, result=MessageId(message_id=42))
 

--- a/tests/test_api/test_methods/test_create_chat_invite_link.py
+++ b/tests/test_api/test_methods/test_create_chat_invite_link.py
@@ -4,9 +4,10 @@ from aiogram.methods import CreateChatInviteLink, Request
 from aiogram.types import ChatInviteLink, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCreateChatInviteLink:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             CreateChatInviteLink,
@@ -27,7 +28,6 @@ class TestCreateChatInviteLink:
         # assert request.data == {"chat_id": -42}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             CreateChatInviteLink,

--- a/tests/test_api/test_methods/test_create_new_sticker_set.py
+++ b/tests/test_api/test_methods/test_create_new_sticker_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import CreateNewStickerSet, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCreateNewStickerSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(CreateNewStickerSet, ok=True, result=True)
 
@@ -16,7 +17,6 @@ class TestCreateNewStickerSet:
         assert request.method == "createNewStickerSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(CreateNewStickerSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_chat_photo.py
+++ b/tests/test_api/test_methods/test_delete_chat_photo.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteChatPhoto, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDeleteChatPhoto:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteChatPhoto, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestDeleteChatPhoto:
         assert request.method == "deleteChatPhoto"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteChatPhoto, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_chat_sticker_set.py
+++ b/tests/test_api/test_methods/test_delete_chat_sticker_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteChatStickerSet, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDeleteChatStickerSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteChatStickerSet, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestDeleteChatStickerSet:
         assert request.method == "deleteChatStickerSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteChatStickerSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_message.py
+++ b/tests/test_api/test_methods/test_delete_message.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteMessage, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDeleteMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteMessage, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestDeleteMessage:
         assert request.method == "deleteMessage"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteMessage, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_my_commands.py
+++ b/tests/test_api/test_methods/test_delete_my_commands.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteMyCommands, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestKickChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteMyCommands, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestKickChatMember:
         assert request.method == "deleteMyCommands"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteMyCommands, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_sticker_from_set.py
+++ b/tests/test_api/test_methods/test_delete_sticker_from_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteStickerFromSet, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDeleteStickerFromSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteStickerFromSet, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestDeleteStickerFromSet:
         assert request.method == "deleteStickerFromSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteStickerFromSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_delete_webhook.py
+++ b/tests/test_api/test_methods/test_delete_webhook.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import DeleteWebhook, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDeleteWebhook:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteWebhook, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestDeleteWebhook:
         assert request.method == "deleteWebhook"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(DeleteWebhook, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_edit_chat_invite_link.py
+++ b/tests/test_api/test_methods/test_edit_chat_invite_link.py
@@ -4,9 +4,10 @@ from aiogram.methods import EditChatInviteLink, Request
 from aiogram.types import ChatInviteLink, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditChatInviteLink:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             EditChatInviteLink,
@@ -27,7 +28,6 @@ class TestEditChatInviteLink:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             EditChatInviteLink,

--- a/tests/test_api/test_methods/test_edit_message_caption.py
+++ b/tests/test_api/test_methods/test_edit_message_caption.py
@@ -7,9 +7,10 @@ from aiogram.methods import EditMessageCaption, Request
 from aiogram.types import Chat, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditMessageCaption:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             EditMessageCaption,
@@ -27,7 +28,6 @@ class TestEditMessageCaption:
         assert request.method == "editMessageCaption"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             EditMessageCaption,

--- a/tests/test_api/test_methods/test_edit_message_live_location.py
+++ b/tests/test_api/test_methods/test_edit_message_live_location.py
@@ -6,9 +6,10 @@ from aiogram.methods import EditMessageLiveLocation, Request
 from aiogram.types import Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditMessageLiveLocation:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageLiveLocation, ok=True, result=True)
 
@@ -19,7 +20,6 @@ class TestEditMessageLiveLocation:
         assert request.method == "editMessageLiveLocation"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageLiveLocation, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_edit_message_media.py
+++ b/tests/test_api/test_methods/test_edit_message_media.py
@@ -6,9 +6,10 @@ from aiogram.methods import EditMessageMedia, Request
 from aiogram.types import BufferedInputFile, InputMediaPhoto, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditMessageMedia:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageMedia, ok=True, result=True)
 
@@ -19,7 +20,6 @@ class TestEditMessageMedia:
         assert request.method == "editMessageMedia"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageMedia, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_edit_message_reply_markup.py
+++ b/tests/test_api/test_methods/test_edit_message_reply_markup.py
@@ -6,9 +6,10 @@ from aiogram.methods import EditMessageReplyMarkup, Request
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditMessageReplyMarkup:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageReplyMarkup, ok=True, result=True)
 
@@ -25,7 +26,6 @@ class TestEditMessageReplyMarkup:
         assert request.method == "editMessageReplyMarkup"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageReplyMarkup, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_edit_message_text.py
+++ b/tests/test_api/test_methods/test_edit_message_text.py
@@ -6,9 +6,10 @@ from aiogram.methods import EditMessageText, Request
 from aiogram.types import Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestEditMessageText:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageText, ok=True, result=True)
 
@@ -19,7 +20,6 @@ class TestEditMessageText:
         assert request.method == "editMessageText"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(EditMessageText, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_export_chat_invite_link.py
+++ b/tests/test_api/test_methods/test_export_chat_invite_link.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import ExportChatInviteLink, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestExportChatInviteLink:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             ExportChatInviteLink, ok=True, result="http://example.com"
@@ -16,7 +17,6 @@ class TestExportChatInviteLink:
         assert request.method == "exportChatInviteLink"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             ExportChatInviteLink, ok=True, result="http://example.com"

--- a/tests/test_api/test_methods/test_forward_message.py
+++ b/tests/test_api/test_methods/test_forward_message.py
@@ -6,9 +6,10 @@ from aiogram.methods import ForwardMessage, Request
 from aiogram.types import Chat, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestForwardMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             ForwardMessage,
@@ -27,7 +28,6 @@ class TestForwardMessage:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             ForwardMessage,

--- a/tests/test_api/test_methods/test_get_chat.py
+++ b/tests/test_api/test_methods/test_get_chat.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetChat, Request
 from aiogram.types import Chat
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetChat:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChat, ok=True, result=Chat(id=-42, type="channel", title="chat")
@@ -17,7 +18,6 @@ class TestGetChat:
         assert request.method == "getChat"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChat, ok=True, result=Chat(id=-42, type="channel", title="chat")

--- a/tests/test_api/test_methods/test_get_chat_administrators.py
+++ b/tests/test_api/test_methods/test_get_chat_administrators.py
@@ -6,9 +6,10 @@ from aiogram.methods import GetChatAdministrators, Request
 from aiogram.types import ChatMember, ChatMemberOwner, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetChatAdministrators:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChatAdministrators,
@@ -25,7 +26,6 @@ class TestGetChatAdministrators:
         assert request.method == "getChatAdministrators"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChatAdministrators,

--- a/tests/test_api/test_methods/test_get_chat_member.py
+++ b/tests/test_api/test_methods/test_get_chat_member.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetChatMember, Request
 from aiogram.types import ChatMember, ChatMemberOwner, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChatMember,
@@ -21,7 +22,6 @@ class TestGetChatMember:
         assert request.method == "getChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetChatMember,

--- a/tests/test_api/test_methods/test_get_chat_member_count.py
+++ b/tests/test_api/test_methods/test_get_chat_member_count.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import GetChatMemberCount, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetChatMembersCount:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetChatMemberCount, ok=True, result=42)
 
@@ -14,7 +15,6 @@ class TestGetChatMembersCount:
         assert request.method == "getChatMemberCount"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetChatMemberCount, ok=True, result=42)
 

--- a/tests/test_api/test_methods/test_get_chat_members_count.py
+++ b/tests/test_api/test_methods/test_get_chat_members_count.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import GetChatMembersCount, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetChatMembersCount:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetChatMembersCount, ok=True, result=42)
 
@@ -14,7 +15,6 @@ class TestGetChatMembersCount:
         assert request.method == "getChatMembersCount"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetChatMembersCount, ok=True, result=42)
 

--- a/tests/test_api/test_methods/test_get_file.py
+++ b/tests/test_api/test_methods/test_get_file.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetFile, Request
 from aiogram.types import File
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetFile:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetFile, ok=True, result=File(file_id="file id", file_unique_id="file id")
@@ -17,7 +18,6 @@ class TestGetFile:
         assert request.method == "getFile"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetFile, ok=True, result=File(file_id="file id", file_unique_id="file id")

--- a/tests/test_api/test_methods/test_get_game_high_scores.py
+++ b/tests/test_api/test_methods/test_get_game_high_scores.py
@@ -6,9 +6,10 @@ from aiogram.methods import GetGameHighScores, Request
 from aiogram.types import GameHighScore, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetGameHighScores:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetGameHighScores,
@@ -25,7 +26,6 @@ class TestGetGameHighScores:
         assert request.method == "getGameHighScores"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetGameHighScores,

--- a/tests/test_api/test_methods/test_get_me.py
+++ b/tests/test_api/test_methods/test_get_me.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetMe, Request
 from aiogram.types import User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetMe:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetMe, ok=True, result=User(id=42, is_bot=False, first_name="User")
@@ -18,7 +19,6 @@ class TestGetMe:
         assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetMe, ok=True, result=User(id=42, is_bot=False, first_name="User")
@@ -29,7 +29,6 @@ class TestGetMe:
         assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_me_property(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetMe, ok=True, result=User(id=42, is_bot=False, first_name="User")

--- a/tests/test_api/test_methods/test_get_my_commands.py
+++ b/tests/test_api/test_methods/test_get_my_commands.py
@@ -6,9 +6,10 @@ from aiogram.methods import GetMyCommands, Request
 from aiogram.types import BotCommand
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetMyCommands:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetMyCommands, ok=True, result=None)
 
@@ -17,7 +18,6 @@ class TestGetMyCommands:
         assert request.method == "getMyCommands"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetMyCommands, ok=True, result=None)
 

--- a/tests/test_api/test_methods/test_get_sticker_set.py
+++ b/tests/test_api/test_methods/test_get_sticker_set.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetStickerSet, Request
 from aiogram.types import Sticker, StickerSet
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetStickerSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetStickerSet,
@@ -33,7 +34,6 @@ class TestGetStickerSet:
         assert request.method == "getStickerSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetStickerSet,

--- a/tests/test_api/test_methods/test_get_updates.py
+++ b/tests/test_api/test_methods/test_get_updates.py
@@ -6,9 +6,10 @@ from aiogram.methods import GetUpdates, Request
 from aiogram.types import Update
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetUpdates:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetUpdates, ok=True, result=[Update(update_id=42)])
 
@@ -17,7 +18,6 @@ class TestGetUpdates:
         assert request.method == "getUpdates"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(GetUpdates, ok=True, result=[Update(update_id=42)])
 

--- a/tests/test_api/test_methods/test_get_user_profile_photos.py
+++ b/tests/test_api/test_methods/test_get_user_profile_photos.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetUserProfilePhotos, Request
 from aiogram.types import PhotoSize, UserProfilePhotos
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetUserProfilePhotos:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetUserProfilePhotos,
@@ -24,7 +25,6 @@ class TestGetUserProfilePhotos:
         assert request.method == "getUserProfilePhotos"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetUserProfilePhotos,

--- a/tests/test_api/test_methods/test_get_webhook_info.py
+++ b/tests/test_api/test_methods/test_get_webhook_info.py
@@ -4,9 +4,10 @@ from aiogram.methods import GetWebhookInfo, Request
 from aiogram.types import WebhookInfo
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestGetWebhookInfo:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetWebhookInfo,
@@ -21,7 +22,6 @@ class TestGetWebhookInfo:
         assert request.method == "getWebhookInfo"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetWebhookInfo,

--- a/tests/test_api/test_methods/test_kick_chat_member.py
+++ b/tests/test_api/test_methods/test_kick_chat_member.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import KickChatMember, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestKickChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(KickChatMember, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestKickChatMember:
         assert request.method == "kickChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(KickChatMember, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_leave_chat.py
+++ b/tests/test_api/test_methods/test_leave_chat.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import LeaveChat, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestLeaveChat:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(LeaveChat, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestLeaveChat:
         assert request.method == "leaveChat"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(LeaveChat, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_log_out.py
+++ b/tests/test_api/test_methods/test_log_out.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import LogOut, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestLogOut:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(LogOut, ok=True, result=True)
 
@@ -15,7 +16,6 @@ class TestLogOut:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(LogOut, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_pin_chat_message.py
+++ b/tests/test_api/test_methods/test_pin_chat_message.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import PinChatMessage, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestPinChatMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(PinChatMessage, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestPinChatMessage:
         assert request.method == "pinChatMessage"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(PinChatMessage, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_promote_chat_member.py
+++ b/tests/test_api/test_methods/test_promote_chat_member.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import PromoteChatMember, Request
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestPromoteChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(PromoteChatMember, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestPromoteChatMember:
         assert request.method == "promoteChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(PromoteChatMember, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_restrict_chat_member.py
+++ b/tests/test_api/test_methods/test_restrict_chat_member.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, RestrictChatMember
 from aiogram.types import ChatPermissions
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestRestrictChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(RestrictChatMember, ok=True, result=True)
 
@@ -17,7 +18,6 @@ class TestRestrictChatMember:
         assert request.method == "restrictChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(RestrictChatMember, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_revoke_chat_invite_link.py
+++ b/tests/test_api/test_methods/test_revoke_chat_invite_link.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, RevokeChatInviteLink
 from aiogram.types import ChatInviteLink, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestRevokeChatInviteLink:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             RevokeChatInviteLink,
@@ -28,7 +29,6 @@ class TestRevokeChatInviteLink:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             RevokeChatInviteLink,

--- a/tests/test_api/test_methods/test_send_animation.py
+++ b/tests/test_api/test_methods/test_send_animation.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendAnimation
 from aiogram.types import Animation, Chat, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendAnimation:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendAnimation,
@@ -28,7 +29,6 @@ class TestSendAnimation:
         assert request.method == "sendAnimation"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendAnimation,

--- a/tests/test_api/test_methods/test_send_audio.py
+++ b/tests/test_api/test_methods/test_send_audio.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendAudio
 from aiogram.types import Audio, Chat, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendAudio:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendAudio,
@@ -26,7 +27,6 @@ class TestSendAudio:
         assert request.method == "sendAudio"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendAudio,

--- a/tests/test_api/test_methods/test_send_chat_action.py
+++ b/tests/test_api/test_methods/test_send_chat_action.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SendChatAction
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendChatAction:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SendChatAction, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSendChatAction:
         assert request.method == "sendChatAction"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SendChatAction, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_send_contact.py
+++ b/tests/test_api/test_methods/test_send_contact.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendContact
 from aiogram.types import Chat, Contact, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendContact:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendContact,
@@ -26,7 +27,6 @@ class TestSendContact:
         assert request.method == "sendContact"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendContact,

--- a/tests/test_api/test_methods/test_send_dice.py
+++ b/tests/test_api/test_methods/test_send_dice.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, SendDice
 from aiogram.types import Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendDice:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SendDice, ok=True, result=None)
 
@@ -15,7 +16,6 @@ class TestSendDice:
         assert request.method == "sendDice"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SendDice, ok=True, result=None)
 

--- a/tests/test_api/test_methods/test_send_document.py
+++ b/tests/test_api/test_methods/test_send_document.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendDocument
 from aiogram.types import Chat, Document, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendDocument:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendDocument,
@@ -26,7 +27,6 @@ class TestSendDocument:
         assert request.method == "sendDocument"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendDocument,

--- a/tests/test_api/test_methods/test_send_game.py
+++ b/tests/test_api/test_methods/test_send_game.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendGame
 from aiogram.types import Chat, Game, Message, PhotoSize
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendGame:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendGame,
@@ -32,7 +33,6 @@ class TestSendGame:
         assert request.method == "sendGame"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendGame,

--- a/tests/test_api/test_methods/test_send_invoice.py
+++ b/tests/test_api/test_methods/test_send_invoice.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendInvoice
 from aiogram.types import Chat, Invoice, LabeledPrice, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendInvoice:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendInvoice,
@@ -41,7 +42,6 @@ class TestSendInvoice:
         assert request.method == "sendInvoice"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendInvoice,

--- a/tests/test_api/test_methods/test_send_location.py
+++ b/tests/test_api/test_methods/test_send_location.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendLocation
 from aiogram.types import Chat, Location, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendLocation:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendLocation,
@@ -26,7 +27,6 @@ class TestSendLocation:
         assert request.method == "sendLocation"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendLocation,

--- a/tests/test_api/test_methods/test_send_media_group.py
+++ b/tests/test_api/test_methods/test_send_media_group.py
@@ -15,9 +15,10 @@ from aiogram.types import (
 )
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendMediaGroup:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendMediaGroup,
@@ -59,7 +60,6 @@ class TestSendMediaGroup:
         assert request.method == "sendMediaGroup"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendMediaGroup,

--- a/tests/test_api/test_methods/test_send_message.py
+++ b/tests/test_api/test_methods/test_send_message.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendMessage
 from aiogram.types import Chat, Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendMessage,
@@ -26,7 +27,6 @@ class TestSendMessage:
         assert request.method == "sendMessage"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendMessage,

--- a/tests/test_api/test_methods/test_send_photo.py
+++ b/tests/test_api/test_methods/test_send_photo.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendPhoto
 from aiogram.types import Chat, Message, PhotoSize
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendPhoto:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendPhoto,
@@ -28,7 +29,6 @@ class TestSendPhoto:
         assert request.method == "sendPhoto"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendPhoto,

--- a/tests/test_api/test_methods/test_send_poll.py
+++ b/tests/test_api/test_methods/test_send_poll.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendPoll
 from aiogram.types import Chat, Message, Poll, PollOption
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendPoll:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendPoll,
@@ -41,7 +42,6 @@ class TestSendPoll:
         assert request.method == "sendPoll"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendPoll,

--- a/tests/test_api/test_methods/test_send_sticker.py
+++ b/tests/test_api/test_methods/test_send_sticker.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendSticker
 from aiogram.types import Chat, Message, Sticker
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendSticker:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendSticker,
@@ -32,7 +33,6 @@ class TestSendSticker:
         assert request.method == "sendSticker"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendSticker,

--- a/tests/test_api/test_methods/test_send_venue.py
+++ b/tests/test_api/test_methods/test_send_venue.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendVenue
 from aiogram.types import Chat, Location, Message, Venue
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendVenue:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVenue,
@@ -38,7 +39,6 @@ class TestSendVenue:
         assert request.method == "sendVenue"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVenue,

--- a/tests/test_api/test_methods/test_send_video.py
+++ b/tests/test_api/test_methods/test_send_video.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendVideo
 from aiogram.types import Chat, Message, Video
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendVideo:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVideo,
@@ -28,7 +29,6 @@ class TestSendVideo:
         assert request.method == "sendVideo"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVideo,

--- a/tests/test_api/test_methods/test_send_video_note.py
+++ b/tests/test_api/test_methods/test_send_video_note.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendVideoNote
 from aiogram.types import BufferedInputFile, Chat, Message, VideoNote
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendVideoNote:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVideoNote,
@@ -30,7 +31,6 @@ class TestSendVideoNote:
         assert request.method == "sendVideoNote"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVideoNote,

--- a/tests/test_api/test_methods/test_send_voice.py
+++ b/tests/test_api/test_methods/test_send_voice.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SendVoice
 from aiogram.types import Chat, Message, Voice
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSendVoice:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVoice,
@@ -26,7 +27,6 @@ class TestSendVoice:
         assert request.method == "sendVoice"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             SendVoice,

--- a/tests/test_api/test_methods/test_set_chat_administrator_custom_title.py
+++ b/tests/test_api/test_methods/test_set_chat_administrator_custom_title.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetChatAdministratorCustomTitle
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatTitle:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatAdministratorCustomTitle, ok=True, result=True)
 
@@ -16,7 +17,6 @@ class TestSetChatTitle:
         assert request.method == "setChatAdministratorCustomTitle"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatAdministratorCustomTitle, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_chat_description.py
+++ b/tests/test_api/test_methods/test_set_chat_description.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetChatDescription
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatDescription:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatDescription, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSetChatDescription:
         assert request.method == "setChatDescription"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatDescription, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_chat_permissions.py
+++ b/tests/test_api/test_methods/test_set_chat_permissions.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, SetChatPermissions
 from aiogram.types import ChatPermissions
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatPermissions:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatPermissions, ok=True, result=True)
 
@@ -17,7 +18,6 @@ class TestSetChatPermissions:
         assert request.method == "setChatPermissions"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatPermissions, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_chat_photo.py
+++ b/tests/test_api/test_methods/test_set_chat_photo.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, SetChatPhoto
 from aiogram.types import BufferedInputFile
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatPhoto:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatPhoto, ok=True, result=True)
 
@@ -17,7 +18,6 @@ class TestSetChatPhoto:
         assert request.method == "setChatPhoto"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatPhoto, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_chat_sticker_set.py
+++ b/tests/test_api/test_methods/test_set_chat_sticker_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetChatStickerSet
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatStickerSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatStickerSet, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSetChatStickerSet:
         assert request.method == "setChatStickerSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatStickerSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_chat_title.py
+++ b/tests/test_api/test_methods/test_set_chat_title.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetChatTitle
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetChatTitle:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatTitle, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSetChatTitle:
         assert request.method == "setChatTitle"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetChatTitle, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_game_score.py
+++ b/tests/test_api/test_methods/test_set_game_score.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, SetGameScore
 from aiogram.types import Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetGameScore:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetGameScore, ok=True, result=True)
 
@@ -19,7 +20,6 @@ class TestSetGameScore:
         assert request.method == "setGameScore"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetGameScore, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_my_commands.py
+++ b/tests/test_api/test_methods/test_set_my_commands.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, SetMyCommands
 from aiogram.types import BotCommand
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetMyCommands:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetMyCommands, ok=True, result=None)
 
@@ -17,7 +18,6 @@ class TestSetMyCommands:
         assert request.method == "setMyCommands"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetMyCommands, ok=True, result=None)
 

--- a/tests/test_api/test_methods/test_set_passport_data_errors.py
+++ b/tests/test_api/test_methods/test_set_passport_data_errors.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, SetPassportDataErrors
 from aiogram.types import PassportElementError
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetPassportDataErrors:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetPassportDataErrors, ok=True, result=True)
 
@@ -15,7 +16,6 @@ class TestSetPassportDataErrors:
         assert request.method == "setPassportDataErrors"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetPassportDataErrors, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_sticker_position_in_set.py
+++ b/tests/test_api/test_methods/test_set_sticker_position_in_set.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetStickerPositionInSet
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetStickerPositionInSet:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetStickerPositionInSet, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSetStickerPositionInSet:
         assert request.method == "setStickerPositionInSet"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetStickerPositionInSet, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_set_sticker_set_thumb.py
+++ b/tests/test_api/test_methods/test_set_sticker_set_thumb.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetStickerSetThumb
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetStickerSetThumb:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetStickerSetThumb, ok=True, result=None)
 
@@ -15,7 +16,6 @@ class TestSetStickerSetThumb:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetStickerSetThumb, ok=True, result=None)
 

--- a/tests/test_api/test_methods/test_set_webhook.py
+++ b/tests/test_api/test_methods/test_set_webhook.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, SetWebhook
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestSetWebhook:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetWebhook, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestSetWebhook:
         assert request.method == "setWebhook"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetWebhook, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_stop_message_live_location.py
+++ b/tests/test_api/test_methods/test_stop_message_live_location.py
@@ -6,9 +6,10 @@ from aiogram.methods import Request, StopMessageLiveLocation
 from aiogram.types import Message
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestStopMessageLiveLocation:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(StopMessageLiveLocation, ok=True, result=True)
 
@@ -19,7 +20,6 @@ class TestStopMessageLiveLocation:
         assert request.method == "stopMessageLiveLocation"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(StopMessageLiveLocation, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_stop_poll.py
+++ b/tests/test_api/test_methods/test_stop_poll.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, StopPoll
 from aiogram.types import Poll, PollOption
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestStopPoll:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             StopPoll,
@@ -29,7 +30,6 @@ class TestStopPoll:
         assert request.method == "stopPoll"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             StopPoll,

--- a/tests/test_api/test_methods/test_unban_chat_member.py
+++ b/tests/test_api/test_methods/test_unban_chat_member.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, UnbanChatMember
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestUnbanChatMember:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnbanChatMember, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestUnbanChatMember:
         assert request.method == "unbanChatMember"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnbanChatMember, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_unpin_all_chat_messages.py
+++ b/tests/test_api/test_methods/test_unpin_all_chat_messages.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, UnpinAllChatMessages
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestUnpinAllChatMessages:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnpinAllChatMessages, ok=True, result=True)
 
@@ -17,7 +18,6 @@ class TestUnpinAllChatMessages:
         # assert request.data == {}
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnpinAllChatMessages, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_unpin_chat_message.py
+++ b/tests/test_api/test_methods/test_unpin_chat_message.py
@@ -3,9 +3,10 @@ import pytest
 from aiogram.methods import Request, UnpinChatMessage
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestUnpinChatMessage:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnpinChatMessage, ok=True, result=True)
 
@@ -14,7 +15,6 @@ class TestUnpinChatMessage:
         assert request.method == "unpinChatMessage"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(UnpinChatMessage, ok=True, result=True)
 

--- a/tests/test_api/test_methods/test_upload_sticker_file.py
+++ b/tests/test_api/test_methods/test_upload_sticker_file.py
@@ -4,9 +4,10 @@ from aiogram.methods import Request, UploadStickerFile
 from aiogram.types import BufferedInputFile, File
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestUploadStickerFile:
-    @pytest.mark.asyncio
     async def test_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             UploadStickerFile, ok=True, result=File(file_id="file id", file_unique_id="file id")
@@ -19,7 +20,6 @@ class TestUploadStickerFile:
         assert request.method == "uploadStickerFile"
         assert response == prepare_result.result
 
-    @pytest.mark.asyncio
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             UploadStickerFile, ok=True, result=File(file_id="file id", file_unique_id="file id")

--- a/tests/test_api/test_types/test_input_file.py
+++ b/tests/test_api/test_types/test_input_file.py
@@ -6,6 +6,8 @@ from aresponses import ResponsesMockServer
 from aiogram import Bot
 from aiogram.types import BufferedInputFile, FSInputFile, InputFile, URLInputFile
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestInputFile:
     def test_fs_input_file(self):
@@ -18,7 +20,6 @@ class TestInputFile:
         assert file.filename.endswith(".py")
         assert file.chunk_size > 0
 
-    @pytest.mark.asyncio
     async def test_fs_input_file_readable(self):
         file = FSInputFile(__file__, chunk_size=1)
 
@@ -39,7 +40,6 @@ class TestInputFile:
         assert file.filename == "file.bin"
         assert isinstance(file.data, bytes)
 
-    @pytest.mark.asyncio
     async def test_buffered_input_file_readable(self):
         file = BufferedInputFile(b"\f" * 10, filename="file.bin", chunk_size=1)
 
@@ -50,7 +50,6 @@ class TestInputFile:
             size += chunk_size
         assert size == 10
 
-    @pytest.mark.asyncio
     async def test_buffered_input_file_from_file(self):
         file = BufferedInputFile.from_file(__file__, chunk_size=10)
 
@@ -62,7 +61,6 @@ class TestInputFile:
         assert isinstance(file.data, bytes)
         assert file.chunk_size == 10
 
-    @pytest.mark.asyncio
     async def test_buffered_input_file_from_file_readable(self):
         file = BufferedInputFile.from_file(__file__, chunk_size=1)
 
@@ -73,7 +71,6 @@ class TestInputFile:
             size += chunk_size
         assert size > 0
 
-    @pytest.mark.asyncio
     async def test_uri_input_file(self, aresponses: ResponsesMockServer):
         aresponses.add(
             aresponses.ANY, aresponses.ANY, "get", aresponses.Response(status=200, body=b"\f" * 10)

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -38,6 +38,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 async def simple_message_handler(message: Message):
     await asyncio.sleep(0.2)
@@ -82,7 +84,6 @@ class TestDispatcher:
         dp._parent_router = Router()
         assert dp.parent_router is None
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("isolate_events", (True, False))
     async def test_feed_update(self, isolate_events):
         dp = Dispatcher(isolate_events=isolate_events)
@@ -112,7 +113,6 @@ class TestDispatcher:
         results_count += 1
         assert result == "test"
 
-    @pytest.mark.asyncio
     async def test_feed_raw_update(self):
         dp = Dispatcher()
         bot = Bot("42:TEST")
@@ -137,7 +137,6 @@ class TestDispatcher:
         )
         assert result == "test"
 
-    @pytest.mark.asyncio
     async def test_listen_updates(self, bot: MockedBot):
         dispatcher = Dispatcher()
         bot.add_result_for(
@@ -151,7 +150,6 @@ class TestDispatcher:
                 break
         assert index == 42
 
-    @pytest.mark.asyncio
     async def test_listen_update_with_error(self, bot: MockedBot):
         dispatcher = Dispatcher()
         listen = dispatcher._listen_updates(bot=bot)
@@ -166,7 +164,6 @@ class TestDispatcher:
             assert isinstance(await anext(listen), Update)
             assert mocked_asleep.awaited
 
-    @pytest.mark.asyncio
     async def test_silent_call_request(self, bot: MockedBot, caplog):
         dispatcher = Dispatcher()
         bot.add_result_for(SendMessage, ok=False, error_code=400, description="Kaboom")
@@ -175,14 +172,12 @@ class TestDispatcher:
         assert len(log_records) == 1
         assert "Failed to make answer" in log_records[0]
 
-    @pytest.mark.asyncio
     async def test_process_update_empty(self, bot: MockedBot):
         dispatcher = Dispatcher()
 
         result = await dispatcher._process_update(bot=bot, update=Update(update_id=42))
         assert not result
 
-    @pytest.mark.asyncio
     async def test_process_update_handled(self, bot: MockedBot):
         dispatcher = Dispatcher()
 
@@ -192,7 +187,6 @@ class TestDispatcher:
 
         assert await dispatcher._process_update(bot=bot, update=Update(update_id=42))
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "event_type,update,has_chat,has_user",
         [
@@ -448,14 +442,12 @@ class TestDispatcher:
         assert result["event_router"] == router
         assert result["test"] == "PASS"
 
-    @pytest.mark.asyncio
     async def test_listen_unknown_update(self):
         dp = Dispatcher()
 
         with pytest.raises(SkipHandler):
             await dp._listen_update(Update(update_id=42))
 
-    @pytest.mark.asyncio
     async def test_listen_unhandled_update(self):
         dp = Dispatcher()
         observer = dp.observers["message"]
@@ -485,7 +477,6 @@ class TestDispatcher:
         )
         assert response is UNHANDLED
 
-    @pytest.mark.asyncio
     async def test_nested_router_listen_update(self):
         dp = Dispatcher()
         router0 = Router()
@@ -514,7 +505,6 @@ class TestDispatcher:
         assert result["event_router"] == router1
         assert result["test"] == "PASS"
 
-    @pytest.mark.asyncio
     async def test_nested_router_middleware_resolution(self, bot: MockedBot):
         counter = Counter()
 
@@ -558,7 +548,6 @@ class TestDispatcher:
         assert counter["child.middleware"] == 1
         assert counter["child.handler"] == 1
 
-    @pytest.mark.asyncio
     async def test_process_update_call_request(self, bot: MockedBot):
         dispatcher = Dispatcher()
 
@@ -576,7 +565,6 @@ class TestDispatcher:
             print(result)
             mocked_silent_call_request.assert_awaited()
 
-    @pytest.mark.asyncio
     async def test_process_update_exception(self, bot: MockedBot, caplog):
         dispatcher = Dispatcher()
 
@@ -590,7 +578,6 @@ class TestDispatcher:
         assert "Cause exception while process update" in log_records[0]
 
     @pytest.mark.parametrize("as_task", [True, False])
-    @pytest.mark.asyncio
     async def test_polling(self, bot: MockedBot, as_task: bool):
         dispatcher = Dispatcher()
 
@@ -609,7 +596,6 @@ class TestDispatcher:
             else:
                 mocked_process_update.assert_awaited()
 
-    @pytest.mark.asyncio
     async def test_exception_handler_catch_exceptions(self):
         dp = Dispatcher()
         router = Router()
@@ -651,7 +637,6 @@ class TestDispatcher:
         assert isinstance(response, CustomException)
         assert str(response) == "KABOOM"
 
-    @pytest.mark.asyncio
     async def test_start_polling(self, bot: MockedBot):
         dispatcher = Dispatcher()
         bot.add_result_for(
@@ -685,7 +670,6 @@ class TestDispatcher:
             dispatcher.run_polling(bot)
             patched_start_polling.assert_awaited_once()
 
-    @pytest.mark.asyncio
     async def test_feed_webhook_update_fast_process(self, bot: MockedBot):
         dispatcher = Dispatcher()
         dispatcher.message.register(simple_message_handler)
@@ -695,7 +679,6 @@ class TestDispatcher:
         assert response["method"] == "sendMessage"
         assert response["text"] == "ok"
 
-    @pytest.mark.asyncio
     async def test_feed_webhook_update_slow_process(self, bot: MockedBot, recwarn):
         warnings.simplefilter("always")
 
@@ -711,7 +694,6 @@ class TestDispatcher:
             await asyncio.sleep(0.5)
             mocked_silent_call_request.assert_awaited()
 
-    @pytest.mark.asyncio
     async def test_feed_webhook_update_fast_process_error(self, bot: MockedBot, caplog):
         warnings.simplefilter("always")
 

--- a/tests/test_dispatcher/test_event/test_event.py
+++ b/tests/test_dispatcher/test_event/test_event.py
@@ -12,6 +12,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 async def my_handler(value: str, index: int = 0) -> Any:
     return value
@@ -39,7 +41,6 @@ class TestEventObserver:
             assert registered_handler.callback == wrapped_handler
             assert not registered_handler.filters
 
-    @pytest.mark.asyncio
     async def test_trigger(self):
         observer = EventObserver()
 

--- a/tests/test_dispatcher/test_event/test_handler.py
+++ b/tests/test_dispatcher/test_event/test_handler.py
@@ -9,6 +9,8 @@ from aiogram.dispatcher.filters.base import BaseFilter
 from aiogram.dispatcher.handler.base import BaseHandler
 from aiogram.types import Update
 
+pytestmark = pytest.mark.asyncio
+
 
 def callback1(foo: int, bar: int, baz: int):
     return locals()
@@ -126,14 +128,12 @@ class TestCallableMixin:
         obj = CallableMixin(callback)
         assert obj._prepare_kwargs(kwargs) == result
 
-    @pytest.mark.asyncio
     async def test_sync_call(self):
         obj = CallableMixin(callback1)
 
         result = await obj.call(foo=42, bar="test", baz="fuz", spam=True)
         assert result == {"foo": 42, "bar": "test", "baz": "fuz"}
 
-    @pytest.mark.asyncio
     async def test_async_call(self):
         obj = CallableMixin(callback2)
 
@@ -154,14 +154,12 @@ async def simple_handler(*args, **kwargs):
 
 
 class TestHandlerObject:
-    @pytest.mark.asyncio
     async def test_check_with_bool_result(self):
         handler = HandlerObject(simple_handler, [FilterObject(lambda value: True)] * 3)
         result, data = await handler.check(42, foo=True)
         assert result
         assert data == {"foo": True}
 
-    @pytest.mark.asyncio
     async def test_check_with_dict_result(self):
         handler = HandlerObject(
             simple_handler,
@@ -176,7 +174,6 @@ class TestHandlerObject:
         assert result
         assert data == {"foo": True, "test0": "ok", "test1": "ok", "test2": "ok"}
 
-    @pytest.mark.asyncio
     async def test_check_with_combined_result(self):
         handler = HandlerObject(
             simple_handler,
@@ -186,13 +183,11 @@ class TestHandlerObject:
         assert result
         assert data == {"foo": True, "test": 42}
 
-    @pytest.mark.asyncio
     async def test_check_rejected(self):
         handler = HandlerObject(simple_handler, [FilterObject(lambda value: False)])
         result, data = await handler.check(42, foo=True)
         assert not result
 
-    @pytest.mark.asyncio
     async def test_check_partial_rejected(self):
         handler = HandlerObject(
             simple_handler, [FilterObject(lambda value: True), FilterObject(lambda value: False)]
@@ -200,7 +195,6 @@ class TestHandlerObject:
         result, data = await handler.check(42, foo=True)
         assert not result
 
-    @pytest.mark.asyncio
     async def test_class_based_handler(self):
         class MyHandler(BaseHandler):
             event: Update

--- a/tests/test_dispatcher/test_event/test_telegram.py
+++ b/tests/test_dispatcher/test_event/test_telegram.py
@@ -11,6 +11,9 @@ from aiogram.dispatcher.filters.base import BaseFilter
 from aiogram.dispatcher.router import Router
 from aiogram.types import Chat, Message, User
 
+pytestmark = pytest.mark.asyncio
+
+
 # TODO: Test middlewares in routers tree
 
 
@@ -138,7 +141,6 @@ class TestTelegramEventObserver:
         assert len(observer.handlers) == 1
         assert observer.handlers[0].callback == my_handler
 
-    @pytest.mark.asyncio
     async def test_trigger(self):
         router = Router(use_builtin_filters=False)
         observer = router.message
@@ -178,7 +180,6 @@ class TestTelegramEventObserver:
             assert registered_handler.callback == wrapped_handler
             assert len(registered_handler.filters) == len(filters)
 
-    @pytest.mark.asyncio
     async def test_trigger_right_context_in_handlers(self):
         router = Router(use_builtin_filters=False)
         observer = router.message
@@ -250,7 +251,6 @@ class TestTelegramEventObserver:
         assert len(router.message._handler.filters) == 1
         assert router.message._handler.filters[0].callback is my_filter
 
-    @pytest.mark.asyncio
     async def test_global_filter(self):
         r1 = Router()
         r2 = Router()
@@ -265,7 +265,6 @@ class TestTelegramEventObserver:
         assert await r1.message.trigger(None) is REJECTED
         assert await r2.message.trigger(None) is None
 
-    @pytest.mark.asyncio
     async def test_global_filter_in_nested_router(self):
         r1 = Router()
         r2 = Router()

--- a/tests/test_dispatcher/test_filters/test_base.py
+++ b/tests/test_dispatcher/test_filters/test_base.py
@@ -10,6 +10,8 @@ except ImportError:
     from unittest.mock import AsyncMock as CoroutineMock  # type: ignore
     from unittest.mock import patch
 
+pytestmark = pytest.mark.asyncio
+
 
 class MyFilter(BaseFilter):
     foo: str
@@ -19,7 +21,6 @@ class MyFilter(BaseFilter):
 
 
 class TestBaseFilter:
-    @pytest.mark.asyncio
     async def test_awaitable(self):
         my_filter = MyFilter(foo="bar")
 

--- a/tests/test_dispatcher/test_filters/test_callback_data.py
+++ b/tests/test_dispatcher/test_filters/test_callback_data.py
@@ -12,6 +12,8 @@ from aiogram import F
 from aiogram.dispatcher.filters.callback_data import CallbackData
 from aiogram.types import CallbackQuery, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class MyIntEnum(Enum):
     FOO = auto()
@@ -163,7 +165,6 @@ class TestCallbackDataFilter:
             ["test:test:", None, False],
         ],
     )
-    @pytest.mark.asyncio
     async def test_call(self, query, rule, result):
         callback_query = CallbackQuery(
             id="1",
@@ -175,7 +176,6 @@ class TestCallbackDataFilter:
         filter_object = MyCallback.filter(rule)
         assert await filter_object(callback_query) == result
 
-    @pytest.mark.asyncio
     async def test_invalid_call(self):
         filter_object = MyCallback.filter(F.test)
         assert not await filter_object(User(id=42, is_bot=False, first_name="test"))

--- a/tests/test_dispatcher/test_filters/test_command.py
+++ b/tests/test_dispatcher/test_filters/test_command.py
@@ -10,6 +10,8 @@ from aiogram.methods import GetMe
 from aiogram.types import Chat, Message, User
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCommandFilter:
     def test_convert_to_list(self):
@@ -52,7 +54,6 @@ class TestCommandFilter:
             ["/start dGVzdA", CommandStart(deep_link=True, deep_link_encoded=True), True],
         ],
     )
-    @pytest.mark.asyncio
     async def test_parse_command(self, bot: MockedBot, text: str, result: bool, command: Command):
         # TODO: test ignore case
         # TODO: test ignore mention
@@ -68,7 +69,6 @@ class TestCommandFilter:
         response = await command(message, bot)
         assert bool(response) is result
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "message,result",
         [

--- a/tests/test_dispatcher/test_filters/test_content_types.py
+++ b/tests/test_dispatcher/test_filters/test_content_types.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 from aiogram.dispatcher.filters import ContentTypesFilter
 from aiogram.types import ContentType, Message
 
+pytestmark = pytest.mark.asyncio
+
 
 @dataclass
 class MinimalMessage:
@@ -14,7 +16,6 @@ class MinimalMessage:
 
 
 class TestContentTypesFilter:
-    @pytest.mark.asyncio
     async def test_validator_empty(self):
         filter_ = ContentTypesFilter()
         assert not filter_.content_types
@@ -53,7 +54,6 @@ class TestContentTypesFilter:
             [[ContentType.ANY, ContentType.PHOTO, ContentType.DOCUMENT], ContentType.TEXT, True],
         ],
     )
-    @pytest.mark.asyncio
     async def test_call(self, values, content_type, result):
         filter_ = ContentTypesFilter(content_types=values)
         assert await filter_(cast(Message, MinimalMessage(content_type=content_type))) == result

--- a/tests/test_dispatcher/test_filters/test_exception.py
+++ b/tests/test_dispatcher/test_filters/test_exception.py
@@ -4,6 +4,8 @@ import pytest
 
 from aiogram.dispatcher.filters import ExceptionMessageFilter, ExceptionTypeFilter
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestExceptionMessageFilter:
     @pytest.mark.parametrize("value", ["value", re.compile("value")])
@@ -11,7 +13,6 @@ class TestExceptionMessageFilter:
         obj = ExceptionMessageFilter(pattern=value)
         assert isinstance(obj.pattern, re.Pattern)
 
-    @pytest.mark.asyncio
     async def test_match(self):
         obj = ExceptionMessageFilter(pattern="KABOOM")
 
@@ -32,7 +33,6 @@ class MyAnotherException(MyException):
 
 
 class TestExceptionTypeFilter:
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "exception,value",
         [

--- a/tests/test_dispatcher/test_filters/test_text.py
+++ b/tests/test_dispatcher/test_filters/test_text.py
@@ -9,6 +9,8 @@ from aiogram.dispatcher.filters import BUILTIN_FILTERS
 from aiogram.dispatcher.filters.text import Text
 from aiogram.types import CallbackQuery, Chat, InlineQuery, Message, Poll, PollOption, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestText:
     def test_default_for_observer(self):
@@ -240,7 +242,6 @@ class TestText:
             ["text", True, ["question", "another question"], object(), False],
         ],
     )
-    @pytest.mark.asyncio
     async def test_check_text(self, argument, ignore_case, input_value, result, update_type):
         text = Text(**{argument: input_value}, text_ignore_case=ignore_case)
         assert await text(obj=update_type) is result

--- a/tests/test_dispatcher/test_fsm/storage/test_redis.py
+++ b/tests/test_dispatcher/test_fsm/storage/test_redis.py
@@ -3,6 +3,8 @@ import pytest
 from aiogram.dispatcher.fsm.storage.redis import RedisStorage
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.mark.redis
 class TestRedisStorage:
@@ -15,7 +17,6 @@ class TestRedisStorage:
             [lambda bot: "kaboom", "fsm:kaboom:-1:2"],
         ],
     )
-    @pytest.mark.asyncio
     async def test_generate_key(self, bot: MockedBot, redis_server, prefix_bot, result):
         storage = RedisStorage.from_url(redis_server, prefix_bot=prefix_bot)
         assert storage.generate_key(bot, -1, 2) == result

--- a/tests/test_dispatcher/test_fsm/storage/test_storages.py
+++ b/tests/test_dispatcher/test_fsm/storage/test_storages.py
@@ -3,19 +3,19 @@ import pytest
 from aiogram.dispatcher.fsm.storage.base import BaseStorage
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.mark.parametrize(
     "storage",
     [pytest.lazy_fixture("redis_storage"), pytest.lazy_fixture("memory_storage")],
 )
 class TestStorages:
-    @pytest.mark.asyncio
     async def test_lock(self, bot: MockedBot, storage: BaseStorage):
         # TODO: ?!?
         async with storage.lock(bot=bot, chat_id=-42, user_id=42):
             assert True, "You are kidding me?"
 
-    @pytest.mark.asyncio
     async def test_set_state(self, bot: MockedBot, storage: BaseStorage):
         assert await storage.get_state(bot=bot, chat_id=-42, user_id=42) is None
 
@@ -24,7 +24,6 @@ class TestStorages:
         await storage.set_state(bot=bot, chat_id=-42, user_id=42, state=None)
         assert await storage.get_state(bot=bot, chat_id=-42, user_id=42) is None
 
-    @pytest.mark.asyncio
     async def test_set_data(self, bot: MockedBot, storage: BaseStorage):
         assert await storage.get_data(bot=bot, chat_id=-42, user_id=42) == {}
 
@@ -33,7 +32,6 @@ class TestStorages:
         await storage.set_data(bot=bot, chat_id=-42, user_id=42, data={})
         assert await storage.get_data(bot=bot, chat_id=-42, user_id=42) == {}
 
-    @pytest.mark.asyncio
     async def test_update_data(self, bot: MockedBot, storage: BaseStorage):
         assert await storage.get_data(bot=bot, chat_id=-42, user_id=42) == {}
         assert await storage.update_data(

--- a/tests/test_dispatcher/test_fsm/test_context.py
+++ b/tests/test_dispatcher/test_fsm/test_context.py
@@ -4,6 +4,8 @@ from aiogram.dispatcher.fsm.context import FSMContext
 from aiogram.dispatcher.fsm.storage.memory import MemoryStorage
 from tests.mocked_bot import MockedBot
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.fixture()
 def state(bot: MockedBot):
@@ -15,7 +17,6 @@ def state(bot: MockedBot):
 
 
 class TestFSMContext:
-    @pytest.mark.asyncio
     async def test_address_mapping(self, bot: MockedBot):
         storage = MemoryStorage()
         ctx = storage.storage[bot][-42][42]

--- a/tests/test_dispatcher/test_handler/test_base.py
+++ b/tests/test_dispatcher/test_handler/test_base.py
@@ -10,6 +10,8 @@ from aiogram.dispatcher.event.handler import HandlerObject
 from aiogram.dispatcher.handler.base import BaseHandler
 from aiogram.types import Chat, Message, Update
 
+pytestmark = pytest.mark.asyncio
+
 
 class MyHandler(BaseHandler):
     async def handle(self) -> Any:
@@ -18,7 +20,6 @@ class MyHandler(BaseHandler):
 
 
 class TestBaseClassBasedHandler:
-    @pytest.mark.asyncio
     async def test_base_handler(self):
         event = Update(update_id=42)
         handler = MyHandler(event=event, key=42)
@@ -28,7 +29,6 @@ class TestBaseClassBasedHandler:
         assert not hasattr(handler, "filters")
         assert await handler == 42
 
-    @pytest.mark.asyncio
     async def test_bot_from_context(self):
         event = Update(update_id=42)
         handler = MyHandler(event=event, key=42)
@@ -40,7 +40,6 @@ class TestBaseClassBasedHandler:
         Bot.set_current(bot)
         assert handler.bot == bot
 
-    @pytest.mark.asyncio
     async def test_bot_from_data(self):
         event = Update(update_id=42)
         bot = Bot("42:TEST")
@@ -59,7 +58,6 @@ class TestBaseClassBasedHandler:
         assert handler.event == event
         assert handler.update == update
 
-    @pytest.mark.asyncio
     async def test_wrapped_handler(self):
         # wrap the handler on dummy function
         handler = wraps(MyHandler)(lambda: None)

--- a/tests/test_dispatcher/test_handler/test_callback_query.py
+++ b/tests/test_dispatcher/test_handler/test_callback_query.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import CallbackQueryHandler
 from aiogram.types import CallbackQuery, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCallbackQueryHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = CallbackQuery(
             id="chosen",

--- a/tests/test_dispatcher/test_handler/test_chat_member.py
+++ b/tests/test_dispatcher/test_handler/test_chat_member.py
@@ -6,9 +6,10 @@ import pytest
 from aiogram.dispatcher.handler.chat_member import ChatMemberHandler
 from aiogram.types import Chat, ChatMemberMember, ChatMemberUpdated, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestChatMemberUpdated:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = ChatMemberUpdated(
             chat=Chat(id=42, type="private"),

--- a/tests/test_dispatcher/test_handler/test_chosen_inline_result.py
+++ b/tests/test_dispatcher/test_handler/test_chosen_inline_result.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import ChosenInlineResultHandler
 from aiogram.types import ChosenInlineResult, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestChosenInlineResultHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = ChosenInlineResult(
             result_id="chosen",

--- a/tests/test_dispatcher/test_handler/test_error.py
+++ b/tests/test_dispatcher/test_handler/test_error.py
@@ -4,9 +4,10 @@ import pytest
 
 from aiogram.dispatcher.handler import ErrorHandler
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestErrorHandler:
-    @pytest.mark.asyncio
     async def test_extensions(self):
         event = KeyError("kaboom")
 

--- a/tests/test_dispatcher/test_handler/test_inline_query.py
+++ b/tests/test_dispatcher/test_handler/test_inline_query.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import InlineQueryHandler
 from aiogram.types import InlineQuery, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestCallbackQueryHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = InlineQuery(
             id="query",

--- a/tests/test_dispatcher/test_handler/test_message.py
+++ b/tests/test_dispatcher/test_handler/test_message.py
@@ -7,6 +7,8 @@ from aiogram.dispatcher.filters import CommandObject
 from aiogram.dispatcher.handler.message import MessageHandler, MessageHandlerCommandMixin
 from aiogram.types import Chat, Message, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class MyHandler(MessageHandler):
     async def handle(self) -> Any:
@@ -14,7 +16,6 @@ class MyHandler(MessageHandler):
 
 
 class TestClassBasedMessageHandler:
-    @pytest.mark.asyncio
     async def test_message_handler(self):
         event = Message(
             message_id=42,

--- a/tests/test_dispatcher/test_handler/test_poll.py
+++ b/tests/test_dispatcher/test_handler/test_poll.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import PollHandler
 from aiogram.types import Poll, PollOption
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestShippingQueryHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = Poll(
             id="query",

--- a/tests/test_dispatcher/test_handler/test_pre_checkout_query.py
+++ b/tests/test_dispatcher/test_handler/test_pre_checkout_query.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import PreCheckoutQueryHandler
 from aiogram.types import PreCheckoutQuery, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestPreCheckoutQueryHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = PreCheckoutQuery(
             id="query",

--- a/tests/test_dispatcher/test_handler/test_shipping_query.py
+++ b/tests/test_dispatcher/test_handler/test_shipping_query.py
@@ -5,9 +5,10 @@ import pytest
 from aiogram.dispatcher.handler import ShippingQueryHandler
 from aiogram.types import ShippingAddress, ShippingQuery, User
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestShippingQueryHandler:
-    @pytest.mark.asyncio
     async def test_attributes_aliases(self):
         event = ShippingQuery(
             id="query",

--- a/tests/test_dispatcher/test_router.py
+++ b/tests/test_dispatcher/test_router.py
@@ -4,6 +4,7 @@ from aiogram.dispatcher.event.bases import UNHANDLED, SkipHandler, skip
 from aiogram.dispatcher.router import Router
 from aiogram.utils.warnings import CodeHasNoEffect
 
+pytestmark = pytest.mark.asyncio
 importable_router = Router()
 
 
@@ -73,7 +74,6 @@ class TestRouter:
         assert router.observers["pre_checkout_query"] == router.pre_checkout_query
         assert router.observers["poll"] == router.poll
 
-    @pytest.mark.asyncio
     async def test_emit_startup(self):
         router1 = Router()
         router2 = Router()
@@ -95,7 +95,6 @@ class TestRouter:
         await router1.emit_startup()
         assert results == [2, 1, 2]
 
-    @pytest.mark.asyncio
     async def test_emit_shutdown(self):
         router1 = Router()
         router2 = Router()
@@ -123,7 +122,6 @@ class TestRouter:
         with pytest.raises(SkipHandler, match="KABOOM"):
             skip("KABOOM")
 
-    @pytest.mark.asyncio
     async def test_global_filter_in_nested_router(self):
         r1 = Router()
         r2 = Router()

--- a/tests/test_utils/test_backoff.py
+++ b/tests/test_utils/test_backoff.py
@@ -3,6 +3,7 @@ import pytest
 from aiogram.utils.backoff import Backoff, BackoffConfig
 
 BACKOFF_CONFIG = BackoffConfig(min_delay=0.1, max_delay=1.0, factor=2.0, jitter=0.0)
+pytestmark = pytest.mark.asyncio
 
 
 class TestBackoffConfig:
@@ -69,7 +70,6 @@ class TestBackoff:
         backoff.sleep()
         assert backoff.counter == 1
 
-    @pytest.mark.asyncio
     async def test_asleep(self):
         backoff = Backoff(config=BACKOFF_CONFIG)
         await backoff.asleep()

--- a/tests/test_utils/test_deep_linking.py
+++ b/tests/test_utils/test_deep_linking.py
@@ -23,6 +23,8 @@ WRONG_PAYLOADS = [
     1234567890123456789.0,
 ]
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.fixture(params=PAYLOADS, name="payload")
 def payload_fixture(request):
@@ -54,7 +56,6 @@ def get_bot_user_fixture(monkeypatch):
     monkeypatch.setattr(MockedBot, "me", get_bot_user_mock)
 
 
-@pytest.mark.asyncio
 class TestDeepLinking:
     async def test_get_start_link(self, bot, payload):
         link = await create_start_link(bot=bot, payload=payload)


### PR DESCRIPTION
# Description
We shouldn't add `@pytest.mark.asyncio` for every test function.
It's enough to set `pytestmark = pytest.mark.asyncio` in the beginning of the file to activate asyncio support
Source: https://github.com/pytest-dev/pytest-asyncio#pytestmarkasyncio

## Type of change
- [x] Refactoring


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
