### PR TITLE
Fix copying of the state, now copying return the same state, not copy

### DIFF
--- a/CHANGES/927.bugfix.rst
+++ b/CHANGES/927.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the ability to copy the state, now copying the state will return the same state.

--- a/aiogram/dispatcher/fsm/state.py
+++ b/aiogram/dispatcher/fsm/state.py
@@ -54,6 +54,12 @@ class State:
             return True
         return raw_state == self.state
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo=None):
+        return self
+
 
 class StatesGroupMeta(type):
     __parent__: "Optional[Type[StatesGroup]]"

--- a/tests/test_dispatcher/test_filters/test_state.py
+++ b/tests/test_dispatcher/test_filters/test_state.py
@@ -1,3 +1,4 @@
+from copy import deepcopy, copy
 from inspect import isclass
 
 import pytest
@@ -50,3 +51,14 @@ class TestStateFilter:
     async def test_filter(self, state, current_state, result):
         f = StateFilter(state=state)
         assert bool(await f(obj=Update(update_id=42), raw_state=current_state)) is result
+
+    @pytestmark
+    async def test_state_copy(self):
+        class SG(StatesGroup):
+            state = State()
+
+        assert SG.state is deepcopy(SG.state)
+        assert SG.state is copy(SG.state)
+
+        assert SG is copy(SG)
+        assert SG is deepcopy(SG)


### PR DESCRIPTION
# Description

Fix the ability to copy the state, now copying the state will return the same state.


## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual testing
- [x] Add unit tests

**Test Configuration**:
* Operating System: Manjaro 21.2.6 Qonos
* Python version: 3.10.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
