### PR TITLE
add `Bot.download_file` aliases ability to save files to a directory and automatically create directories

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import pathlib
 import typing
 import warnings
 
@@ -43,25 +44,37 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         if hasattr(self, '_me'):
             delattr(self, '_me')
 
-    async def download_file_by_id(self, file_id: base.String, destination=None,
-                                  timeout: base.Integer = 30, chunk_size: base.Integer = 65536,
-                                  seek: base.Boolean = True):
+    async def download_file_by_id(
+            self,
+            file_id: base.String,
+            destination: typing.Optional[base.InputFile, pathlib.Path] = None,
+            timeout: base.Integer = 30,
+            chunk_size: base.Integer = 65536,
+            seek: base.Boolean = True,
+            destination_dir: typing.Optional[typing.Union[str, pathlib.Path]] = None,
+            make_dirs: typing.Optional[base.Boolean] = True,
+    ):
         """
-        Download file by file_id to destination
+        Download file by file_id to destination file or directory
 
         if You want to automatically create destination (:class:`io.BytesIO`) use default
         value of destination and handle result of this method.
+
+        At most one of these parameters can be used: :param destination:, :param destination_dir:
 
         :param file_id: str
         :param destination: filename or instance of :class:`io.IOBase`. For e. g. :class:`io.BytesIO`
         :param timeout: int
         :param chunk_size: int
         :param seek: bool - go to start of file when downloading is finished
+        :param destination_dir: directory for saving files
+        :param make_dirs: Make dirs if not exist
         :return: destination
         """
         file = await self.get_file(file_id)
         return await self.download_file(file_path=file.file_path, destination=destination,
-                                        timeout=timeout, chunk_size=chunk_size, seek=seek)
+                                        timeout=timeout, chunk_size=chunk_size, seek=seek,
+                                        destination_dir=destination_dir, make_dirs=make_dirs)
 
     # === Getting updates ===
     # https://core.telegram.org/bots/api#getting-updates

--- a/aiogram/types/mixins.py
+++ b/aiogram/types/mixins.py
@@ -49,7 +49,6 @@ class Downloadable:
             destination,
             destination_dir,
             destination_file,
-            make_dirs
         )
 
         return await self.bot.download_file(
@@ -58,9 +57,10 @@ class Downloadable:
             timeout=timeout,
             chunk_size=chunk_size,
             seek=seek,
+            make_dirs=make_dirs
         )
 
-    async def _prepare_destination(self, dest, destination_dir, destination_file, make_dirs):
+    async def _prepare_destination(self, dest, destination_dir, destination_file):
         file = await self.get_file()
 
         if not(any((dest, destination_dir, destination_file))):
@@ -86,9 +86,6 @@ class Downloadable:
                 destination = destination_file
             else:
                 raise TypeError("destination_file must be str, pathlib.Path or io.IOBase type")
-
-        if make_dirs and os.path.dirname(destination):
-            os.makedirs(os.path.dirname(destination), exist_ok=True)
 
         return file, destination
 

--- a/tests/test_bot/test_bot_download_file.py
+++ b/tests/test_bot/test_bot_download_file.py
@@ -1,0 +1,78 @@
+import os
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from aiogram import Bot
+from aiogram.types import File
+from tests import TOKEN
+from tests.types.dataset import FILE
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(name='bot')
+async def bot_fixture():
+    async def get_file():
+        return File(**FILE)
+
+    """ Bot fixture """
+    _bot = Bot(TOKEN)
+    _bot.get_file = get_file
+    yield _bot
+    await _bot.session.close()
+
+
+@pytest.fixture
+def file():
+    return File(**FILE)
+
+
+@pytest.fixture
+def tmppath(tmpdir, request):
+    os.chdir(tmpdir)
+    yield Path(tmpdir)
+    os.chdir(request.config.invocation_dir)
+
+
+class TestBotDownload:
+    async def test_download_file(self, tmppath, bot, file):
+        f = await bot.download_file(file_path=file.file_path)
+        assert len(f.read()) != 0
+
+    async def test_download_file_destination(self, tmppath, bot, file):
+        await bot.download_file(file_path=file.file_path, destination="test.file")
+        assert os.path.isfile(tmppath.joinpath('test.file'))
+
+    async def test_download_file_destination_with_dir(self, tmppath, bot, file):
+        await bot.download_file(file_path=file.file_path,
+                                destination=os.path.join('dir_name', 'file_name'))
+        assert os.path.isfile(tmppath.joinpath('dir_name', 'file_name'))
+
+    async def test_download_file_destination_raise_file_not_found(self, tmppath, bot, file):
+        with pytest.raises(FileNotFoundError):
+            await bot.download_file(file_path=file.file_path,
+                                    destination=os.path.join('dir_name', 'file_name'),
+                                    make_dirs=False)
+
+    async def test_download_file_destination_io_bytes(self, tmppath, bot, file):
+        f = BytesIO()
+        await bot.download_file(file_path=file.file_path,
+                                destination=f)
+        assert len(f.read()) != 0
+
+    async def test_download_file_raise_value_error(self, tmppath, bot, file):
+        with pytest.raises(ValueError):
+            await bot.download_file(file_path=file.file_path, destination="a", destination_dir="b")
+
+    async def test_download_file_destination_dir(self, tmppath, bot, file):
+        await bot.download_file(file_path=file.file_path, destination_dir='test_dir')
+        assert os.path.isfile(tmppath.joinpath('test_dir', file.file_path))
+
+    async def test_download_file_destination_dir_raise_file_not_found(self, tmppath, bot, file):
+        with pytest.raises(FileNotFoundError):
+            await bot.download_file(file_path=file.file_path,
+                                    destination_dir='test_dir',
+                                    make_dirs=False)
+            assert os.path.isfile(tmppath.joinpath('test_dir', file.file_path))


### PR DESCRIPTION
# Description


* add the ability to save files to a directory with path completion based on `file.file_path`,
* add an option to automatically create directories in the file path

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add tests and run locally
- [ ] Manual testing (not yet)

**Test Configuration**:
* Operating System: Win 10
* Python version: 3.9.6

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
