### PR TITLE
fix unregister handlers

### DIFF
--- a/aiogram/dispatcher/handler.py
+++ b/aiogram/dispatcher/handler.py
@@ -76,8 +76,8 @@ class Handler:
         """
         for handler_obj in self.handlers:
             registered = handler_obj.handler
-            if handler is registered:
-                self.handlers.remove(handler_obj)
+            if handler in self.handlers:
+                self.handlers.remove(handler)
                 return True
         raise ValueError('This handler is not registered!')
 


### PR DESCRIPTION
# Description
Fixed unregister function in dispatcher. In release version it just delete first of handlers

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Message and query handlers was delete by new realisation and bot starts correctly without deleted methods.
- [x] Test A

**Test Configuration**:
* Operating System: Ubuntu 20.0.4
* Python version: python3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
