### PR TITLE
Automatically put `2.x` label on new pull requests to `dev-2.x`

### DIFF
--- a/.github/workflows/label_pr.yaml
+++ b/.github/workflows/label_pr.yaml
@@ -1,0 +1,17 @@
+name: Label new pull request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - dev-2.x
+
+jobs:
+  put-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 2.x label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 2.x


### PR DESCRIPTION
# Description

Add GitHub Actions workflow to automatically put `2.x` label on new pull requests to `dev-2.x` branch.