### PR TITLE
Changed skip updates method

### DIFF
--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -216,11 +216,11 @@ class Dispatcher(DataMixin, ContextInstanceMixin):
     async def skip_updates(self):
         """
         You can skip old incoming updates from queue.
-        This method is not recommended to use if you use payments or you bot has high-load.
+        This method is not recommended for using in production.
 
-        :return: None
+        Note that the webhook will be deleted!
         """
-        await self.bot.get_updates(offset=-1, timeout=1)
+        await self.bot.delete_webhook(drop_pending_updates=True)
 
     async def process_updates(self, updates, fast: bool = True):
         """


### PR DESCRIPTION
# Description

Changed skip updates method from using `get_updates `with `offset=-1` to `delete_webhook` with `drop_pending_updates=true`

Fixes #418

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
