### PR TITLE
#944 Rename "extract()" to "extract_from()" for entities

### DIFF
--- a/CHANGES/944.misc.rst
+++ b/CHANGES/944.misc.rst
@@ -1,0 +1,1 @@
+`MessageEntity` method `get_text` was removed and `extract` was renamed to `extract_from`

--- a/aiogram/types/message_entity.py
+++ b/aiogram/types/message_entity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from ..utils.text_decorations import add_surrogates, remove_surrogates
@@ -29,7 +30,15 @@ class MessageEntity(MutableTelegramObject):
     language: Optional[str] = None
     """*Optional*. For 'pre' only, the programming language of the entity text"""
 
-    def extract(self, text: str) -> str:
+    def extract_from(self, text: str) -> str:
         return remove_surrogates(
             add_surrogates(text)[self.offset * 2 : (self.offset + self.length) * 2]
         )
+
+    def extract(self, text: str) -> str:
+        warnings.warn(
+            "Method `MessageEntity.get_text(...)` deprecated and will be removed in 3.0b5.\n"
+            " Use `MessageEntity.extract(...)` instead.",
+            DeprecationWarning,
+        )
+        return self.extract_from(text=text)

--- a/aiogram/types/message_entity.py
+++ b/aiogram/types/message_entity.py
@@ -37,8 +37,8 @@ class MessageEntity(MutableTelegramObject):
 
     def extract(self, text: str) -> str:
         warnings.warn(
-            "Method `MessageEntity.get_text(...)` deprecated and will be removed in 3.0b5.\n"
-            " Use `MessageEntity.extract(...)` instead.",
+            "Method `MessageEntity.extract(...)` deprecated and will be removed in 3.0b5.\n"
+            " Use `MessageEntity.extract_from(...)` instead.",
             DeprecationWarning,
         )
         return self.extract_from(text=text)

--- a/tests/test_api/test_types/test_message_entity.py
+++ b/tests/test_api/test_types/test_message_entity.py
@@ -3,11 +3,11 @@ from tests.deprecated import check_deprecated
 
 
 class TestMessageEntity:
-    def test_extract(self):
+    def test_extract_from(self):
         entity = MessageEntity(type="hashtag", length=4, offset=5)
         assert entity.extract_from("#foo #bar #baz") == "#bar"
 
-    def test_get_text(self):
+    def test_extract(self):
         entity = MessageEntity(type="hashtag", length=4, offset=5)
         with check_deprecated("3.0b5", exception=AttributeError):
             assert entity.extract("#foo #bar #baz") == "#bar"

--- a/tests/test_api/test_types/test_message_entity.py
+++ b/tests/test_api/test_types/test_message_entity.py
@@ -1,7 +1,13 @@
 from aiogram.types import MessageEntity
+from tests.deprecated import check_deprecated
 
 
 class TestMessageEntity:
     def test_extract(self):
         entity = MessageEntity(type="hashtag", length=4, offset=5)
-        assert entity.extract("#foo #bar #baz") == "#bar"
+        assert entity.extract_from("#foo #bar #baz") == "#bar"
+
+    def test_get_text(self):
+        entity = MessageEntity(type="hashtag", length=4, offset=5)
+        with check_deprecated("3.0b5", exception=AttributeError):
+            assert entity.extract("#foo #bar #baz") == "#bar"


### PR DESCRIPTION
# Description

Renamed `MessageEntity.extract` to `MessageEntity.extract_from`
Removed `MessageEntity.get_text`

Fixes #944 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
