### PR TITLE
Fix warning about asyncio marker in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def pytest_addoption(parser):
         default=None,
         help="run tests which require redis connection",
     )
+    parser.addini("asyncio_mode", "", default='auto')
 
 
 def pytest_configure(config):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,8 +3,6 @@ import pytest
 from aiogram import Bot, types
 from . import BOT_ID, FakeTelegram
 
-pytestmark = pytest.mark.asyncio
-
 
 async def test_get_me(bot: Bot):
     """ getMe method test """

--- a/tests/test_bot/test_bot_download_file.py
+++ b/tests/test_bot/test_bot_download_file.py
@@ -13,8 +13,6 @@ from aiogram.utils.json import json
 from tests import TOKEN
 from tests.types.dataset import FILE
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest_asyncio.fixture(name='bot')
 async def bot_fixture():

--- a/tests/test_contrib/test_fsm_storage/test_storage.py
+++ b/tests/test_contrib/test_fsm_storage/test_storage.py
@@ -6,10 +6,7 @@ from redis.asyncio.connection import Connection, ConnectionPool
 
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from aiogram.contrib.fsm_storage.redis import RedisStorage, RedisStorage2
-from aiogram.types import Chat, User
-from tests.types.dataset import CHAT, USER
 
-pytestmark = pytest.mark.asyncio
 
 @pytest_asyncio.fixture()
 @pytest.mark.redis

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -2,8 +2,6 @@ import pytest
 
 from aiogram import Dispatcher, Bot
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestDispatcherInit:
     async def test_successful_init(self, bot):

--- a/tests/test_dispatcher/test_middlewares/test_lifetimecontroller.py
+++ b/tests/test_dispatcher/test_middlewares/test_lifetimecontroller.py
@@ -1,9 +1,6 @@
 from unittest.mock import AsyncMock
 
-import pytest
 from aiogram.dispatcher.middlewares import LifetimeControllerMiddleware
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_no_skip():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,9 +6,6 @@ import pytest
 from aiogram.dispatcher.filters import Text, CommandStart
 from aiogram.types import Message, CallbackQuery, InlineQuery, Poll
 
-# enable asyncio mode
-pytestmark = pytest.mark.asyncio
-
 
 def data_sample_1():
     return [

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -4,8 +4,6 @@ import pytest_asyncio
 from aiogram import Bot, types
 from . import FakeTelegram
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest_asyncio.fixture(name="message")
 async def message_fixture(bot: Bot):

--- a/tests/test_utils/test_deep_linking.py
+++ b/tests/test_utils/test_deep_linking.py
@@ -8,8 +8,6 @@ from aiogram.utils.deep_linking import (
 )
 from tests.types import dataset
 
-# enable asyncio mode
-pytestmark = pytest.mark.asyncio
 
 PAYLOADS = [
     'foo',

--- a/tests/types/test_chat.py
+++ b/tests/types/test_chat.py
@@ -1,10 +1,7 @@
-import pytest
-
 from aiogram import Bot, types
 from .dataset import CHAT, FULL_CHAT
 from .. import FakeTelegram
 
-pytestmark = pytest.mark.asyncio
 
 chat = types.Chat(**CHAT)
 

--- a/tests/types/test_mixins.py
+++ b/tests/types/test_mixins.py
@@ -14,8 +14,6 @@ from aiogram.utils.json import json
 from tests import TOKEN
 from tests.types.dataset import FILE
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest_asyncio.fixture(name='bot')
 async def bot_fixture():


### PR DESCRIPTION
# Description

Made a fix to avoid asyncio marker warnings that were applied to non-asynchronous tests.

Now you do not need to put this marker in every file with asynchronous tests, as it is applied automatically.

Fix #1005

## Type of change

This is just a bug fix in tests, not breaking change) 

# How has this been tested?

To test the fix, you can run tests and make sure there are no warnings about `pytest.mark.asyncio`.

## Test Configuration

- All tests run with the `make test` command

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
