### PR TITLE
Add global allow sending without reply parameter

### DIFF
--- a/aiogram/bot/base.py
+++ b/aiogram/bot/base.py
@@ -38,6 +38,7 @@ class BaseBot:
             validate_token: Optional[base.Boolean] = True,
             parse_mode: typing.Optional[base.String] = None,
             disable_web_page_preview: Optional[base.Boolean] = None,
+            allow_sending_without_reply: Optional[base.Boolean] = None,
             timeout: typing.Optional[typing.Union[base.Integer, base.Float, aiohttp.ClientTimeout]] = None,
             server: TelegramAPIServer = TELEGRAM_PRODUCTION
     ):
@@ -60,6 +61,8 @@ class BaseBot:
         :type parse_mode: :obj:`str`
         :param disable_web_page_preview: You can set default disable web page preview parameter
         :type disable_web_page_preview: :obj:`bool`
+        :param allow_sending_without_reply: You can set default allow sending without reply parameter
+        :type allow_sending_without_reply: :obj:`bool`
         :param timeout: Request timeout
         :type timeout: :obj:`typing.Optional[typing.Union[base.Integer, base.Float, aiohttp.ClientTimeout]]`
         :param server: Telegram Bot API Server endpoint.
@@ -109,8 +112,8 @@ class BaseBot:
         self.timeout = timeout
 
         self.parse_mode = parse_mode
-
         self.disable_web_page_preview = disable_web_page_preview
+        self.allow_sending_without_reply = allow_sending_without_reply
 
     async def get_new_session(self) -> aiohttp.ClientSession:
         return aiohttp.ClientSession(
@@ -360,6 +363,23 @@ class BaseBot:
     @disable_web_page_preview.deleter
     def disable_web_page_preview(self):
         self.disable_web_page_preview = None
+
+    @property
+    def allow_sending_without_reply(self):
+        return getattr(self, '_allow_sending_without_reply', None)
+
+    @allow_sending_without_reply.setter
+    def allow_sending_without_reply(self, value):
+        if value is None:
+            setattr(self, '_allow_sending_without_reply', None)
+        elif not isinstance(value, bool):
+            raise TypeError(f"Allow sending without reply must be bool, not {type(value)}")
+        else:
+            setattr(self, '_allow_sending_without_reply', value)
+
+    @allow_sending_without_reply.deleter
+    def allow_sending_without_reply(self):
+        self.allow_sending_without_reply = None
 
     def check_auth_widget(self, data):
         return check_integrity(self.__token, data)

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -330,6 +330,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
             payload.setdefault('parse_mode', self.parse_mode)
         if self.disable_web_page_preview:
             payload.setdefault('disable_web_page_preview', self.disable_web_page_preview)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_MESSAGE, payload)
         return types.Message(**result)
@@ -452,6 +454,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals())
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.COPY_MESSAGE, payload)
         return types.MessageId(**result)
@@ -520,6 +524,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['photo'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'photo', photo)
@@ -610,6 +616,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['audio', 'thumb'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'audio', audio)
@@ -700,6 +708,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['document'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'document', document)
@@ -792,6 +802,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['video', 'thumb'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'video', video)
@@ -887,6 +899,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=["animation", "thumb"])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'animation', animation)
@@ -967,6 +981,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['voice'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'voice', voice)
@@ -1033,6 +1049,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals(), exclude=['video_note'])
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'video_note', video_note)
@@ -1096,6 +1114,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         media = prepare_arg(media)
         payload = generate_payload(**locals(), exclude=['files'])
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_MEDIA_GROUP, payload, files)
         return [types.Message(**message) for message in result]
@@ -1169,6 +1189,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_LOCATION, payload)
         return types.Message(**result)
@@ -1347,6 +1369,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_VENUE, payload)
         return types.Message(**result)
@@ -1408,6 +1432,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_CONTACT, payload)
         return types.Message(**result)
@@ -1528,6 +1554,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals())
         if self.parse_mode and explanation_entities is None:
             payload.setdefault('explanation_parse_mode', self.parse_mode)
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_POLL, payload)
         return types.Message(**result)
@@ -1587,6 +1615,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_DICE, payload)
         return types.Message(**result)
@@ -2961,6 +2991,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals(), exclude=['sticker'])
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         files = {}
         prepare_file(payload, files, 'sticker', sticker)
@@ -3393,6 +3425,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         reply_markup = prepare_arg(reply_markup)
         provider_data = prepare_arg(provider_data)
         payload_ = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_INVOICE, payload_)
         return types.Message(**result)
@@ -3535,6 +3569,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.allow_sending_without_reply:
+            payload.setdefault('allow_sending_without_reply', self.allow_sending_without_reply)
 
         result = await self.request(api.Methods.SEND_GAME, payload)
         return types.Message(**result)


### PR DESCRIPTION
# Description
Similar to the global `parse_mode` and `disable_web_page_preview` parameters, the global `allow_sending_without_reply` parameter is added to set a default for `allow_sending_without_reply` when sending messages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I cannot add a unit test for this because the returned `Message` object from `Bot.send_message` does not indicate if the message was allowed to be sent without a reply.

I created a bot with `allow_sending_without_reply=True` and it did set the `allow_sending_without_reply` parameter in its `sendMessage` request.

**Test Configuration**:
* Operating System: Windows 10
* Python version: Python 3.9.0


3 existing unit tests failed before my changes. There were no extra failed tests after my changes.
```
============================================================ short test summary info ============================================================
FAILED tests/types/test_chat.py::test_update_chat - AssertionError: assert {'bio': 'bio',\n 'can_set_sticker_set': True,\n 'description': 'desc...
FAILED tests/types/test_message.py::test_export - AssertionError: assert {'chat': {'first_name': 'FirstName',\n          'id': 12345678,\n     ...
FAILED tests/types/test_update.py::test_export - AssertionError: assert {'message': {'chat': {'first_name': 'FirstName',\n                     ...
============================================ 3 failed, 388 passed, 8 skipped, 17 warnings in 17.58s =============================================
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (explained above)
- [ ] New and existing unit tests pass locally with my changes (explained above)