### PR TITLE
Typo fix in docs: language -> default_locale

### DIFF
--- a/docs/utils/i18n.rst
+++ b/docs/utils/i18n.rst
@@ -86,7 +86,7 @@ On top of your application the instance of :class:`aiogram.utils.i18n.code.I18n`
 
 .. code-block::
 
-    i18n = I18n(path="locales", language="en", domain="messages")
+    i18n = I18n(path="locales", default_locale="en", domain="messages")
 
 
 After that you will need to choose one of builtin I18n middleware or write your own.


### PR DESCRIPTION
# Description

https://github.com/aiogram/aiogram/blob/24a805d517edd3618371fa401b08d3fe8b58e676/aiogram/utils/i18n/core.py#L12-L19

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
