### PR TITLE
Actually use the `Executor`'s event loop

### DIFF
--- a/aiogram/utils/executor.py
+++ b/aiogram/utils/executor.py
@@ -314,7 +314,7 @@ class Executor:
         :param timeout:
         """
         self._prepare_polling()
-        loop = asyncio.get_event_loop()
+        loop: asyncio.AbstractEventLoop = self.loop
 
         try:
             loop.run_until_complete(self._startup_polling())


### PR DESCRIPTION

# Description

Actually use the `Executor`'s event loop instead of creating a new one. So that the event loop can actually be passed to `Executor()` and used in the `Executor().start_polling()` method.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

E.g.
```python
if __name__ == "__main__":
    loop = asyncio.new_event_loop()
    loop.create_task(foobar())

    executor.start_polling(dp, on_startup=startup, on_shutdown=shutdown, loop=loop)

```
- [x] The `foobar: awaitable` must be executed at some point.

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings