### PR TITLE
command filter now can be sets with BotCommand object

### DIFF
--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -71,13 +71,12 @@ class Command(Filter):
         elif isinstance(commands, Iterable):
             if not all(map(lambda cmd: isinstance(cmd, str), commands)):
                 raise ValueError(
-                    "Command filter doesn't support {} as input. "
-                    "It only supports str, BotCommand object or their Iterable"
+                    "Command filter only supports str, BotCommand object or their Iterable"
                 )
         else:
             raise ValueError(
                 "Command filter doesn't support {} as input. "
-                "It only supports str, BotCommand object or their Iterable"
+                "It only supports str, BotCommand object or their Iterable".format(type(commands))
             )
         commands = [cmd.command if isinstance(cmd, BotCommand) else cmd for cmd in commands]
 

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -69,7 +69,7 @@ class Command(Filter):
         if isinstance(commands, (str, BotCommand)):
             commands = (commands,)
         elif isinstance(commands, Iterable):
-            if not all(map(lambda cmd: isinstance(cmd, str), commands)):
+            if not all(map(lambda cmd: isinstance(cmd, (str, BotCommand)), commands)):
                 raise ValueError(
                     "Command filter only supports str, BotCommand object or their Iterable"
                 )

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -34,7 +34,7 @@ class Command(Filter):
     By default this filter is registered for messages and edited messages handlers.
     """
 
-    def __init__(self, commands: Union[Iterable[str], Iterable[BotCommand], str, BotCommand],
+    def __init__(self, commands: Union[Iterable[Union[str, BotCommand]], str, BotCommand],
                  prefixes: Union[Iterable, str] = '/',
                  ignore_case: bool = True,
                  ignore_mention: bool = False,

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -10,7 +10,7 @@ from babel.support import LazyProxy
 
 from aiogram import types
 from aiogram.dispatcher.filters.filters import BoundFilter, Filter
-from aiogram.types import CallbackQuery, ChatType, InlineQuery, Message, Poll, ChatMemberUpdated
+from aiogram.types import CallbackQuery, ChatType, InlineQuery, Message, Poll, ChatMemberUpdated, BotCommand
 
 ChatIDArgumentType = typing.Union[typing.Iterable[typing.Union[int, str]], str, int]
 
@@ -34,7 +34,7 @@ class Command(Filter):
     By default this filter is registered for messages and edited messages handlers.
     """
 
