### PR TITLE
Fixed possible incorrect escaping of strings inside collections.

### DIFF
--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -166,7 +166,10 @@ def compose_data(params=None, files=None):
 
     if params:
         for key, value in params.items():
-            data.add_field(key, str(value))
+            if isinstance(value, (list, dict)):
+                data.add_field(key, json.dumps(value))
+            else:
+                data.add_field(key, str(value))
 
     if files:
         for key, f in files.items():


### PR DESCRIPTION
# Description
By default if you call `str()` on collection python will escape strings inside of it using single quotes, which will cause

> Can't parse custom emoji identifiers json object

error when calling `getCustomEmojiStickers()`. `json.dumps()` escapes strings by double quotes so no error occurs.

## Type of change
- Bug fix (non-breaking change that fixes an issue)

## Test Configuration
- Operating system: Windows 11  22000.708
- Python version: 3.10.6

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors
- [ ] My changes are compatible with minimum requirements of the project
