### PR TITLE
Add `full_name` shortcut for `Chat`

### DIFF
--- a/CHANGES/929.feature.rst
+++ b/CHANGES/929.feature.rst
@@ -1,0 +1,1 @@
+Added `full_name` shortcut for `Chat` object

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -76,6 +76,21 @@ class Chat(TelegramObject):
         shift = int(-1 * pow(10, len(short_id) + 2))
         return shift - self.id
 
+    @property
+    def full_name(self) -> str:
+        """Get full name of the Chat.
+
+        For private chat it is first_name + last_name.
+        For other chat types it is title.
+        """
+        if self.title is not None:
+            return self.title
+
+        if self.last_name is not None:
+            return f"{self.first_name} {self.last_name}"
+
+        return self.first_name
+
     def ban_sender_chat(self, sender_chat_id: int) -> BanChatSenderChat:
         from ..methods import BanChatSenderChat
 

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -89,7 +89,7 @@ class Chat(TelegramObject):
         if self.last_name is not None:
             return f"{self.first_name} {self.last_name}"
 
-        return self.first_name
+        return f"{self.first_name}"
 
     def ban_sender_chat(self, sender_chat_id: int) -> BanChatSenderChat:
         from ..methods import BanChatSenderChat

--- a/tests/test_api/test_types/test_chat.py
+++ b/tests/test_api/test_types/test_chat.py
@@ -1,3 +1,7 @@
+from typing import Optional
+
+from pytest import mark, param
+
 from aiogram.types import Chat
 
 
@@ -15,3 +19,24 @@ class TestChat:
         method = chat.unban_sender_chat(sender_chat_id=-1337)
         assert method.chat_id == chat.id
         assert method.sender_chat_id == -1337
+
+    @mark.parametrize(
+        "first,last,title,chat_type,result",
+        [
+            param("First", None, None, "private", "First", id="private_first_only"),
+            param("First", "Last", None, "private", "First Last", id="private_with_last"),
+            param(None, None, "Title", "group", "Title", id="group_with_title"),
+            param(None, None, "Title", "supergroup", "Title", id="supergroup_with_title"),
+            param(None, None, "Title", "channel", "Title", id="channel_with_title"),
+        ],
+    )
+    def test_full_name(
+        self,
+        first: Optional[str],
+        last: Optional[str],
+        title: Optional[str],
+        chat_type: str,
+        result: str,
+    ):
+        chat = Chat(id=42, first_name=first, last_name=last, title=title, type=chat_type)
+        assert chat.full_name == result


### PR DESCRIPTION
# Description

In some cases it's handy to get user's current params via `get_chat` method.
Then you want to use `full_name` shortcut similar to `User`, but it's absent for `Chat`... :(

So, may be add it? :)

## Type of change

Please delete options that are not relevant.
- [x] Ported 2.x feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
