### PR TITLE
Added possibility to pass kwargs into handlers from webhook

### DIFF
--- a/CHANGES/785.feature
+++ b/CHANGES/785.feature
@@ -1,0 +1,2 @@
+Added possibility to pass additional arguments into the aiohttp webhook handler to use this
+arguments inside handlers as the same as it possible in polling mode.


### PR DESCRIPTION
# Description

Added possibility to pass additional arguments into the aiohttp webhook handler to use this
arguments inside handlers as the same as it possible in polling mode.

Fixes #785

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
