### PR TITLE
Prevent to crash polling

### DIFF
--- a/CHANGES/995.misc.rst
+++ b/CHANGES/995.misc.rst
@@ -1,0 +1,1 @@
+Fixed polling crash when Telegram Bot API raises HTTP 429 status-code.


### PR DESCRIPTION
# Description

Sometime Telegram restart the server with HTTP 429 error, so that's mean we need to handle it in polling mode

## Type of change

- Bug fix (non-breaking change that fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
- [x] I have made corresponding changes to the documentation
