### PR TITLE
Added support for lazyproxy in keyboard buttons

### DIFF
--- a/aiogram/types/inline_keyboard_button.py
+++ b/aiogram/types/inline_keyboard_button.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union, Any
 
 from .base import MutableTelegramObject
+
+try:
+    from babel.support import LazyProxy
+except ImportError:  # pragma: no cover
+
+    class LazyProxy:  # type: ignore
+        def __init__(self, func: Any, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError(
+                "LazyProxy can be used only when Babel installed\n"
+                "Just install Babel (`pip install Babel`) "
+                "or aiogram with i18n support (`pip install aiogram[i18n]`)"
+            )
 
 if TYPE_CHECKING:
     from .callback_game import CallbackGame
@@ -16,7 +28,7 @@ class InlineKeyboardButton(MutableTelegramObject):
     Source: https://core.telegram.org/bots/api#inlinekeyboardbutton
     """
 
-    text: str
+    text: Union[str, 'LazyProxy']
     """Label text on the button"""
     url: Optional[str] = None
     """*Optional*. HTTP or tg:// url to be opened when the button is pressed. Links :code:`tg://user?id=<user_id>` can be used to mention a user by their ID without using a username, if this is allowed by their privacy settings."""
@@ -32,3 +44,5 @@ class InlineKeyboardButton(MutableTelegramObject):
     """*Optional*. Description of the game that will be launched when the user presses the button."""
     pay: Optional[bool] = None
     """*Optional*. Specify :code:`True`, to send a `Pay button <https://core.telegram.org/bots/api#payments>`_."""
+    class Config:
+        arbitrary_types_allowed = True

--- a/aiogram/types/keyboard_button.py
+++ b/aiogram/types/keyboard_button.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union, Any
 
 from .base import MutableTelegramObject
+
+try:
+    from babel.support import LazyProxy
+except ImportError:  # pragma: no cover
+
+    class LazyProxy:  # type: ignore
+        def __init__(self, func: Any, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError(
+                "LazyProxy can be used only when Babel installed\n"
+                "Just install Babel (`pip install Babel`) "
+                "or aiogram with i18n support (`pip install aiogram[i18n]`)"
+            )
+
 
 if TYPE_CHECKING:
     from .keyboard_button_poll_type import KeyboardButtonPollType
@@ -18,7 +31,7 @@ class KeyboardButton(MutableTelegramObject):
     Source: https://core.telegram.org/bots/api#keyboardbutton
     """
 
-    text: str
+    text: Union[str, 'LazyProxy']
     """Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed"""
     request_contact: Optional[bool] = None
     """*Optional*. If :code:`True`, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only"""
@@ -26,3 +39,7 @@ class KeyboardButton(MutableTelegramObject):
     """*Optional*. If :code:`True`, the user's current location will be sent when the button is pressed. Available in private chats only"""
     request_poll: Optional[KeyboardButtonPollType] = None
     """*Optional*. If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only"""
+
+    class Config:
+        arbitrary_types_allowed = True
+


### PR DESCRIPTION
# Description
Added support for lazy_gettext in keyboard buttons

Fixes # (issue)

Added LazyProxy type support in keyboard buttons type like in class Text(BaseFilter)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on my bot