### PR TITLE
#901 Fixed false-positive coercing of Union types in API methods 

### DIFF
--- a/CHANGES/901.bugfix.rst
+++ b/CHANGES/901.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed false-positive coercing of Union types in API methods

--- a/aiogram/methods/base.py
+++ b/aiogram/methods/base.py
@@ -46,6 +46,7 @@ class TelegramMethod(abc.ABC, BaseModel, Generic[TelegramType]):
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
         orm_mode = True
+        smart_union = True  # https://github.com/aiogram/aiogram/issues/901
 
     @root_validator(pre=True)
     def remove_unset(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/aiogram/types/force_reply.py
+++ b/aiogram/types/force_reply.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from pydantic import Field
+
 from .base import MutableTelegramObject
 
 
@@ -19,7 +21,7 @@ class ForceReply(MutableTelegramObject):
     Source: https://core.telegram.org/bots/api#forcereply
     """
 
-    force_reply: bool
+    force_reply: bool = Field(True, const=True)
     """Shows reply interface to the user, as if they manually selected the bot's message and tapped 'Reply'"""
     input_field_placeholder: Optional[str] = None
     """*Optional*. The placeholder to be shown in the input field when the reply is active; 1-64 characters"""

--- a/tests/test_api/test_methods/test_send_message.py
+++ b/tests/test_api/test_methods/test_send_message.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 from aiogram.methods import Request, SendMessage
-from aiogram.types import Chat, Message
+from aiogram.types import Chat, ForceReply, Message
 from tests.mocked_bot import MockedBot
 
 pytestmark = pytest.mark.asyncio
@@ -43,3 +43,8 @@ class TestSendMessage:
         request: Request = bot.get_request()
         assert request.method == "sendMessage"
         assert response == prepare_result.result
+
+    async def test_force_reply(self):
+        # https://github.com/aiogram/aiogram/issues/901
+        method = SendMessage(text="test", chat_id=42, reply_markup=ForceReply())
+        assert isinstance(method.reply_markup, ForceReply)


### PR DESCRIPTION
# Description

Fixed false-positive coercing of Union types in API methods 

Fixes #901

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
