### PR TITLE
Deleting deprecated CHOSEN_INLINE_QUERY

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -768,7 +768,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
         .. code-block:: python3
 
-            dp.register_chosen_inline_handler(some_chosen_inline_handler, lambda chosen_inline_query: True)
+            dp.register_chosen_inline_handler(some_chosen_inline_handler, lambda chosen_inline_result: True)
 
         :param callback:
         :param state:
@@ -793,8 +793,8 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
 
         .. code-block:: python3
 
-            @dp.chosen_inline_handler(lambda chosen_inline_query: True)
-            async def some_chosen_inline_handler(chosen_inline_query: types.ChosenInlineResult)
+            @dp.chosen_inline_handler(lambda chosen_inline_result: True)
+            async def some_chosen_inline_handler(chosen_inline_result: types.ChosenInlineResult)
 
         :param state:
         :param custom_filters:

--- a/aiogram/types/update.py
+++ b/aiogram/types/update.py
@@ -11,7 +11,7 @@ from .poll import Poll, PollAnswer
 from .pre_checkout_query import PreCheckoutQuery
 from .shipping_query import ShippingQuery
 from .chat_join_request import ChatJoinRequest
-from ..utils import helper, deprecated
+from ..utils import helper
 
 
 class Update(base.TelegramObject):
@@ -69,12 +69,6 @@ class AllowedUpdates(helper.Helper):
     MY_CHAT_MEMBER = helper.ListItem()  # my_chat_member
     CHAT_MEMBER = helper.ListItem()  # chat_member
     CHAT_JOIN_REQUEST = helper.ListItem()  # chat_join_request
-
-    CHOSEN_INLINE_QUERY = deprecated.DeprecatedReadOnlyClassVar(
-        "`CHOSEN_INLINE_QUERY` is a deprecated value for allowed update. "
-        "Use `CHOSEN_INLINE_RESULT`",
-        new_value_getter=lambda cls: cls.CHOSEN_INLINE_RESULT,
-    )
 
     @classmethod
     def default(cls):


### PR DESCRIPTION
# Description

Deleting deprecated `CHOSEN_INLINE_QUERY`
Removing outdated code

Fixes #589 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Operating System: Windows 7
* Python version: version: 3.8.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
