### PR TITLE
Fix datetime serialization error on Windows

### DIFF
--- a/aiogram/types/fields.py
+++ b/aiogram/types/fields.py
@@ -169,7 +169,7 @@ class DateTimeField(Field):
     """
 
     def serialize(self, value: datetime.datetime):
-        return round(value.timestamp())
+        return (value - datetime.datetime(1970, 1, 1)).total_seconds()
 
     def deserialize(self, value, parent=None):
         return datetime.datetime.fromtimestamp(value)

--- a/aiogram/types/fields.py
+++ b/aiogram/types/fields.py
@@ -1,6 +1,7 @@
 import abc
 import datetime
 import weakref
+import sys
 
 __all__ = ('BaseField', 'Field', 'ListField', 'DateTimeField', 'TextField', 'ListOfLists', 'ConstField')
 
@@ -168,8 +169,13 @@ class DateTimeField(Field):
     out: datetime
     """
 
-    def serialize(self, value: datetime.datetime):
-        return (value - datetime.datetime(1970, 1, 1)).total_seconds()
+    if sys.platform == "win32":
+        def serialize(self, value: datetime.datetime):
+            return round((value - datetime.datetime(1970, 1, 1)).total_seconds())
+
+    else:
+        def serialize(self, value: datetime.datetime):
+            return round(value.timestamp())
 
     def deserialize(self, value, parent=None):
         return datetime.datetime.fromtimestamp(value)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #349 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

```
@dp.chat_join_request_handler()
async def chat_join_request_handler(chat_join_request: types.ChatJoinRequest) ->None:
    print(chat_join_request)
```

**Test Configuration**:
* Operating System: Windows 10 Pro 21H1 (19043.1586)
* Python version: Python 3.10.4 (tags/v3.10.4:9d38120) [MSC v.1929 64 bit (AMD64)]

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
