### PR TITLE
add aliases for edit/delete reply markup to Message

### DIFF
--- a/CHANGES/662.feature
+++ b/CHANGES/662.feature
@@ -1,0 +1,1 @@
+add aliases for edit/delete reply markup to Message

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
         CopyMessage,
         DeleteMessage,
         EditMessageCaption,
+        EditMessageReplyMarkup,
         EditMessageText,
         SendAnimation,
         SendAudio,
@@ -1736,6 +1737,21 @@ class Message(TelegramObject):
             disable_web_page_preview=disable_web_page_preview,
             reply_markup=reply_markup,
         )
+
+    def edit_reply_markup(
+        self,
+        reply_markup: Optional[InlineKeyboardMarkup] = None,
+    ) -> EditMessageReplyMarkup:
+        from ..methods import EditMessageReplyMarkup
+
+        return EditMessageReplyMarkup(
+            chat_id=self.chat.id,
+            message_id=self.message_id,
+            reply_markup=reply_markup,
+        )
+
+    def delete_reply_markup(self) -> EditMessageReplyMarkup:
+        return self.edit_reply_markup(reply_markup=None)
 
     def edit_caption(
         self,

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -7,6 +7,7 @@ from aiogram.methods import (
     CopyMessage,
     DeleteMessage,
     EditMessageCaption,
+    EditMessageReplyMarkup,
     EditMessageText,
     SendAnimation,
     SendAudio,
@@ -36,6 +37,8 @@ from aiogram.types import (
     Document,
     EncryptedCredentials,
     Game,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
     Invoice,
     Location,
     MessageAutoDeleteTimerChanged,
@@ -559,6 +562,64 @@ class TestMessage:
         )
         method = message.edit_text(text="test")
         assert isinstance(method, EditMessageText)
+        assert method.chat_id == message.chat.id
+
+    def test_edit_reply_markup(self):
+        reply_markup = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="test",
+                        callback_data="test",
+                    ),
+                ],
+            ]
+        )
+        reply_markup_new = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="test2",
+                        callback_data="test2",
+                    ),
+                ],
+            ]
+        )
+
+        message = Message(
+            message_id=42,
+            chat=Chat(id=42, type="private"),
+            date=datetime.datetime.now(),
+            reply_markup=reply_markup,
+        )
+        method = message.edit_reply_markup(
+            reply_markup=reply_markup_new,
+        )
+        assert isinstance(method, EditMessageReplyMarkup)
+        assert method.reply_markup == reply_markup_new
+        assert method.chat_id == message.chat.id
+
+    def test_delete_reply_markup(self):
+        reply_markup = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="test",
+                        callback_data="test",
+                    ),
+                ],
+            ]
+        )
+
+        message = Message(
+            message_id=42,
+            chat=Chat(id=42, type="private"),
+            date=datetime.datetime.now(),
+            reply_markup=reply_markup,
+        )
+        method = message.delete_reply_markup()
+        assert isinstance(method, EditMessageReplyMarkup)
+        assert method.reply_markup is None
         assert method.chat_id == message.chat.id
 
     def test_edit_caption(self):


### PR DESCRIPTION
# Description

add aliases for edit/delete reply markup to Message

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add tests
- [x] Manual testing in bot

**Test Configuration**:
* Operating System: Win10
* Python version: 3.9.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
