### PR TITLE
enh: remove unnecessarily strict condition in send_media_group

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -1004,6 +1004,10 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         # Convert list to MediaGroup
         if isinstance(media, list):
             media = types.MediaGroup(media)
+        
+        # Check MediaGroup quantity
+        if not (1 <= len(media.media) <= 10):
+            raise ValidationError("Media group must include 2-10 items as written in docs, but also it works with 1 element")
 
         files = dict(media.get_files())
 

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -1005,10 +1005,6 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         if isinstance(media, list):
             media = types.MediaGroup(media)
 
-        # check MediaGroup quantity
-        if not 2 <= len(media.media) <= 10:
-            raise ValidationError("Media group must include 2-10 items")
-
         files = dict(media.get_files())
 
         media = prepare_arg(media)

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -1004,7 +1004,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         # Convert list to MediaGroup
         if isinstance(media, list):
             media = types.MediaGroup(media)
-        
+
         # Check MediaGroup quantity
         if not (1 <= len(media.media) <= 10):
             raise ValidationError("Media group must include 2-10 items as written in docs, but also it works with 1 element")


### PR DESCRIPTION
## Description

Media groups work well even with 1 media element inside. So this check unnecessarily strict.

The check was fixed in https://github.com/aiogram/aiogram/pull/642, it's working now, but it's bad 😅

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On my bot with many media groups.

**Test Configuration**:
* Operating System: macOS
* Python version: 3.9.6

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
