### PR TITLE
Remove unnecessary `Optional`s

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -222,7 +222,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
         """
         await self.bot.get_updates(offset=-1, timeout=1)
 
-    async def process_updates(self, updates, fast: typing.Optional[bool] = True):
+    async def process_updates(self, updates, fast: bool = True):
         """
         Process list of updates
 
@@ -337,7 +337,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
                             relax=0.1,
                             limit=None,
                             reset_webhook=None,
-                            fast: typing.Optional[bool] = True,
+                            fast: bool = True,
                             error_sleep: int = 5,
                             allowed_updates: typing.Optional[typing.List[str]] = None):
         """
@@ -404,7 +404,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
             self._close_waiter.set_result(None)
             log.warning('Polling is stopped.')
 
-    async def _process_polling_updates(self, updates, fast: typing.Optional[bool] = True):
+    async def _process_polling_updates(self, updates, fast: bool = True):
         """
         Process updates received from long-polling.
 
@@ -949,7 +949,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
     def register_poll_handler(self, callback, *custom_filters, run_task=None, **kwargs):
         """
         Register handler for poll
-        
+
         Example:
 
         .. code-block:: python3
@@ -992,7 +992,7 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
     def register_poll_answer_handler(self, callback, *custom_filters, run_task=None, **kwargs):
         """
         Register handler for poll_answer
-        
+
         Example:
 
         .. code-block:: python3


### PR DESCRIPTION
# Description

Remove `Optional` where default argument is not None.
At first I planned this PR to be about replacing `run_task=None` by `run_task=False`, but it turns out it is different things in this context.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
