### PR TITLE
Fix unexpected behavior of sequences in StateFilter

### DIFF
--- a/CHANGES/791.bugfix
+++ b/CHANGES/791.bugfix
@@ -1,0 +1,1 @@
+Fixed unexpected behavior of sequences in the StateFilter.

--- a/aiogram/dispatcher/filters/state.py
+++ b/aiogram/dispatcher/filters/state.py
@@ -37,11 +37,12 @@ class StateFilter(BaseFilter):
         allowed_states = cast(Sequence[StateType], self.state)
         for allowed_state in allowed_states:
             if isinstance(allowed_state, str) or allowed_state is None:
-                if allowed_state == "*":
+                if allowed_state == "*" or raw_state == allowed_state:
                     return True
-                return raw_state == allowed_state
             elif isinstance(allowed_state, (State, StatesGroup)):
-                return allowed_state(event=obj, raw_state=raw_state)
+                if allowed_state(event=obj, raw_state=raw_state):
+                    return True
             elif isclass(allowed_state) and issubclass(allowed_state, StatesGroup):
-                return allowed_state()(event=obj, raw_state=raw_state)
+                if allowed_state()(event=obj, raw_state=raw_state):
+                    return True
         return False

--- a/tests/test_dispatcher/test_filters/test_state.py
+++ b/tests/test_dispatcher/test_filters/test_state.py
@@ -41,6 +41,9 @@ class TestStateFilter:
             [[None], None, True],
             [None, "state", False],
             [[], "state", False],
+            [[State("state"), "state"], "state", True],
+            [[MyGroup(), State("state")], "@:state", True],
+            [[MyGroup, State("state")], "state", False],
         ],
     )
     @pytestmark


### PR DESCRIPTION
# Description

At the moment of preparing this PR, the StateFilter, given a sequence of values, makes a check only for its first element, which results in unexpected behavior for developers using the framework.

## Type of change

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: Windows 11
* Python version:  3.9.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
