### PR TITLE
Fix default lock kwargs in RedisEventIsolation

### DIFF
--- a/CHANGES/972.bugfix.rst
+++ b/CHANGES/972.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed default lock kwargs in RedisEventIsolation.

--- a/aiogram/dispatcher/fsm/storage/redis.py
+++ b/aiogram/dispatcher/fsm/storage/redis.py
@@ -93,7 +93,6 @@ class RedisStorage(BaseStorage):
         key_builder: Optional[KeyBuilder] = None,
         state_ttl: Optional[ExpiryT] = None,
         data_ttl: Optional[ExpiryT] = None,
-        lock_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         :param redis: Instance of Redis connection
@@ -104,13 +103,10 @@ class RedisStorage(BaseStorage):
         """
         if key_builder is None:
             key_builder = DefaultKeyBuilder()
-        if lock_kwargs is None:
-            lock_kwargs = DEFAULT_REDIS_LOCK_KWARGS
         self.redis = redis
         self.key_builder = key_builder
         self.state_ttl = state_ttl
         self.data_ttl = data_ttl
-        self.lock_kwargs = lock_kwargs
 
     @classmethod
     def from_url(
@@ -202,9 +198,11 @@ class RedisEventIsolation(BaseEventIsolation):
     ) -> None:
         if key_builder is None:
             key_builder = DefaultKeyBuilder()
+        if lock_kwargs is None:
+            lock_kwargs = DEFAULT_REDIS_LOCK_KWARGS
         self.redis = redis
         self.key_builder = key_builder
-        self.lock_kwargs = lock_kwargs or {}
+        self.lock_kwargs = lock_kwargs
 
     @classmethod
     def from_url(


### PR DESCRIPTION
# Description

After the event isolation was rewritten, default Redis lock kwargs, specifically timeout, were left out, causing locks to be permanent, which might result in some users being continuously ignored in case the bot is restarted during the update processing.

## Type of change

- Bug fix (non-breaking change that fixes an issue)

# How has this been tested?

## Test Configuration
- Operating system: Windows 11
- Python version: 3.10.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [ ] My changes are compatible with minimum requirements of the project
- [ ] I have made corresponding changes to the documentation
