### PR TITLE
Add `protect_content` global default

### DIFF
--- a/aiogram/bot/base.py
+++ b/aiogram/bot/base.py
@@ -38,6 +38,7 @@ class BaseBot:
             validate_token: Optional[base.Boolean] = True,
             parse_mode: typing.Optional[base.String] = None,
             disable_web_page_preview: Optional[base.Boolean] = None,
+            protect_content: Optional[base.Boolean] = None,
             timeout: typing.Optional[typing.Union[base.Integer, base.Float, aiohttp.ClientTimeout]] = None,
             server: TelegramAPIServer = TELEGRAM_PRODUCTION
     ):
@@ -60,6 +61,9 @@ class BaseBot:
         :type parse_mode: :obj:`str`
         :param disable_web_page_preview: You can set default disable web page preview parameter
         :type disable_web_page_preview: :obj:`bool`
+        :param protect_content: Protects the contents of sent messages
+            from forwarding and saving
+        :type protect_content: :obj:`typing.Optional[base.Boolean]`
         :param timeout: Request timeout
         :type timeout: :obj:`typing.Optional[typing.Union[base.Integer, base.Float, aiohttp.ClientTimeout]]`
         :param server: Telegram Bot API Server endpoint.
@@ -111,6 +115,7 @@ class BaseBot:
         self.parse_mode = parse_mode
 
         self.disable_web_page_preview = disable_web_page_preview
+        self.protect_content = protect_content
 
     async def get_new_session(self) -> aiohttp.ClientSession:
         return aiohttp.ClientSession(
@@ -360,6 +365,23 @@ class BaseBot:
     @disable_web_page_preview.deleter
     def disable_web_page_preview(self):
         self.disable_web_page_preview = None
+
+    @property
+    def protect_content(self):
+        return getattr(self, "_protect_content", None)
+
+    @protect_content.setter
+    def protect_content(self, value):
+        if value is None:
+            setattr(self, "_protect_content", None)
+            return
+        if not isinstance(value, bool):
+            raise TypeError(f"Protect content must be bool, not {type(value)}")
+        setattr(self, "_protect_content", value)
+
+    @protect_content.deleter
+    def protect_content(self):
+        self.protect_content = None
 
     def check_auth_widget(self, data):
         return check_integrity(self.__token, data)

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -330,6 +330,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
             payload.setdefault('parse_mode', self.parse_mode)
         if self.disable_web_page_preview:
             payload.setdefault('disable_web_page_preview', self.disable_web_page_preview)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_MESSAGE, payload)
         return types.Message(**result)
