### PR TITLE
Add TelegramObject readable representation

### DIFF
--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -211,6 +211,15 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         """
         return self.as_json()
 
+    def __repr__(self) -> str:
+        """
+        Return object readable representation.
+
+        Example: <ObjectName {"id": 123456}>
+        :return: object class name and object data as a string
+        """
+        return f"<{type(self).__name__} {self}>"
+
     def __getitem__(self, item: typing.Union[str, int]) -> typing.Any:
         """
         Item getter (by key)


### PR DESCRIPTION
# Description

Object representation in pydantic style is very handy on debugging. E.g. with Sentry:
![telegram-cloud-photo-size-2-5343797000174417582-x](https://user-images.githubusercontent.com/25399456/147358521-ee30f197-75a7-4f13-be39-180d0714cc25.jpg)

As you can see, Item (pydantic object) shows it's fields.
So it would be nice to see Telegram Objects this way in aiogram 2.x


## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
```python
import logging

from aiogram import Bot, Dispatcher, executor
from aiogram.types import Message

logging.basicConfig(level=logging.INFO)
bot = Bot(token='TOKEN')
dp = Dispatcher(bot)

messages = []


@dp.message_handler()
async def echo_handler(message: Message):
    messages.append(message)
    logging.info("Collected messages: %s", messages)
    await message.answer(message.text)


if __name__ == '__main__':
    executor.start_polling(dp, skip_updates=True)

```

BEFORE:
```
INFO:root:Collected messages: [<aiogram.types.message.Message object at 0x101d94c40>]
```

AFTER:
```
INFO:root:Collected messages: [<Message {"message_id": 560, "from": {"id": 66812456, "is_bot": false, "first_name": "Oleg", "last_name": "A. 🇷🇺", "username": "Oleg_Oleg_Oleg", "language_code": "en"}, "chat": {"id": 66812456, "first_name": "Oleg", "last_name": "A. 🇷🇺", "username": "Oleg_Oleg_Oleg", "type": "private"}, "date": 1640355914, "text": "/start", "entities": [{"type": "bot_command", "offset": 0, "length": 6}]}>]
```


**Test Configuration**:
* Operating System:  macOS
* Python version: 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
