### PR TITLE
Removed an old now non-working feature from documentation

### DIFF
--- a/CHANGES/1060.doc.rst
+++ b/CHANGES/1060.doc.rst
@@ -1,0 +1,1 @@
+Removed an old now non-working feature

--- a/aiogram/dispatcher/router.py
+++ b/aiogram/dispatcher/router.py
@@ -179,11 +179,9 @@ class Router:
         self._parent_router = router
         router.sub_routers.append(self)
 
-    def include_router(self, router: Union[Router, str]) -> Router:
+    def include_router(self, router: Router) -> Router:
         """
         Attach another router.
-
-        Can be attached directly or by import string in format "<module>:<attribute>"
 
         :param router:
         :return:

--- a/aiogram/dispatcher/router.py
+++ b/aiogram/dispatcher/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Final, Generator, List, Optional, Set, Union
+from typing import Any, Dict, Final, Generator, List, Optional, Set
 
 from ..types import TelegramObject
 from .event.bases import REJECTED, UNHANDLED


### PR DESCRIPTION
# Description
`include_router` method in `Router` has an old now non-working feature still documented. It was removed in #897.

## Type of change
- Documentation (typos, documentation)