### PR TITLE
Fix type hints for redis TTL params

### DIFF
--- a/CHANGES/922.feature.rst
+++ b/CHANGES/922.feature.rst
@@ -1,1 +1,1 @@
-Allowed to use int and datetime.timedelta in RedisStorage.state_ttl and RedisStorage.data_ttl
+Fixed type hints for redis TTL params.

--- a/CHANGES/922.feature.rst
+++ b/CHANGES/922.feature.rst
@@ -1,0 +1,1 @@
+Allowed to use int and datetime.timedelta in RedisStorage.state_ttl and RedisStorage.data_ttl

--- a/aiogram/dispatcher/fsm/storage/redis.py
+++ b/aiogram/dispatcher/fsm/storage/redis.py
@@ -2,9 +2,10 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Dict, Literal, Optional, cast
 
-from redis.asyncio.client import ExpiryT, Redis
+from redis.asyncio.client import Redis
 from redis.asyncio.connection import ConnectionPool
 from redis.asyncio.lock import Lock
+from redis.typing import ExpiryT
 
 from aiogram import Bot
 from aiogram.dispatcher.fsm.state import State

--- a/aiogram/dispatcher/fsm/storage/redis.py
+++ b/aiogram/dispatcher/fsm/storage/redis.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Dict, Literal, Optional, cast
 
-from redis.asyncio.client import Redis
+from redis.asyncio.client import ExpiryT, Redis
 from redis.asyncio.connection import ConnectionPool
 from redis.asyncio.lock import Lock
 
@@ -90,8 +90,8 @@ class RedisStorage(BaseStorage):
         self,
         redis: Redis,
         key_builder: Optional[KeyBuilder] = None,
-        state_ttl: Optional[int] = None,
-        data_ttl: Optional[int] = None,
+        state_ttl: Optional[ExpiryT] = None,
+        data_ttl: Optional[ExpiryT] = None,
         lock_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """


### PR DESCRIPTION
# Description

Use `float` and `datetime.timedelta` type hints in `RedisStorage.state_ttl` and `RedisStorage.data_ttl`.

Let's reuse type hint `ExpiryT` from redis.

## Type of change

- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
