### PR TITLE
adapt ChatPermissions for Bot API 6.5

### DIFF
--- a/aiogram/types/chat_permissions.py
+++ b/aiogram/types/chat_permissions.py
@@ -9,7 +9,13 @@ class ChatPermissions(base.TelegramObject):
     https://core.telegram.org/bots/api#chatpermissions
     """
     can_send_messages: base.Boolean = fields.Field()
-    can_send_media_messages: base.Boolean = fields.Field()
+    can_send_media_messages: base.Boolean = fields.Field() # isn't in the api docs
+    can_send_audios: base.Boolean = fields.Field()
+    can_send_documents: base.Boolean = fields.Field()
+    can_send_photos: base.Boolean = fields.Field()
+    can_send_videos: base.Boolean = fields.Field()
+    can_send_video_notes: base.Boolean = fields.Field()
+    can_send_voice_notes: base.Boolean = fields.Field()
     can_send_polls: base.Boolean = fields.Field()
     can_send_other_messages: base.Boolean = fields.Field()
     can_add_web_page_previews: base.Boolean = fields.Field()
@@ -21,6 +27,12 @@ class ChatPermissions(base.TelegramObject):
     def __init__(self,
                  can_send_messages: base.Boolean = None,
                  can_send_media_messages: base.Boolean = None,
+                 can_send_audios: base.Boolean = None,
+                 can_send_documents: base.Boolean = None,
+                 can_send_photos: base.Boolean = None,
+                 can_send_videos: base.Boolean = None,
+                 can_send_video_notes: base.Boolean = None,
+                 can_send_voice_notes: base.Boolean = None,
                  can_send_polls: base.Boolean = None,
                  can_send_other_messages: base.Boolean = None,
                  can_add_web_page_previews: base.Boolean = None,
@@ -32,6 +44,12 @@ class ChatPermissions(base.TelegramObject):
         super(ChatPermissions, self).__init__(
             can_send_messages=can_send_messages,
             can_send_media_messages=can_send_media_messages,
+            can_send_audios=can_send_audios,
+            can_send_documents=can_send_documents,
+            can_send_photos=can_send_photos,
+            can_send_videos=can_send_videos,
+            can_send_video_notes=can_send_video_notes,
+            can_send_voice_notes=can_send_voice_notes,
             can_send_polls=can_send_polls,
             can_send_other_messages=can_send_other_messages,
             can_add_web_page_previews=can_add_web_page_previews,
@@ -39,4 +57,5 @@ class ChatPermissions(base.TelegramObject):
             can_invite_users=can_invite_users,
             can_pin_messages=can_pin_messages,
             can_manage_topics=can_manage_topics,
+            **kwargs
         )

--- a/aiogram/types/chat_permissions.py
+++ b/aiogram/types/chat_permissions.py
@@ -9,7 +9,7 @@ class ChatPermissions(base.TelegramObject):
     https://core.telegram.org/bots/api#chatpermissions
     """
     can_send_messages: base.Boolean = fields.Field()
-    can_send_media_messages: base.Boolean = fields.Field() # isn't in the api docs
+    can_send_media_messages: base.Boolean = fields.Field()  # Deprecated since Bot API 6.5
     can_send_audios: base.Boolean = fields.Field()
     can_send_documents: base.Boolean = fields.Field()
     can_send_photos: base.Boolean = fields.Field()


### PR DESCRIPTION
# Description
As asked by Alex: add new fields, make sure kwargs are not ignored, add a comment next to can_send_media_messages

- New feature (non-breaking change that adds functionality)

# How has this been tested?
ran a bot that uses updated ChatPermissions

## Test Configuration
- Operating system: e.g. Ubuntu 20.04.2 LTS
-Python version: e.g. 3.10.1

# Checklist:

<!--
Please delete options that are not relevant to your change.
-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
- [x] I have made corresponding changes to the documentation
