### PR TITLE
Fixed send_copy: added caption to send_voice

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -2899,7 +2899,9 @@ class Message(base.TelegramObject):
                 video_note=self.video_note.file_id, **kwargs
             )
         elif self.voice:
-            return await self.bot.send_voice(voice=self.voice.file_id, **kwargs)
+            return await self.bot.send_voice(
+                voice=self.voice.file_id, caption=text, **kwargs
+            )
         elif self.contact:
             kwargs.pop("parse_mode")
             return await self.bot.send_contact(


### PR DESCRIPTION
## Description

`send_copy` does not copy a caption of the voice.

Example:

https://user-images.githubusercontent.com/43146729/136397756-456dfc59-c805-4a69-bf39-4540df6c2ff3.mp4

```python
from aiogram import Dispatcher, Bot, types
from aiogram.utils import executor

bot = Bot("1234:ABCD")
dp = Dispatcher(bot)

@dp.message_handler(content_types="voice")
async def _(msg: types.Message):
  await msg.send_copy(msg.chat.id)

executor.start_polling(dp)
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Run code from example after fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
