### PR TITLE
Automatically put `3.x` label on new pull requests to `dev-3.x`

### DIFF
--- a/.github/workflows/label_pr.yaml
+++ b/.github/workflows/label_pr.yaml
@@ -1,0 +1,17 @@
+name: Label new pull request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - dev-3.x
+
+jobs:
+  put-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 3.x label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 3.x


### PR DESCRIPTION
# Description

Add GitHub Actions workflow to automatically put `3.x` label on new pull requests to `dev-3.x` branch.