### PR TITLE
Add type-checking to webhook (parse_update)

### DIFF
--- a/aiogram/dispatcher/webhook.py
+++ b/aiogram/dispatcher/webhook.py
@@ -116,6 +116,8 @@ class WebhookRequestHandler(web.View):
         :return: :class:`aiogram.types.Update`
         """
         data = await self.request.json()
+        if isinstance(data, list):
+            data = data[0]
         return types.Update(**data)
 
     async def post(self):


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change.

e.g. Add a new awesome feature or Fix documentation typo.

Please also include relevant motivation and context.
If you are fixing an issue, specify what issue is fixed.

e.g. Fix #12345
-->

I tried to configure aiogram with [Sendpulse](https://sendpulse.com/), but I get an error when receiving a webhook: 

```
.../aiogram/dispatcher/webhook.py", line 122, in parse_update
    return types.Update(**data)
TypeError: MetaTelegramObject object argument after ** must be a mapping, not a list
```

I figured out that sendpulse sends a hook like this: `[{...}]`

Some minor changes solved this problem.

## Type of change

<!--
Please delete options that are not relevant.
-->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?
`$ curl -X POST https://example.com/webhook -d '[{"from": "me"}]'`
`ok%`

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
-->

## Test Configuration
- Operating system: Ubuntu 20.04.5 LTS
- Python version: Python 3.8.10
- Aiogram version: 2.22.1

# Checklist:

<!--
Please delete options that are not relevant to your change.
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors
- [ ] My changes are compatible with minimum requirements of the project