### PR TITLE
Show callback_query.data in logging

### DIFF
--- a/aiogram/contrib/middlewares/logging.py
+++ b/aiogram/contrib/middlewares/logging.py
@@ -89,13 +89,15 @@ class LoggingMiddleware(BaseMiddleware):
 
     async def on_pre_process_callback_query(self, callback_query: types.CallbackQuery, data: dict):
         if callback_query.message:
+            message = callback_query.message
             text = (f"Received callback query [ID:{callback_query.id}] "
                     f"from user [ID:{callback_query.from_user.id}] "
-                    f"for message [ID:{callback_query.message.message_id}] "
-                    f"in chat [{callback_query.message.chat.type}:{callback_query.message.chat.id}]")
+                    f"for message [ID:{message.message_id}] "
+                    f"in chat [{message.chat.type}:{message.chat.id}]"
+                    f"with data: {callback_query.data}")
 
-            if callback_query.message.from_user:
-                text += f" originally posted by user [ID:{callback_query.message.from_user.id}]"
+            if message.from_user:
+                text = f"{text} originally posted by user [ID:{message.from_user.id}]"
 
             self.logger.info(text)
 
@@ -106,14 +108,16 @@ class LoggingMiddleware(BaseMiddleware):
 
     async def on_post_process_callback_query(self, callback_query, results, data: dict):
         if callback_query.message:
+            message = callback_query.message
             text = (f"{HANDLED_STR[bool(len(results))]} "
                     f"callback query [ID:{callback_query.id}] "
                     f"from user [ID:{callback_query.from_user.id}] "
-                    f"for message [ID:{callback_query.message.message_id}] "
-                    f"in chat [{callback_query.message.chat.type}:{callback_query.message.chat.id}]")
+                    f"for message [ID:{message.message_id}] "
+                    f"in chat [{message.chat.type}:{message.chat.id}] "
+                    f"with data: {callback_query.data}")
 
-            if callback_query.message.from_user:
-                text += f" originally posted by user [ID:{callback_query.message.from_user.id}]"
+            if message.from_user:
+                text = f"{text} originally posted by user [ID:{message.from_user.id}]"
 
             self.logger.info(text)
 


### PR DESCRIPTION
# Description
Now LoggingMiddleware doesn't show CallbackQuery.data.
This PR will fix it :) 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
