### PR TITLE
Fix: close #822 Fix exception filter

### DIFF
--- a/CHANGES/827.bugfix
+++ b/CHANGES/827.bugfix
@@ -1,0 +1,1 @@
+fix exceptions filters

--- a/CHANGES/827.bugfix
+++ b/CHANGES/827.bugfix
@@ -1,1 +1,1 @@
-fix exceptions filters
+Fixed exceptions filters

--- a/aiogram/dispatcher/filters/exception.py
+++ b/aiogram/dispatcher/filters/exception.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Pattern, Tuple, Type, Union, cast
 from pydantic import validator
 
 from aiogram.dispatcher.filters import BaseFilter
+from aiogram.types import TelegramObject
 
 
 class ExceptionTypeFilter(BaseFilter):
@@ -17,7 +18,9 @@ class ExceptionTypeFilter(BaseFilter):
     class Config:
         arbitrary_types_allowed = True
 
-    async def __call__(self, exception: Exception) -> Union[bool, Dict[str, Any]]:
+    async def __call__(
+        self, obj: TelegramObject, exception: Exception
+    ) -> Union[bool, Dict[str, Any]]:
         return isinstance(exception, self.exception)
 
 
@@ -38,7 +41,9 @@ class ExceptionMessageFilter(BaseFilter):
             return re.compile(value)
         return value
 
-    async def __call__(self, exception: Exception) -> Union[bool, Dict[str, Any]]:
+    async def __call__(
+        self, obj: TelegramObject, exception: Exception
+    ) -> Union[bool, Dict[str, Any]]:
         pattern = cast(Pattern[str], self.pattern)
         result = pattern.match(str(exception))
         if not result:


### PR DESCRIPTION
# Description

Fix exception filters

Exception filters `__call__` first parameter must be event from Telegram

Fixes #822 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run test locally

**Test Configuration**:
* Operating System: Manjaro 21.2.2 Qonos
* Python version: Python 3.10.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
