### PR TITLE
Typo fix in docs: invalid import

### DIFF
--- a/docs/dispatcher/filters/index.rst
+++ b/docs/dispatcher/filters/index.rst
@@ -55,7 +55,7 @@ For example if you need to make simple text filter:
 
 .. code-block:: python
 
-    from aiogram.filters import BaseFilter
+    from aiogram.dispatcher.filters import BaseFilter
 
 
     class MyText(BaseFilter):


### PR DESCRIPTION
# Description

Replace `from aiogram.filters import BaseFilter` with `from aiogram.dispatcher.filters import BaseFilter`

Fixes #753 

## Type of change

- [x] Documentation (typos, code examples or any documentation update)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
