### PR TITLE
Fix Handler unregister

### DIFF
--- a/aiogram/dispatcher/handler.py
+++ b/aiogram/dispatcher/handler.py
@@ -74,11 +74,12 @@ class Handler:
         :param handler: callback
         :return:
         """
+        
         for handler_obj in self.handlers:
-            registered = handler_obj.handler
-            if handler in self.handlers:
-                self.handlers.remove(handler)
+            if handler == handler_obj or handler == handler_obj.handler:
+                self.handlers.remove(handler_obj)
                 return True
+            
         raise ValueError('This handler is not registered!')
 
     async def notify(self, *args):


### PR DESCRIPTION
Add checking for handler_obj.handler

# Description
At Handler unregister method variable registered was unused so removing handlers by handler function was did`t work. That fix add checking of handler_obj.handler.
 
## Type of change
- Bug fix

# How has this been tested?
- Register handler with dp.register_message_handler(some_func) and then call dp.messages_handler.unregister(some_func)

## Test Configuration
-Python version: 3.9.1
