### PR TITLE
Fix typehints for `Message` media group methods

### DIFF
--- a/CHANGES/1029.doc.rst
+++ b/CHANGES/1029.doc.rst
@@ -1,0 +1,1 @@
+Fix typehints for `Message` `reply_media_group` & `answer_media_group` methods

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -897,7 +897,7 @@ class Message(TelegramObject):
 
     def reply_media_group(
         self,
-        media: List[Union[InputMediaPhoto, InputMediaVideo]],
+        media: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
         disable_notification: Optional[bool] = None,
         allow_sending_without_reply: Optional[bool] = None,
     ) -> SendMediaGroup:
@@ -921,7 +921,7 @@ class Message(TelegramObject):
 
     def answer_media_group(
         self,
-        media: List[Union[InputMediaPhoto, InputMediaVideo]],
+        media: List[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
         disable_notification: Optional[bool] = None,
     ) -> SendMediaGroup:
         """

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
     from .game import Game
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
+    from .input_media_audio import InputMediaAudio
+    from .input_media_document import InputMediaDocument
     from .input_media_photo import InputMediaPhoto
     from .input_media_video import InputMediaVideo
     from .invoice import Invoice


### PR DESCRIPTION
# Fix typehints for `Message` methods
Fix typehints for `Message` `reply_media_group` & `answer_media_group` methods

Fix typehints to be the same as in:
- BotAPI `sendMediaGroup`: [link](https://core.telegram.org/bots/api#sendmediagroup)
- aiogram dev-3 `send_media_group`: [link](https://github.com/aiogram/aiogram/blob/dev-3.x/aiogram/client/bot.py#L1065)
- aiogram dev-3 documentation: [link](https://docs.aiogram.dev/en/dev-3.x/api/methods/send_media_group.html)

## Type of change
- Bug fix (non-breaking change that fixes an issue)
- Documentation (typos, code examples or any documentation update)

# How has this been tested?
Local test run.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
- [x] I have made corresponding changes to the documentation
