### PR TITLE
Added possibility to reply into webhook with files

### DIFF
--- a/CHANGES/1120.misc.rst
+++ b/CHANGES/1120.misc.rst
@@ -1,0 +1,1 @@
+Added possibility to reply into webhook with files

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -13,7 +13,7 @@ from ..fsm.middleware import FSMContextMiddleware
 from ..fsm.storage.base import BaseEventIsolation, BaseStorage
 from ..fsm.storage.memory import DisabledEventIsolation, MemoryStorage
 from ..fsm.strategy import FSMStrategy
-from ..methods import GetUpdates, TelegramMethod
+from ..methods import GetUpdates, Request, TelegramMethod
 from ..types import Update, User
 from ..types.update import UpdateTypeLookupError
 from ..utils.backoff import Backoff, BackoffConfig
@@ -351,7 +351,7 @@ class Dispatcher(Router):
 
     async def feed_webhook_update(
         self, bot: Bot, update: Union[Update, Dict[str, Any]], _timeout: float = 55, **kwargs: Any
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Request]:
         if not isinstance(update, Update):  # Allow to use raw updates
             update = Update(**update)
 
@@ -397,8 +397,7 @@ class Dispatcher(Router):
                 # TODO: handle exceptions
                 response: Any = process_updates.result()
                 if isinstance(response, TelegramMethod):
-                    request = response.build_request(bot=bot)
-                    return request.render_webhook_request()
+                    return response.build_request(bot=bot)
 
             else:
                 process_updates.remove_done_callback(release_waiter)

--- a/aiogram/methods/base.py
+++ b/aiogram/methods/base.py
@@ -33,12 +33,6 @@ class Request(BaseModel):
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
-    def render_webhook_request(self) -> Dict[str, Any]:
-        return {
-            "method": self.method,
-            **{key: value for key, value in self.data.items() if value is not None},
-        }
-
 
 class Response(GenericModel, Generic[TelegramType]):
     ok: bool

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -12,7 +12,7 @@ from aiogram import Bot
 from aiogram.dispatcher.dispatcher import Dispatcher
 from aiogram.dispatcher.event.bases import UNHANDLED, SkipHandler
 from aiogram.dispatcher.router import Router
-from aiogram.methods import GetMe, GetUpdates, SendMessage
+from aiogram.methods import GetMe, GetUpdates, Request, SendMessage
 from aiogram.types import (
     CallbackQuery,
     Chat,
@@ -703,9 +703,9 @@ class TestDispatcher:
         dispatcher.message.register(simple_message_handler)
 
         response = await dispatcher.feed_webhook_update(bot, RAW_UPDATE, _timeout=0.3)
-        assert isinstance(response, dict)
-        assert response["method"] == "sendMessage"
-        assert response["text"] == "ok"
+        assert isinstance(response, Request)
+        assert response.method == "sendMessage"
+        assert response.data["text"] == "ok"
 
     async def test_feed_webhook_update_slow_process(self, bot: MockedBot, recwarn):
         warnings.simplefilter("always")


### PR DESCRIPTION
# Description

Added possibility to reply into webhook with files.

Previously there was no support for sending documents in reply into webhook because `application/json` response type is used, but Telegram Bot API supports `multipart/form-data` responses from webhook serve ([Docs](https://core.telegram.org/bots/api#making-requests-when-getting-updates)), so thats mean the sending documents is supported by server.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- New feature (non-breaking change that adds functionality)
- Documentation (typos, code examples or any documentation update)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works as expected
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
- [x] My changes are compatible with minimum requirements of the project
- [x] I have made corresponding changes to the documentation
