### PR TITLE
make ChatTypeFilter work with inline queries

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -732,7 +732,7 @@ class ChatTypeFilter(BoundFilter):
         if isinstance(obj, Message):
             chat_type = obj.chat.type
         elif isinstance(obj, CallbackQuery):
-            chat_type = obj.message.chat.type
+            chat_type = obj.message.chat.type if obj.message else None
         elif isinstance(obj, ChatMemberUpdated):
             chat_type = obj.chat.type
         elif isinstance(obj, InlineQuery):

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -728,18 +728,20 @@ class ChatTypeFilter(BoundFilter):
 
         self.chat_type: typing.Set[str] = set(chat_type)
 
-    async def check(self, obj: Union[Message, CallbackQuery, ChatMemberUpdated]):
+    async def check(self, obj: Union[Message, CallbackQuery, ChatMemberUpdated, InlineQuery]):
         if isinstance(obj, Message):
-            obj = obj.chat
+            chat_type = obj.chat.type
         elif isinstance(obj, CallbackQuery):
-            obj = obj.message.chat
+            chat_type = obj.message.chat.type
         elif isinstance(obj, ChatMemberUpdated):
-            obj = obj.chat
+            chat_type = obj.chat.type
+        elif isinstance(obj, InlineQuery):
+            chat_type = obj.chat_type
         else:
             warnings.warn("ChatTypeFilter doesn't support %s as input", type(obj))
             return False
 
-        return obj.type in self.chat_type
+        return chat_type in self.chat_type
     
     
 class MediaGroupFilter(BoundFilter):

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -652,6 +652,7 @@ class ChatType(helper.Helper):
     """
     List of chat types
 
+    :key: SENDER
     :key: PRIVATE
     :key: GROUP
     :key: SUPER_GROUP
@@ -661,6 +662,7 @@ class ChatType(helper.Helper):
 
     mode = helper.HelperMode.lowercase
 
+    SENDER = helper.Item()  # sender
     PRIVATE = helper.Item()  # private
     GROUP = helper.Item()  # group
     SUPERGROUP = helper.Item()  # supergroup


### PR DESCRIPTION
# Description

I added the ability to work with the ChatTypeFilter filter with inline mode. Also added a new type of chat - sender, also added it to the documentation in the chat types

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual Testing

**Test Configuration**:
* Operating System:  Ubuntu 20.04 LTS
* Python version: 3.8.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