-    def __init__(self, commands: Union[Iterable, str],
+    def __init__(self, commands: Union[Iterable[str], Iterable[BotCommand], str, BotCommand],
                  prefixes: Union[Iterable, str] = '/',
                  ignore_case: bool = True,
                  ignore_mention: bool = False,
@@ -66,8 +66,10 @@ class Command(Filter):
                 @dp.message_handler(commands=['myCommand'], commands_ignore_caption=False, content_types=ContentType.ANY)
                 @dp.message_handler(Command(['myCommand'], ignore_caption=False), content_types=[ContentType.TEXT, ContentType.DOCUMENT])
         """
-        if isinstance(commands, str):
+        if isinstance(commands, str) or isinstance(commands, BotCommand):
             commands = (commands,)
+        if isinstance(commands, Iterable):
+            commands = [cmd.command if isinstance(cmd, BotCommand) else cmd for cmd in commands]
 
         self.commands = list(map(str.lower, commands)) if ignore_case else commands
         self.prefixes = prefixes

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -68,8 +68,14 @@ class Command(Filter):
         """
         if isinstance(commands, (str, BotCommand)):
             commands = (commands,)
-        if isinstance(commands, Iterable):
-            commands = [cmd.command if isinstance(cmd, BotCommand) else cmd for cmd in commands]
+        elif isinstance(commands, Iterable):
+            pass
+        else:
+            raise ValueError(
+                "Command filter doesn't support {} as input. "
+                "It only supports str, BotCommand object or their Iterable"
+            )
+        commands = [cmd.command if isinstance(cmd, BotCommand) else cmd for cmd in commands]
 
         self.commands = list(map(str.lower, commands)) if ignore_case else commands
         self.prefixes = prefixes

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -69,7 +69,7 @@ class Command(Filter):
         if isinstance(commands, (str, BotCommand)):
             commands = (commands,)
         elif isinstance(commands, Iterable):
-            if not all(map(lambda cmd: isinstance(cmd, (str, BotCommand)), commands)):
+            if not all(isinstance(cmd, (str, BotCommand)) for cmd in commands):
                 raise ValueError(
                     "Command filter only supports str, BotCommand object or their Iterable"
                 )

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -66,7 +66,7 @@ class Command(Filter):
                 @dp.message_handler(commands=['myCommand'], commands_ignore_caption=False, content_types=ContentType.ANY)
                 @dp.message_handler(Command(['myCommand'], ignore_caption=False), content_types=[ContentType.TEXT, ContentType.DOCUMENT])
         """
-        if isinstance(commands, str) or isinstance(commands, BotCommand):
+        if isinstance(commands, (str, BotCommand)):
             commands = (commands,)
         if isinstance(commands, Iterable):
             commands = [cmd.command if isinstance(cmd, BotCommand) else cmd for cmd in commands]

--- a/aiogram/dispatcher/filters/builtin.py
+++ b/aiogram/dispatcher/filters/builtin.py
@@ -69,7 +69,11 @@ class Command(Filter):
         if isinstance(commands, (str, BotCommand)):
             commands = (commands,)
         elif isinstance(commands, Iterable):
-            pass
+            if not all(map(lambda cmd: isinstance(cmd, str), commands)):
+                raise ValueError(
+                    "Command filter doesn't support {} as input. "
+                    "It only supports str, BotCommand object or their Iterable"
+                )
         else:
             raise ValueError(
                 "Command filter doesn't support {} as input. "

--- a/tests/test_dispatcher/test_filters/test_builtin.py
+++ b/tests/test_dispatcher/test_filters/test_builtin.py
@@ -141,8 +141,9 @@ async def test_commands_filter_not_checked():
     assert not await start_filter.check(message_with_command)
 
 
-@pytest.mark.asyncio
-async def test_commands_filter_not_checked():
+def test_commands_filter_not_checked():
     with pytest.raises(ValueError):
         start_filter = Command(commands=42)  # noqa
+    with pytest.raises(ValueError):
+        start_filter = Command(commands=[42])  # noqa
 

--- a/tests/test_dispatcher/test_filters/test_builtin.py
+++ b/tests/test_dispatcher/test_filters/test_builtin.py
@@ -141,7 +141,7 @@ async def test_commands_filter_not_checked():
     assert not await start_filter.check(message_with_command)
 
 
-def test_commands_filter_not_checked():
+def test_commands_filter_raises_error():
     with pytest.raises(ValueError):
         start_filter = Command(commands=42)  # noqa
     with pytest.raises(ValueError):

--- a/tests/test_dispatcher/test_filters/test_builtin.py
+++ b/tests/test_dispatcher/test_filters/test_builtin.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Set, Union, Iterable
 from datetime import datetime
 
 import pytest
@@ -6,9 +6,9 @@ import pytest
 from aiogram.dispatcher.filters.builtin import (
     Text,
     extract_chat_ids,
-    ChatIDArgumentType, ForwardedMessageFilter, IDFilter,
+    ChatIDArgumentType, ForwardedMessageFilter, IDFilter, Command,
 )
-from aiogram.types import Message
+from aiogram.types import Message, BotCommand
 from tests.types.dataset import MESSAGE, MESSAGE_FROM_CHANNEL
 
 
@@ -108,3 +108,34 @@ class TestIDFilter:
         filter = IDFilter(chat_id=message_from_channel.chat.id)
 
         assert await filter.check(message_from_channel)
+
+
+@pytest.mark.parametrize("command", [
+    "/start",
+    "/start some args",
+])
+@pytest.mark.parametrize("cmd_filter", [
+    "start",
+    ("start",),
+    BotCommand(command="start", description="my desc"),
+    (BotCommand(command="start", description="bar"),),
+    (BotCommand(command="start", description="foo"), "help"),
+])
+@pytest.mark.asyncio
+async def test_commands_filter(command: str, cmd_filter: Union[Iterable[Union[str, BotCommand]], str, BotCommand]):
+    message_with_command = Message(**MESSAGE)
+    message_with_command.text = command
+
+    start_filter = Command(commands=cmd_filter)
+
+    assert await start_filter.check(message_with_command)
+
+
+@pytest.mark.asyncio
+async def test_commands_filter_not_checked():
+    message_with_command = Message(**MESSAGE)
+    message_with_command.text = "/start"
+
+    start_filter = Command(commands=["help", BotCommand("about", "my desc")])
+
+    assert not await start_filter.check(message_with_command)

--- a/tests/test_dispatcher/test_filters/test_builtin.py
+++ b/tests/test_dispatcher/test_filters/test_builtin.py
@@ -139,3 +139,10 @@ async def test_commands_filter_not_checked():
     start_filter = Command(commands=["help", BotCommand("about", "my desc")])
 
     assert not await start_filter.check(message_with_command)
+
+
+@pytest.mark.asyncio
+async def test_commands_filter_not_checked():
+    with pytest.raises(ValueError):
+        start_filter = Command(commands=42)  # noqa
+


### PR DESCRIPTION
# Description

it will be usefull for bots using SetMyCommands api call. 
Example:
```python
ABOUT_CMD = BotCommand("about", "few info about bot, its creater etc")
...
@dp.message_handler(commands=ABOUT_CMD)
async def about_cmd_handler(m: Message):
    ...
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.8.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes.
Few tests are not pass. Probably problem is in windows  ( https://t.me/aiogram_ru/1176021 ) 
