### PR TITLE
Add changelog hint extension

### DIFF
--- a/.github/workflows/pull_request_changelog.yml
+++ b/.github/workflows/pull_request_changelog.yml
@@ -53,7 +53,7 @@ jobs:
 
             You need to add a brief description of the changes to the `CHANGES` directory.
 
-            For example, you can run `towncrier create <issue>.<type>` to create a file in the change directory and then write a description on that file.
+            For example, you can run `towncrier create <issue>.<type>.rst` to create a file in the change directory and then write a description on that file.
 
             Read more at [Towncrier docs](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments)
 


### PR DESCRIPTION
# Description

Recommended line creates file without extension:
`towncrier create <issue>.<type>`

Let's change it to:
`towncrier create <issue>.<type>.rst`


## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
