### PR TITLE
Changed `url` in `TelegramEntityTooLarge`

### DIFF
--- a/aiogram/exceptions.py
+++ b/aiogram/exceptions.py
@@ -103,7 +103,7 @@ class RestartingTelegram(TelegramServerError):
 
 
 class TelegramEntityTooLarge(TelegramNetworkError):
-    url = "https://core.telegram.org/bots/api#sending-files"
+    url = "https://core.telegram.org/api/entities#entity-length"
 
 
 class ClientDecodeError(AiogramError):


### PR DESCRIPTION
# Description
Changed `url` in `TelegramEntityTooLarge` to a more appropriate documentation link, because [JSON list of RPC errors](https://core.telegram.org/file/464001173/109f8/k9gTkjfzNHs.87735.json/de2c1dc08a54bde597) and error key `ENTITY_BOUNDS_INVALID` contains link to `https://core.telegram.org/api/entities#entity-length` instead of `https://core.telegram.org/bots/api#sending-files`.

## Type of change
- Attribute used as documentation