### PR TITLE
Fix: default parent for `__setitem__`

### DIFF
--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -240,7 +240,7 @@ class TelegramObject(ContextInstanceMixin, metaclass=MetaTelegramObject):
         :return:
         """
         if key in self.props:
-            return self.props[key].set_value(self, value, self.conf.get('parent', None))
+            return self.props[key].set_value(self, value, self.conf.get('parent', self))
         self.values[key] = value
 
         # Log warning when Telegram silently adds new Fields

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
+import asyncio
+
 import aioredis
 import pytest
 from _pytest.config import UsageError
+
+from aiogram import Bot
+from . import TOKEN
 
 try:
     import aioredis.util
@@ -72,3 +77,14 @@ def redis_options(request):
             raise UsageError(f"Invalid redis URI {redis_uri!r}: {e}")
 
     raise UsageError("Unsupported aioredis version")
+
+
+@pytest.fixture(name='bot')
+async def bot_fixture():
+    """Bot fixture."""
+    bot = Bot(TOKEN)
+    yield bot
+    session = await bot.get_session()
+    if session and not session.closed:
+        await session.close()
+        await asyncio.sleep(0.2)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6,14 +6,6 @@ from . import FakeTelegram, TOKEN, BOT_ID
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture(name='bot')
-async def bot_fixture():
-    """ Bot fixture """
-    _bot = Bot(TOKEN, parse_mode=types.ParseMode.MARKDOWN_V2)
-    yield _bot
-    await _bot.close()
-
-
 async def test_get_me(bot: Bot):
     """ getMe method test """
     from .types.dataset import USER

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -5,14 +5,6 @@ from aiogram import Dispatcher, Bot
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture(name='bot')
-async def bot_fixture():
-    """ Bot fixture """
-    _bot = Bot(token='123456789:AABBCCDDEEFFaabbccddeeff-1234567890')
-    yield _bot
-    await _bot.close()
-
-
 class TestDispatcherInit:
     async def test_successful_init(self, bot):
         """

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,16 +8,8 @@ from . import FakeTelegram, TOKEN
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture(name='bot')
-async def bot_fixture():
-    """ Bot fixture """
-    _bot = Bot(TOKEN, parse_mode=types.ParseMode.HTML)
-    yield _bot
-    await _bot.close()
-
-
 @pytest.fixture()
-async def message(bot):
+async def message(bot: Bot):
     """
     Message fixture
     :param bot: Telegram bot fixture

--- a/tests/types/dataset.py
+++ b/tests/types/dataset.py
@@ -19,6 +19,14 @@ CHAT = {
     "type": "private",
 }
 
+CHAT_PHOTO = {
+    "small_file_id": 1,
+    "small_file_unique_id": 1,
+    "big_file_id": 1,
+    "big_file_unique_id": 1,
+}
+
+
 PHOTO = {
     "file_id": "AgADBAADFak0G88YZAf8OAug7bHyS9x2ZxkABHVfpJywcloRAAGAAQABAg",
     "file_size": 1101,
@@ -484,4 +492,38 @@ WEBHOOK_INFO = {
 REPLY_KEYBOARD_MARKUP = {
     "keyboard": [[{"text": "something here"}]],
     "resize_keyboard": True,
+}
+
+CHAT_PERMISSIONS = {
+    "can_send_messages": True,
+    "can_send_media_messages": True,
+    "can_send_polls": True,
+    "can_send_other_messages": True,
+    "can_add_web_page_previews": True,
+    "can_change_info": True,
+    "can_invite_users": True,
+    "can_pin_messages": True,
+}
+
+CHAT_LOCATION = {
+    "location": LOCATION,
+    "address": "address",
+}
+
+FULL_CHAT = {
+    **CHAT,
+    "photo": CHAT_PHOTO,
+    "bio": "bio",
+    "has_private_forwards": False,
+    "description": "description",
+    "invite_link": "invite_link",
+    "pinned_message": MESSAGE,
+    "permissions": CHAT_PERMISSIONS,
+    "slow_mode_delay": 10,
+    "message_auto_delete_time": 60,
+    "has_protected_content": True,
+    "sticker_set_name": "sticker_set_name",
+    "can_set_sticker_set": True,
+    "linked_chat_id": -1234567890,
+    "location": CHAT_LOCATION,
 }

--- a/tests/types/dataset.py
+++ b/tests/types/dataset.py
@@ -20,10 +20,10 @@ CHAT = {
 }
 
 CHAT_PHOTO = {
-    "small_file_id": 1,
-    "small_file_unique_id": 1,
-    "big_file_id": 1,
-    "big_file_unique_id": 1,
+    "small_file_id": "small_file_id",
+    "small_file_unique_id": "small_file_unique_id",
+    "big_file_id": "big_file_id",
+    "big_file_unique_id": "big_file_unique_id",
 }
 
 

--- a/tests/types/test_chat.py
+++ b/tests/types/test_chat.py
@@ -1,5 +1,10 @@
-from aiogram import types
-from .dataset import CHAT
+import pytest
+
+from aiogram import Bot, types
+from .dataset import CHAT, FULL_CHAT
+from .. import FakeTelegram
+
+pytestmark = pytest.mark.asyncio
 
 chat = types.Chat(**CHAT)
 
@@ -59,3 +64,10 @@ def test_chat_actions():
     assert types.ChatActions.FIND_LOCATION == 'find_location'
     assert types.ChatActions.RECORD_VIDEO_NOTE == 'record_video_note'
     assert types.ChatActions.UPLOAD_VIDEO_NOTE == 'upload_video_note'
+
+
+async def test_update_chat(bot: Bot):
+    Bot.set_current(bot)
+    async with FakeTelegram(message_data=FULL_CHAT):
+        await chat.update_chat()
+        assert chat.to_python() == types.Chat(**FULL_CHAT).to_python()


### PR DESCRIPTION
# Description

Fixes #513

Set value similar to `__init__`, default parent is self:
https://github.com/aiogram/aiogram/blob/4d2d81138681d730270819579f22b3a0001c43a5/aiogram/types/base.py#L95


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

PyTest [100%] PASSED 
`.update_chat()` 100% covered


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
