### PR TITLE
Add support for URI-provided db_name in MongoStorage

### DIFF
--- a/aiogram/contrib/fsm_storage/mongo.py
+++ b/aiogram/contrib/fsm_storage/mongo.py
@@ -21,6 +21,7 @@ STATE = 'aiogram_state'
 DATA = 'aiogram_data'
 BUCKET = 'aiogram_bucket'
 COLLECTIONS = (STATE, DATA, BUCKET)
+DEFAULT_DB_NAME = 'aiogram_fsm'
 
 
 class MongoStorage(BaseStorage):
@@ -42,7 +43,7 @@ class MongoStorage(BaseStorage):
         await dp.storage.wait_closed()
     """
 
-    def __init__(self, host='localhost', port=27017, db_name='aiogram_fsm', uri=None,
+    def __init__(self, host='localhost', port=27017, db_name=DEFAULT_DB_NAME, uri=None,
                  username=None, password=None, index=True, db_from_uri=False, **kwargs):
         self._host = host
         self._port = port

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -17,3 +17,4 @@ rethinkdb>=2.4.1
 coverage==4.5.3
 motor>=2.2.0
 pytest-lazy-fixture==0.6.*
+yarl

--- a/tests/contrib/fsm_storage/test_storage.py
+++ b/tests/contrib/fsm_storage/test_storage.py
@@ -3,6 +3,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from aiogram.contrib.fsm_storage.redis import RedisStorage, RedisStorage2
+from aiogram.contrib.fsm_storage.mongo import MongoStorage, DEFAULT_DB_NAME
 
 
 @pytest.fixture()
@@ -39,11 +40,18 @@ async def memory_store():
     yield MemoryStorage()
 
 
+@pytest.fixture()
+@pytest.mark.mongo
+async def mongo_store(mongo_options):
+    yield MongoStorage(uri=mongo_options['uri'], db_from_uri=True)
+
+
 @pytest.mark.parametrize(
     "store", [
         lazy_fixture('redis_store'),
         lazy_fixture('redis_store2'),
         lazy_fixture('memory_store'),
+        lazy_fixture('mongo_store'),
     ]
 )
 class TestStorage:
@@ -82,3 +90,29 @@ class TestRedisStorage2:
         assert await store.get_data(chat='1234') == {
             'foo': 'bar'}  # new pool was opened at this point
         assert id(store._redis) != pool_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.mongo
+async def test_mongo_dbname_from_uri(mongo_options):
+    """
+    Check that it is possible to use the db_name provided in the URI
+    without specifying it as a separate parameter.
+    """
+
+    mongo_uri = mongo_options['uri']
+
+    default_db_name = DEFAULT_DB_NAME
+    uri_db_name = mongo_options['db_name']
+    assert uri_db_name in mongo_uri
+    assert default_db_name not in mongo_uri
+
+    # Make two instances - one with the parameter, and the other - without
+    mongo_store_1 = MongoStorage(uri=mongo_options['uri'])
+    mongo_store_2 = MongoStorage(uri=mongo_options['uri'], db_from_uri=True)
+
+    db_1 = await mongo_store_1.get_db()
+    db_2 = await mongo_store_2.get_db()
+
+    assert db_1.name == default_db_name
+    assert db_2.name == uri_db_name


### PR DESCRIPTION
# Description

Added the option to pass `db_name` as part of the URI.
Say, you have the full URI (as is often done) in your settings file or environment variable. This way you don't have to think of ways to correctly parse `db_name` from the URI yourself in your app code just to pass it as a separate argument to `MongoStorage`. Just add `db_from_uri=True`, and the db_name contained in the URI will override the `'aiogram_fsm'` default.

Also, as minor patch, I added `**self._kwargs` to `AsyncIOMotorClient` initialization for the case when the URI was not provided, and username and password are used to construct it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: 
* Python version: 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
