### PR TITLE
Add StatesGroup filter

### DIFF
--- a/aiogram/dispatcher/fsm/state.py
+++ b/aiogram/dispatcher/fsm/state.py
@@ -111,8 +111,8 @@ class StatesGroupMeta(type):
             return item in cls.__all_states_names__
         if isinstance(item, State):
             return item in cls.__all_states__
-        # if isinstance(item, StatesGroup):
-        #     return item in cls.__all_childs__
+        if isinstance(item, StatesGroupMeta):
+            return item in cls.__all_childs__
         return False
 
     def __str__(self) -> str:
@@ -126,8 +126,11 @@ class StatesGroup(metaclass=StatesGroupMeta):
             return cls
         return cls.__parent__.get_root()
 
-    # def __call__(cls, event: TelegramObject, raw_state: Optional[str] = None) -> bool:
-    #     return raw_state in cls.__all_states_names__
+    def __call__(cls, event: TelegramObject, raw_state: Optional[str] = None) -> bool:
+        return raw_state in type(cls).__all_states_names__
+
+    def __str__(self) -> str:
+        return f"StatesGroup {type(self).__full_group_name__}"
 
 
 default_state = State()

--- a/tests/test_dispatcher/test_fsm/test_state.py
+++ b/tests/test_dispatcher/test_fsm/test_state.py
@@ -139,8 +139,7 @@ class TestStatesGroup:
         assert MyGroup.state1 not in MyGroup.MyNestedGroup
         assert MyGroup.state1 in MyGroup
 
-        # Not working as well
-        # assert MyGroup.MyNestedGroup in MyGroup
+        assert MyGroup.MyNestedGroup in MyGroup
 
         assert "MyGroup.MyNestedGroup:state1" in MyGroup
         assert "MyGroup.MyNestedGroup:state1" in MyGroup.MyNestedGroup
@@ -150,3 +149,36 @@ class TestStatesGroup:
         assert 42 not in MyGroup
 
         assert MyGroup.MyNestedGroup.get_root() is MyGroup
+
+    def test_empty_filter(self):
+        class MyGroup(StatesGroup):
+            pass
+
+        assert str(MyGroup()) == "StatesGroup MyGroup"
+
+    def test_with_state_filter(self):
+        class MyGroup(StatesGroup):
+            state1 = State()
+            state2 = State()
+
+        assert MyGroup()(None, "MyGroup:state1")
+        assert MyGroup()(None, "MyGroup:state2")
+        assert not MyGroup()(None, "MyGroup:state3")
+
+        assert str(MyGroup()) == "StatesGroup MyGroup"
+
+    def test_nested_group_filter(self):
+        class MyGroup(StatesGroup):
+            state1 = State()
+
+            class MyNestedGroup(StatesGroup):
+                state1 = State()
+
+        assert MyGroup()(None, "MyGroup:state1")
+        assert MyGroup()(None, "MyGroup.MyNestedGroup:state1")
+        assert not MyGroup()(None, "MyGroup:state2")
+        assert MyGroup.MyNestedGroup()(None, "MyGroup.MyNestedGroup:state1")
+        assert not MyGroup.MyNestedGroup()(None, "MyGroup:state1")
+
+        assert str(MyGroup()) == "StatesGroup MyGroup"
+        assert str(MyGroup.MyNestedGroup()) == "StatesGroup MyGroup.MyNestedGroup"


### PR DESCRIPTION
# Description

Added filtering by StatesGroups
There is also a [second](https://github.com/darksidecat/aiogram/commit/0e5285701226cea9d5ba1340d8410d6dcf2693f2) filtering implementation

Usage:
```python3
router.message.filter(StatesGroupName())
```

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add tests cases
- [x] Manual testing in bot

**Test Configuration**:
* Operating System: Win10
* Python version: 3.9.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
