### PR TITLE
Fix ChatMemberHandler import in __init__.py

### DIFF
--- a/CHANGES/751.bugfix
+++ b/CHANGES/751.bugfix
@@ -1,0 +1,1 @@
+Fixed: Missing ChatMemberHandler import in aiogram/dispatcher/handler

--- a/aiogram/dispatcher/handler/__init__.py
+++ b/aiogram/dispatcher/handler/__init__.py
@@ -1,6 +1,6 @@
 from .base import BaseHandler, BaseHandlerMixin
 from .callback_query import CallbackQueryHandler
-from .chat_member import ChatMemberUpdated
+from .chat_member import ChatMemberHandler
 from .chosen_inline_result import ChosenInlineResultHandler
 from .error import ErrorHandler
 from .inline_query import InlineQueryHandler
@@ -13,7 +13,7 @@ __all__ = (
     "BaseHandler",
     "BaseHandlerMixin",
     "CallbackQueryHandler",
-    "ChatMemberUpdated",
+    "ChatMemberHandler",
     "ChosenInlineResultHandler",
     "ErrorHandler",
     "InlineQueryHandler",


### PR DESCRIPTION
# Description

The ChatMemberUpdated class is being imported instead of ChatMemberHandler, which is wrong here.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
