### PR TITLE
Add error handling example

### DIFF
--- a/CHANGES/1099.doc.rst
+++ b/CHANGES/1099.doc.rst
@@ -1,1 +1,1 @@
-Add error handling example `examples/error_handling.py`
+Added error handling example `examples/error_handling.py`

--- a/CHANGES/1099.doc.rst
+++ b/CHANGES/1099.doc.rst
@@ -1,0 +1,1 @@
+Add error handling example `examples/error_handling.py`

--- a/examples/error_handling.py
+++ b/examples/error_handling.py
@@ -3,9 +3,8 @@ import html
 import logging
 
 from aiogram import Bot, Dispatcher, types
-from aiogram.filters import Command, ExceptionTypeFilter, CommandObject, ExceptionMessageFilter
+from aiogram.filters import Command, CommandObject, ExceptionMessageFilter, ExceptionTypeFilter
 from aiogram.types import ErrorEvent
-
 
 TOKEN = "42:TOKEN"
 
@@ -19,7 +18,6 @@ class InvalidAge(Exception):
 
 
 class InvalidName(Exception):
-
     def __init__(self, message: str):
         super().__init__(message)
 

--- a/examples/error_handling.py
+++ b/examples/error_handling.py
@@ -1,0 +1,103 @@
+import asyncio
+import html
+import logging
+
+from aiogram import Bot, Dispatcher, types
+from aiogram.filters import Command, ExceptionTypeFilter, CommandObject
+from aiogram.types import ErrorEvent
+
+
+# TOKEN = "42:TOKEN"
+dp = Dispatcher()
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidAge(Exception):
+    pass
+
+
+class InvalidName(Exception):
+    pass
+
+
+@dp.errors(ExceptionTypeFilter(InvalidAge))
+async def handle_invalid_age_exception(event: ErrorEvent, bot: Bot) -> None:
+    """
+    This handler receives only error events with `InvalidAge` exception type.
+    """
+    # To get the original event that caused the exception you can use `event.update` property.
+    # In this case it will be `Message` object.
+    # To get the exception itself you can use `event.exception` property.
+    # In this case we filter errors, so we can be sure `event.exception` is an `InvalidAge` object.
+    assert isinstance(event.exception, InvalidAge)
+    logger.error("Error caught: %r while processing %r", event.exception, event.update)
+
+    assert event.update.message is not None
+    chat_id = event.update.message.chat.id
+
+    # Bot instance is passed to the handler as a keyword argument.
+    # We can use `bot.send_message` method to send a message to the user, logging the error.
+    text = f"Error caught: {html.escape(repr(event.exception))}"
+    await bot.send_message(chat_id=chat_id, text=text)
+
+
+@dp.errors()
+async def handle_all_exceptions(event: ErrorEvent) -> None:
+    """
+    This handler receives error events with any exception type.
+    """
+    # Because we specified `ExceptionTypeFilter` with `InvalidAge` exception type earlier,
+    # this handler will receive error events with any exception type except `InvalidAge`.
+    logger.error("Error caught: %r while processing %r", event.exception, event.update)
+
+
+@dp.message(Command(commands=["age"]))
+async def handle_set_age(message: types.Message, command: CommandObject) -> None:
+    """
+    This handler receives only messages with `/age` command.
+
+    If the user sends a message with `/age` command, but the age is invalid,
+    the `InvalidAge` exception will be raised and the `handle_invalid_age_exception`
+    handler will be called.
+    """
+    # To get the command object you can use `command` keyword argument with `CommandObject` type.
+    # To get the command arguments you can use `command.args` property.
+    age = command.args
+    if not age:
+        raise InvalidAge("No age provided. Please provide your age as a command argument.")
+
+    # If the age is invalid, raise an exception.
+    if not age.isdigit():
+        raise InvalidAge("Age should be a number")
+
+    # If the age is valid, send a message to the user.
+    age = int(age)
+    await message.reply(text=f"Your age is {age}")
+
+
+@dp.message(Command(commands=["name"]))
+async def handle_set_name(message: types.Message, command: CommandObject) -> None:
+    """
+    This handler receives only messages with `/name` command.
+    """
+    # To get the command object you can use `command` keyword argument with `CommandObject` type.
+    # To get the command arguments you can use `command.args` property.
+    name = command.args
+    if not name:
+        raise InvalidName("No name provided. Please provide your name as a command argument.")
+
+    # If the name is valid, send a message to the user.
+    await message.reply(text=f"Your name is {name}")
+
+
+async def main() -> None:
+    # Initialize Bot instance with a default parse mode which will be passed to all API calls
+    bot = Bot(TOKEN, parse_mode="HTML")
+    # And the run events dispatching
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(main())


### PR DESCRIPTION
# Add error handling example

Add error handling example `examples/error_handling.py` where following features used:
- Using error handler: `dp.error`;
- Using error filter: `ExceptionTypeFilter`;
- Using error filter: `ExceptionMessageFilter`;
- Using command object: `CommandObject`;
- Getting `bot` instance passed to a handler;

My motivation is that currently using error handlers is not that obvious.

## Type of change
- Documentation (typos, code examples or any documentation update)

# How has this been tested?
Locally.
Also, `make lint` was used.

## Test Configuration
- Windows 10
- Python version: 3.10.8

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
- [x] I have made corresponding changes to the documentation