@@ -370,6 +372,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :rtype: :obj:`types.Message`
         """
         payload = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.FORWARD_MESSAGE, payload)
         return types.Message(**result)
@@ -452,6 +456,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals())
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.COPY_MESSAGE, payload)
         return types.MessageId(**result)
@@ -520,6 +526,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['photo'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'photo', photo)
@@ -610,6 +618,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['audio', 'thumb'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'audio', audio)
@@ -700,6 +710,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['document'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'document', document)
@@ -792,6 +804,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['video', 'thumb'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'video', video)
@@ -887,6 +901,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=["animation", "thumb"])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'animation', animation)
@@ -967,6 +983,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals(), exclude=['voice'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'voice', voice)
@@ -1033,6 +1051,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals(), exclude=['video_note'])
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'video_note', video_note)
@@ -1096,6 +1116,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         media = prepare_arg(media)
         payload = generate_payload(**locals(), exclude=['files'])
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_MEDIA_GROUP, payload, files)
         return [types.Message(**message) for message in result]
@@ -1169,6 +1191,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_LOCATION, payload)
         return types.Message(**result)
@@ -1347,6 +1371,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_VENUE, payload)
         return types.Message(**result)
@@ -1410,6 +1436,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals())
 
         result = await self.request(api.Methods.SEND_CONTACT, payload)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
         return types.Message(**result)
 
     async def send_poll(self,
@@ -1528,6 +1556,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         payload = generate_payload(**locals())
         if self.parse_mode and explanation_entities is None:
             payload.setdefault('explanation_parse_mode', self.parse_mode)
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_POLL, payload)
         return types.Message(**result)
@@ -1587,6 +1617,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_DICE, payload)
         return types.Message(**result)
@@ -2961,6 +2993,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals(), exclude=['sticker'])
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'sticker', sticker)
@@ -3393,6 +3427,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         reply_markup = prepare_arg(reply_markup)
         provider_data = prepare_arg(provider_data)
         payload_ = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_INVOICE, payload_)
         return types.Message(**result)
@@ -3535,6 +3571,8 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         payload = generate_payload(**locals())
+        if self.protect_content is not None:
+            payload.setdefault('protect_content', self.protect_content)
 
         result = await self.request(api.Methods.SEND_GAME, payload)
         return types.Message(**result)

--- a/aiogram/dispatcher/webhook.py
+++ b/aiogram/dispatcher/webhook.py
@@ -458,6 +458,18 @@ class ProtectContentMixin:
         setattr(self, "protect_content", True)
         return self
 
+    @staticmethod
+    def _global_protect_content():
+        """
+        Detect global protect content value
+
+        :return:
+        """
+        from aiogram import Bot
+        bot = Bot.get_current()
+        if bot is not None:
+            return bot.protect_content
+
 
 class ParseModeMixin:
     def as_html(self):
@@ -536,6 +548,8 @@ class SendMessage(BaseResponse, ReplyToMixin, ParseModeMixin,
             parse_mode = self._global_parse_mode()
         if disable_web_page_preview is None:
             disable_web_page_preview = self._global_disable_web_page_preview()
+        if protect_content is None:
+            protect_content = self._global_protect_content()
 
         self.chat_id = chat_id
         self.text = text
@@ -607,6 +621,9 @@ class ForwardMessage(BaseResponse, ReplyToMixin, DisableNotificationMixin, Prote
             from forwarding and saving
         :param message_id: Integer - Message identifier in the chat specified in from_chat_id
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.from_chat_id = from_chat_id
         self.message_id = message_id
@@ -669,6 +686,9 @@ class SendPhoto(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCon
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.photo = photo
         self.caption = caption
@@ -731,6 +751,9 @@ class SendAudio(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCon
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.audio = audio
         self.caption = caption
@@ -793,6 +816,9 @@ class SendDocument(BaseResponse, ReplyToMixin, DisableNotificationMixin, Protect
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.document = document
         self.caption = caption
@@ -856,6 +882,9 @@ class SendVideo(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCon
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.video = video
         self.duration = duration
@@ -919,6 +948,9 @@ class SendVoice(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCon
             - Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard,
             instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.voice = voice
         self.caption = caption
@@ -977,6 +1009,9 @@ class SendVideoNote(BaseResponse, ReplyToMixin, DisableNotificationMixin, Protec
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.video_note = video_note
         self.duration = duration
@@ -1037,6 +1072,8 @@ class SendMediaGroup(BaseResponse, ReplyToMixin, DisableNotificationMixin, Prote
         elif isinstance(media, list):
             # Convert list to MediaGroup
             media = types.MediaGroup(media)
+        if protect_content is None:
+            protect_content = self._global_protect_content()
 
         self.chat_id = chat_id
         self.media = media
@@ -1117,6 +1154,9 @@ class SendLocation(BaseResponse, ReplyToMixin, DisableNotificationMixin, Protect
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.latitude = latitude
         self.longitude = longitude
@@ -1177,6 +1217,9 @@ class SendVenue(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCon
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.latitude = latitude
         self.longitude = longitude
@@ -1237,6 +1280,9 @@ class SendContact(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectC
             - Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.phone_number = phone_number
         self.first_name = first_name
@@ -1845,6 +1891,9 @@ class SendSticker(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectC
             Additional interface options. A JSON-serialized object for an inline keyboard,
             custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.sticker = sticker
         self.disable_notification = disable_notification
@@ -2288,6 +2337,9 @@ class SendGame(BaseResponse, ReplyToMixin, DisableNotificationMixin, ProtectCont
         :param reply_markup: types.InlineKeyboardMarkup (Optional) - A JSON-serialized object for an inline keyboard.
             If empty, one ‘Play game_title’ button will be shown. If not empty, the first button must launch the game.
         """
+        if protect_content is None:
+            protect_content = self._global_protect_content()
+
         self.chat_id = chat_id
         self.game_short_name = game_short_name
         self.disable_notification = disable_notification


### PR DESCRIPTION
# Description

add global default parameter protect_content for Bot.
Usage. For make all messages by bot protected by default add new keyword arg to Bot constructor:
```python 
    bot = Bot(..., protect_content=True, ...)
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have been using this feaеure in production bot since January 2022, no problems found.

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
