### PR TITLE
Fixed path of I18n Class

### DIFF
--- a/docs/utils/i18n.rst
+++ b/docs/utils/i18n.rst
@@ -81,7 +81,7 @@ Configuring engine
 
 After you messages is already done to use gettext your bot should know how to detect user language
 
-On top of your application the instance of :class:`aiogram.utils.i18n.code.I18n` should be created
+On top of your application the instance of :class:`aiogram.utils.i18n.I18n` should be created
 
 
 .. code-block::


### PR DESCRIPTION
# Description

The I18n Class gets imported in 3.0.0b2 as follows:
```python
from aiogram.utils.i18n import I18n
```

Whereas the documentation implies that it should be:
```python
from aiogram.utils.i18n.code import I18n
```
## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Test Configuration**:
* Operating System: Linux
* Python version: 3.10.4
* aiogram version: 3.0.0b2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
