### PR TITLE
Bot API 6.6 for 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPi status](https://img.shields.io/pypi/status/aiogram.svg?style=flat-square)](https://pypi.python.org/pypi/aiogram)
 [![Downloads](https://img.shields.io/pypi/dm/aiogram.svg?style=flat-square)](https://pypi.python.org/pypi/aiogram)
 [![Supported python versions](https://img.shields.io/pypi/pyversions/aiogram.svg?style=flat-square)](https://pypi.python.org/pypi/aiogram)
-[![Telegram Bot API](https://img.shields.io/badge/Telegram%20Bot%20API-6.4-blue.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
+[![Telegram Bot API](https://img.shields.io/badge/Telegram%20Bot%20API-6.6-blue.svg?style=flat-square&logo=telegram)](https://core.telegram.org/bots/api)
 [![Documentation Status](https://img.shields.io/readthedocs/aiogram?style=flat-square)](http://docs.aiogram.dev/en/latest/?badge=latest)
 [![Github issues](https://img.shields.io/github/issues/aiogram/aiogram.svg?style=flat-square)](https://github.com/aiogram/aiogram/issues)
 [![MIT License](https://img.shields.io/pypi/l/aiogram.svg?style=flat-square)](https://opensource.org/licenses/MIT)

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ aiogram
    :target: https://pypi.python.org/pypi/aiogram
    :alt: Supported python versions
 
-.. image:: https://img.shields.io/badge/Telegram%20Bot%20API-6.4-blue.svg?style=flat-square&logo=telegram
+.. image:: https://img.shields.io/badge/Telegram%20Bot%20API-6.6-blue.svg?style=flat-square&logo=telegram
    :target: https://core.telegram.org/bots/api
    :alt: Telegram Bot API
 

--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -43,5 +43,5 @@ __all__ = (
     'utils',
 )
 
-__version__ = '2.25.1'
-__api_version__ = '6.5'
+__version__ = '2.26.0'
+__api_version__ = '6.6'

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -270,6 +270,7 @@ class Methods(Helper):
     GET_MY_COMMANDS = Item()  # getMyCommands
     SET_MY_DESCRIPTION = Item()  # setMyDescription
     GET_MY_DESCRIPTION = Item()  # getMyDescription
+    SET_MY_SHORT_DESCRIPTION = Item()  # setMyShortDescription
 
     # Updating messages
     EDIT_MESSAGE_TEXT = Item()  # editMessageText

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -293,6 +293,7 @@ class Methods(Helper):
     SET_STICKER_SET_TITLE = Item()  # setStickerSetTitle
     SET_STICKER_SET_THUMBNAIL = Item()  # setStickerSetThumbnail
     SET_CUSTOM_EMOJI_STICKER_SET_THUMBNAIL = Item()  # setCustomEmojiStickerSetThumbnail
+    DELETE_STICKER_SET = Item()  # deleteStickerSet
 
     # Inline mode
     ANSWER_INLINE_QUERY = Item()  # answerInlineQuery

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -291,6 +291,7 @@ class Methods(Helper):
     SET_STICKER_POSITION_IN_SET = Item()  # setStickerPositionInSet
     DELETE_STICKER_FROM_SET = Item()  # deleteStickerFromSet
     SET_STICKER_SET_THUMBNAIL = Item()  # setStickerSetThumbnail
+    SET_CUSTOM_EMOJI_STICKER_SET_THUMBNAIL = Item()  # setCustomEmojiStickerSetThumbnail
 
     # Inline mode
     ANSWER_INLINE_QUERY = Item()  # answerInlineQuery

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -290,6 +290,7 @@ class Methods(Helper):
     ADD_STICKER_TO_SET = Item()  # addStickerToSet
     SET_STICKER_POSITION_IN_SET = Item()  # setStickerPositionInSet
     DELETE_STICKER_FROM_SET = Item()  # deleteStickerFromSet
+    SET_STICKER_SET_TITLE = Item()  # setStickerSetTitle
     SET_STICKER_SET_THUMBNAIL = Item()  # setStickerSetThumbnail
     SET_CUSTOM_EMOJI_STICKER_SET_THUMBNAIL = Item()  # setCustomEmojiStickerSetThumbnail
 

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -290,7 +290,7 @@ class Methods(Helper):
     ADD_STICKER_TO_SET = Item()  # addStickerToSet
     SET_STICKER_POSITION_IN_SET = Item()  # setStickerPositionInSet
     DELETE_STICKER_FROM_SET = Item()  # deleteStickerFromSet
-    SET_STICKER_SET_THUMB = Item()  # setStickerSetThumb
+    SET_STICKER_SET_THUMBNAIL = Item()  # setStickerSetThumbnail
 
     # Inline mode
     ANSWER_INLINE_QUERY = Item()  # answerInlineQuery

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -269,6 +269,7 @@ class Methods(Helper):
     DELETE_MY_COMMANDS = Item()  # deleteMyCommands
     GET_MY_COMMANDS = Item()  # getMyCommands
     SET_MY_DESCRIPTION = Item()  # setMyDescription
+    GET_MY_DESCRIPTION = Item()  # getMyDescription
 
     # Updating messages
     EDIT_MESSAGE_TEXT = Item()  # editMessageText

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -271,6 +271,7 @@ class Methods(Helper):
     SET_MY_DESCRIPTION = Item()  # setMyDescription
     GET_MY_DESCRIPTION = Item()  # getMyDescription
     SET_MY_SHORT_DESCRIPTION = Item()  # setMyShortDescription
+    GET_MY_SHORT_DESCRIPTION = Item()  # getMyShortDescription
 
     # Updating messages
     EDIT_MESSAGE_TEXT = Item()  # editMessageText

--- a/aiogram/bot/api.py
+++ b/aiogram/bot/api.py
@@ -268,6 +268,7 @@ class Methods(Helper):
     SET_MY_COMMANDS = Item()  # setMyCommands
     DELETE_MY_COMMANDS = Item()  # deleteMyCommands
     GET_MY_COMMANDS = Item()  # getMyCommands
+    SET_MY_DESCRIPTION = Item()  # setMyDescription
 
     # Updating messages
     EDIT_MESSAGE_TEXT = Item()  # editMessageText

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3404,51 +3404,78 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
     # === Stickers ===
     # https://core.telegram.org/bots/api#stickers
 
-    async def send_sticker(self, chat_id: typing.Union[base.Integer, base.String],
-                           sticker: typing.Union[base.InputFile, base.String],
-                           message_thread_id: typing.Optional[base.Integer] = None,
-                           disable_notification: typing.Optional[base.Boolean] = None,
-                           protect_content: typing.Optional[base.Boolean] = None,
-                           reply_to_message_id: typing.Optional[base.Integer] = None,
-                           allow_sending_without_reply: typing.Optional[base.Boolean] = None,
-                           reply_markup: typing.Union[types.InlineKeyboardMarkup,
-                           types.ReplyKeyboardMarkup,
-                           types.ReplyKeyboardRemove,
-                           types.ForceReply, None] = None,
-                           ) -> types.Message:
+    async def send_sticker(
+        self,
+        chat_id: typing.Union[base.Integer, base.String],
+        sticker: typing.Union[base.InputFile, base.String],
+        message_thread_id: typing.Optional[base.Integer] = None,
+        emoji: typing.Optional[base.String] = None,
+        disable_notification: typing.Optional[base.Boolean] = None,
+        protect_content: typing.Optional[base.Boolean] = None,
+        reply_to_message_id: typing.Optional[base.Integer] = None,
+        allow_sending_without_reply: typing.Optional[base.Boolean] = None,
+        reply_markup: typing.Union[
+            types.InlineKeyboardMarkup,
+            types.ReplyKeyboardMarkup,
+            types.ReplyKeyboardRemove,
+            types.ForceReply,
+            None,
+        ] = None,
+    ) -> types.Message:
         """
-        Use this method to send .webp stickers.
+        Use this method to send static .WEBP, animated .TGS, or video
+        .WEBM stickers.
 
         Source: https://core.telegram.org/bots/api#sendsticker
 
-        :param chat_id: Unique identifier for the target chat or username of the target channel
+        :param chat_id: Unique identifier for the target chat or
+            username of the target channel (in the format
+            @channelusername)
         :type chat_id: :obj:`typing.Union[base.Integer, base.String]`
 
-        :param message_thread_id: Unique identifier for the target message thread (topic) of the forum; for forum
-            supergroups only
+        :param message_thread_id: Unique identifier for the target
+            message thread (topic) of the forum; for forum supergroups
+            only
         :type message_thread_id: :obj:`typing.Optional[base.Integer]`
 
-        :param sticker: Sticker to send
+        :param sticker: Sticker to send. Pass a file_id as String to
+            send a file that exists on the Telegram servers
+            (recommended), pass an HTTP URL as a String for Telegram to
+            get a .WEBP sticker from the Internet, or upload a new .WEBP
+            or .TGS sticker using multipart/form-data. More information
+            on Sending Files ». Video stickers can only be sent by a
+            file_id. Animated stickers can't be sent via an HTTP URL.
         :type sticker: :obj:`typing.Union[base.InputFile, base.String]`
 
-        :param disable_notification: Sends the message silently. Users will receive a notification with no sound
+        :param emoji: Emoji associated with the sticker; only for just
+            uploaded stickers
+        :type emoji: :obj:`typing.Optional[base.String]`
+
+        :param disable_notification: Sends the message silently. Users
+            will receive a notification with no sound.
         :type disable_notification: :obj:`typing.Optional[base.Boolean]`
 
-        :param protect_content: Protects the contents of sent messages
-            from forwarding and saving
+        :param protect_content: Protects the contents of the sent
+            message from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
 
-        :param reply_to_message_id: If the message is a reply, ID of the original message
+        :param reply_to_message_id: If the message is a reply, ID of the
+            original message
         :type reply_to_message_id: :obj:`typing.Optional[base.Integer]`
 
-        :param allow_sending_without_reply: Pass True, if the message should be sent
-            even if the specified replied-to message is not found
-        :type allow_sending_without_reply: :obj:`typing.Optional[base.Boolean]`
+        :param allow_sending_without_reply: Pass True if the message
+            should be sent even if the specified replied-to message is
+            not found
+        :type allow_sending_without_reply: :obj:`typing.Optional[
+            base.Boolean]`
 
-        :param reply_markup: Additional interface options. A JSON-serialized object for an inline keyboard,
-            custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user
-        :type reply_markup: :obj:`typing.Union[types.InlineKeyboardMarkup,
-            types.ReplyKeyboardMarkup, types.ReplyKeyboardRemove, types.ForceReply, None]`
+        :param reply_markup: Additional interface options.
+            A JSON-serialized object for an inline keyboard, custom
+            reply keyboard, instructions to remove reply keyboard or to
+            force a reply from the user.
+        :type reply_markup: :obj:`typing.Union[
+            types.InlineKeyboardMarkup, types.ReplyKeyboardMarkup,
+            types.ReplyKeyboardRemove, types.ForceReply, None]`
 
         :return: On success, the sent Message is returned
         :rtype: :obj:`types.Message`

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3785,6 +3785,31 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.SET_STICKER_SET_THUMBNAIL, payload, files)
 
+    async def set_custom_emoji_sticker_set_thumbnail(
+        self,
+        name: base.String,
+        custom_emoji_id: typing.Optional[base.String] = None,
+    ) -> base.Boolean:
+        """
+        Use this method to set the thumbnail of a custom emoji sticker set.
+
+        Source: https://core.telegram.org/bots/api#setcustomemojistickersetthumbnail
+
+        :param name: Sticker set name
+        :type name: :obj:`base.String`
+
+        :param custom_emoji_id: Custom emoji identifier of a sticker
+        from the sticker set; pass an empty string to drop the thumbnail
+        and use the first sticker as the thumbnail.
+        :type custom_emoji_id: :obj:`typing.Optional[base.String]`
+
+        :return: Returns True on success.
+        :rtype: :obj:`base.Boolean`
+        """
+        payload = generate_payload(**locals())
+
+        return await self.request(api.Methods.SET_CUSTOM_EMOJI_STICKER_SET_THUMBNAIL, payload)
+
     async def answer_inline_query(self, inline_query_id: base.String,
                                   results: typing.List[types.InlineQueryResult],
                                   cache_time: typing.Optional[base.Integer] = None,

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -8,7 +8,7 @@ import warnings
 from .base import BaseBot, api
 from .. import types
 from ..types import base
-from ..utils.deprecated import deprecated
+from ..utils.deprecated import deprecated, renamed_argument
 from ..utils.exceptions import ValidationError
 from ..utils.mixins import DataMixin, ContextInstanceMixin
 from ..utils.payload import generate_payload, prepare_arg, prepare_attachment, prepare_file
@@ -565,6 +565,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         result = await self.request(api.Methods.SEND_PHOTO, payload, files)
         return types.Message(**result)
 
+    @renamed_argument('thumb', 'thumbnail', '3.0')
     async def send_audio(self,
                          chat_id: typing.Union[base.Integer, base.String],
                          audio: typing.Union[base.InputFile, base.String],
@@ -574,7 +575,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                          duration: typing.Optional[base.Integer] = None,
                          performer: typing.Optional[base.String] = None,
                          title: typing.Optional[base.String] = None,
-                         thumb: typing.Union[base.InputFile, base.String, None] = None,
+                         thumbnail: typing.Union[base.InputFile, base.String, None] = None,
                          message_thread_id: typing.Optional[base.Integer] = None,
                          disable_notification: typing.Optional[base.Boolean] = None,
                          protect_content: typing.Optional[base.Boolean] = None,
@@ -584,6 +585,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                          types.ReplyKeyboardMarkup,
                          types.ReplyKeyboardRemove,
                          types.ForceReply, None] = None,
+                         thumb: typing.Union[base.InputFile, base.String, None] = None,
                          ) -> types.Message:
         """
         Use this method to send audio files, if you want Telegram clients to display them in the music player.
@@ -623,8 +625,12 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :param title: Track name
         :type title: :obj:`typing.Optional[base.String]`
 
-        :param thumb: Thumbnail of the file sent
+
+        :param thumb: deprecated in API 6.6. Use thumbnail instead
         :type thumb: :obj:`typing.Union[base.InputFile, base.String, None]`
+
+        :param thumbnail: Thumbnail of the file sent
+        :type thumbnail: :obj:`typing.Union[base.InputFile, base.String, None]`
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound
         :type disable_notification: :obj:`typing.Optional[base.Boolean]`
@@ -650,7 +656,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         caption_entities = prepare_arg(caption_entities)
-        payload = generate_payload(**locals(), exclude=['audio', 'thumb'])
+        payload = generate_payload(**locals(), exclude=['audio', 'thumb', 'thumbnail'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
         if self.protect_content is not None:
@@ -658,15 +664,16 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         files = {}
         prepare_file(payload, files, 'audio', audio)
-        prepare_attachment(payload, files, 'thumb', thumb)
+        prepare_attachment(payload, files, 'thumbnail', thumbnail or thumb)
 
         result = await self.request(api.Methods.SEND_AUDIO, payload, files)
         return types.Message(**result)
 
+    @renamed_argument('thumb', 'thumbnail', '3.0')
     async def send_document(self,
                             chat_id: typing.Union[base.Integer, base.String],
                             document: typing.Union[base.InputFile, base.String],
-                            thumb: typing.Union[base.InputFile, base.String, None] = None,
+                            thumbnail: typing.Union[base.InputFile, base.String, None] = None,
                             caption: typing.Optional[base.String] = None,
                             parse_mode: typing.Optional[base.String] = None,
                             caption_entities: typing.Optional[typing.List[types.MessageEntity]] = None,
@@ -681,6 +688,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                             types.ReplyKeyboardRemove,
                             types.ForceReply,
                             None] = None,
+                            thumb: typing.Union[base.InputFile, base.String, None] = None,
                             ) -> types.Message:
         """
         Use this method to send general files. On success, the sent Message is
@@ -701,7 +709,10 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :param document: File to send
         :type document: :obj:`typing.Union[base.InputFile, base.String]`
 
-        :param thumb: Thumbnail of the file sent
+        :param thumbnail: Thumbnail of the file sent
+        :type thumbnail: :obj:`typing.Union[base.InputFile, base.String, None]`
+
+        :param thumb: deprecated in API 6.6. Use thumbnail instead
         :type thumb: :obj:`typing.Union[base.InputFile, base.String, None]`
 
         :param caption: Document caption (may also be used when resending documents
@@ -748,7 +759,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         caption_entities = prepare_arg(caption_entities)
-        payload = generate_payload(**locals(), exclude=['document'])
+        payload = generate_payload(**locals(), exclude=['document', 'thumb', 'thumbnail'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
         if self.protect_content is not None:
@@ -756,17 +767,18 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         files = {}
         prepare_file(payload, files, 'document', document)
-        prepare_attachment(payload, files, 'thumb', thumb)
+        prepare_attachment(payload, files, 'thumbnail', thumbnail or thumb)
 
         result = await self.request(api.Methods.SEND_DOCUMENT, payload, files)
         return types.Message(**result)
 
+    @renamed_argument('thumb', 'thumbnail', '6.6')
     async def send_video(self, chat_id: typing.Union[base.Integer, base.String],
                          video: typing.Union[base.InputFile, base.String],
                          duration: typing.Optional[base.Integer] = None,
                          width: typing.Optional[base.Integer] = None,
                          height: typing.Optional[base.Integer] = None,
-                         thumb: typing.Union[base.InputFile, base.String, None] = None,
+                         thumbnail: typing.Union[base.InputFile, base.String, None] = None,
                          caption: typing.Optional[base.String] = None,
                          parse_mode: typing.Optional[base.String] = None,
                          caption_entities: typing.Optional[typing.List[types.MessageEntity]] = None,
@@ -781,6 +793,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                          types.ReplyKeyboardRemove,
                          types.ForceReply, None] = None,
                          has_spoiler: typing.Optional[base.Boolean] = None,
+                         thumb: typing.Union[base.InputFile, base.String, None] = None,
                          ) -> types.Message:
         """
         Use this method to send video files, Telegram clients support mp4 videos
@@ -807,7 +820,10 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :param height: Video height
         :type height: :obj:`typing.Optional[base.Integer]`
 
-        :param thumb: Thumbnail of the file sent
+        :param thumbnail: Thumbnail of the file sent
+        :type thumbnail: :obj:`typing.Union[base.InputFile, base.String, None]`
+
+        :param thumb: deprecated in API 6.6, Use thumbnail instead
         :type thumb: :obj:`typing.Union[base.InputFile, base.String, None]`
 
         :param caption: Video caption (may also be used when resending videos by file_id), 0-1024 characters
@@ -851,7 +867,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         caption_entities = prepare_arg(caption_entities)
-        payload = generate_payload(**locals(), exclude=['video', 'thumb'])
+        payload = generate_payload(**locals(), exclude=['video', 'thumb', 'thumbnail'])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
         if self.protect_content is not None:
@@ -859,18 +875,19 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         files = {}
         prepare_file(payload, files, 'video', video)
-        prepare_attachment(payload, files, 'thumb', thumb)
+        prepare_attachment(payload, files, 'thumbnail', thumbnail or thumb)
 
         result = await self.request(api.Methods.SEND_VIDEO, payload, files)
         return types.Message(**result)
 
+    @renamed_argument('thumb', 'thumbnail', '3.0')
     async def send_animation(self,
                              chat_id: typing.Union[base.Integer, base.String],
                              animation: typing.Union[base.InputFile, base.String],
                              duration: typing.Optional[base.Integer] = None,
                              width: typing.Optional[base.Integer] = None,
                              height: typing.Optional[base.Integer] = None,
-                             thumb: typing.Union[typing.Union[base.InputFile, base.String], None] = None,
+                             thumbnail: typing.Union[typing.Union[base.InputFile, base.String], None] = None,
                              caption: typing.Optional[base.String] = None,
                              parse_mode: typing.Optional[base.String] = None,
                              caption_entities: typing.Optional[typing.List[types.MessageEntity]] = None,
@@ -884,6 +901,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                              types.ReplyKeyboardRemove,
                              types.ForceReply], None] = None,
                              has_spoiler: typing.Optional[base.Boolean] = None,
+                             thumb: typing.Union[typing.Union[base.InputFile, base.String], None] = None,
                              ) -> types.Message:
         """
         Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
@@ -915,8 +933,11 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :param height: Animation height
         :type height: :obj:`typing.Optional[base.Integer]`
 
-        :param thumb: Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
+        :param thumbnail: Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
             A thumbnail‘s width and height should not exceed 320.
+        :type thumbnail: :obj:`typing.Union[typing.Union[base.InputFile, base.String], None]`
+
+        :param thumb: deprecated in API 6.6. Use thumbnail instead
         :type thumb: :obj:`typing.Union[typing.Union[base.InputFile, base.String], None]`
 
         :param caption: Animation caption (may also be used when resending animation by file_id), 0-1024 characters
@@ -957,7 +978,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         """
         reply_markup = prepare_arg(reply_markup)
         caption_entities = prepare_arg(caption_entities)
-        payload = generate_payload(**locals(), exclude=["animation", "thumb"])
+        payload = generate_payload(**locals(), exclude=["animation", "thumbnail", "thumb"])
         if self.parse_mode and caption_entities is None:
             payload.setdefault('parse_mode', self.parse_mode)
         if self.protect_content is not None:
@@ -965,7 +986,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         files = {}
         prepare_file(payload, files, 'animation', animation)
-        prepare_attachment(payload, files, 'thumb', thumb)
+        prepare_attachment(payload, files, 'thumbnail', thumbnail or thumb)
 
         result = await self.request(api.Methods.SEND_ANIMATION, payload, files)
         return types.Message(**result)
@@ -1056,11 +1077,12 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         result = await self.request(api.Methods.SEND_VOICE, payload, files)
         return types.Message(**result)
 
+    @renamed_argument('thumb', 'thumbnail', '3.0')
     async def send_video_note(self, chat_id: typing.Union[base.Integer, base.String],
                               video_note: typing.Union[base.InputFile, base.String],
                               duration: typing.Optional[base.Integer] = None,
                               length: typing.Optional[base.Integer] = None,
-                              thumb: typing.Union[base.InputFile, base.String, None] = None,
+                              thumbnail: typing.Union[base.InputFile, base.String, None] = None,
                               message_thread_id: typing.Optional[base.Integer] = None,
                               disable_notification: typing.Optional[base.Boolean] = None,
                               protect_content: typing.Optional[base.Boolean] = None,
@@ -1070,6 +1092,7 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                               types.ReplyKeyboardMarkup,
                               types.ReplyKeyboardRemove,
                               types.ForceReply, None] = None,
+                              thumb: typing.Union[base.InputFile, base.String, None] = None,
                               ) -> types.Message:
         """
         As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long.
@@ -1093,7 +1116,10 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :param length: Video width and height
         :type length: :obj:`typing.Optional[base.Integer]`
 
-        :param thumb: Thumbnail of the file sent
+        :param thumbnail: Thumbnail of the file sent
+        :type thumbnail: :obj:`typing.Union[base.InputFile, base.String, None]`
+
+        :param thumb: deprecated in API 6.6. Use thumbnail instead
         :type thumb: :obj:`typing.Union[base.InputFile, base.String, None]`
 
         :param disable_notification: Sends the message silently. Users will receive a notification with no sound
@@ -1119,12 +1145,13 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         :rtype: :obj:`types.Message`
         """
         reply_markup = prepare_arg(reply_markup)
-        payload = generate_payload(**locals(), exclude=['video_note'])
+        payload = generate_payload(**locals(), exclude=['video_note', 'thumb', 'thumbnail'])
         if self.protect_content is not None:
             payload.setdefault('protect_content', self.protect_content)
 
         files = {}
         prepare_file(payload, files, 'video_note', video_note)
+        prepare_file(payload, files, 'thumbnail', thumbnail)
 
         result = await self.request(api.Methods.SEND_VIDEO_NOTE, payload, files)
         return types.Message(**result)

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3063,6 +3063,28 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.SET_MY_SHORT_DESCRIPTION, payload)
 
+    async def get_my_short_description(
+        self,
+        language_code: typing.Optional[base.String] = None,
+    ) -> types.BotShortDescription:
+        """
+        Use this method to get the current bot short description for the
+        given user language.
+
+        Source: https://core.telegram.org/bots/api#getmyshortdescription
+
+        :param language_code: A two-letter ISO 639-1 language code or an
+            empty string
+        :type language_code: :obj: `typing.Optional[base.String]`
+
+        :return: Returns BotShortDescription on success.
+        :rtype: :obj:`types.BotShortDescription`
+        """
+        payload = generate_payload(**locals())
+
+        result = await self.request(api.Methods.GET_MY_SHORT_DESCRIPTION, payload)
+        return types.BotShortDescription(**result)
+
     async def set_chat_menu_button(self, chat_id: typing.Optional[base.Integer] = None,
                                    menu_button: typing.Optional[types.MenuButton] = None) -> bool:
         """

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3012,6 +3012,28 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.SET_MY_DESCRIPTION, payload)
 
+    async def get_my_description(
+        self,
+        language_code: typing.Optional[base.String] = None,
+    ) -> types.BotDescription:
+        """
+        Use this method to get the current bot description for the given
+        user language.
+
+        Source: https://core.telegram.org/bots/api#getmydescription
+
+        :param language_code: A two-letter ISO 639-1 language code or an
+            empty string
+        :type language_code: :obj: `typing.Optional[base.String]`
+
+        :return: Returns BotDescription on success.
+        :rtype: :obj:`types.BotDescription`
+        """
+        payload = generate_payload(**locals())
+
+        result = await self.request(api.Methods.GET_MY_DESCRIPTION, payload)
+        return types.BotDescription(**result)
+
     async def set_chat_menu_button(self, chat_id: typing.Optional[base.Integer] = None,
                                    menu_button: typing.Optional[types.MenuButton] = None) -> bool:
         """

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -2983,6 +2983,35 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         result = await self.request(api.Methods.GET_MY_COMMANDS, payload)
         return [types.BotCommand(**bot_command_data) for bot_command_data in result]
 
+    async def set_my_description(
+        self,
+        description: typing.Optional[base.String] = None,
+        language_code: typing.Optional[base.String] = None,
+    ) -> base.Boolean:
+        """
+        Use this method to change the bot's description, which is shown
+        in the chat with the bot if the chat is empty.
+
+
+        Source: https://core.telegram.org/bots/api#setmydescription
+
+        :param description: New bot description; 0-512 characters.
+            Pass an empty string to remove the dedicated description for
+            the given language.
+        :type description: :obj: `typing.Optional[base.String]`
+
+        :param language_code: A two-letter ISO 639-1 language code. If
+            empty, the description will be applied to all users for
+            whose language there is no dedicated description.
+        :type language_code: :obj: `typing.Optional[base.String]`
+
+        :return: Returns True on success.
+        :rtype: :obj:`base.Boolean`
+        """
+        payload = generate_payload(**locals())
+
+        return await self.request(api.Methods.SET_MY_DESCRIPTION, payload)
+
     async def set_chat_menu_button(self, chat_id: typing.Optional[base.Integer] = None,
                                    menu_button: typing.Optional[types.MenuButton] = None) -> bool:
         """

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3548,70 +3548,95 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         result = await self.request(api.Methods.GET_CUSTOM_EMOJI_STICKERS, payload)
         return [types.Sticker(**item) for item in result]
 
-    async def create_new_sticker_set(self,
-                                     user_id: base.Integer,
-                                     name: base.String,
-                                     title: base.String,
-                                     emojis: base.String,
-                                     png_sticker: typing.Union[base.InputFile, base.String] = None,
-                                     tgs_sticker: base.InputFile = None,
-                                     webm_sticker: base.InputFile = None,
-                                     contains_masks: typing.Optional[base.Boolean] = None,
-                                     sticker_type: typing.Optional[base.String] = None,
-                                     mask_position: typing.Optional[types.MaskPosition] = None) -> base.Boolean:
+    async def create_new_sticker_set(
+        self,
+        user_id: base.Integer,
+        name: base.String,
+        title: base.String,
+        emojis: base.String,
+        stickers: typing.List[types.InputSticker],
+        sticker_format: base.String,
+        sticker_type: typing.Optional[base.String] = None,
+        needs_repainting: typing.Optional[base.Boolean] = None,
+        png_sticker: typing.Union[base.InputFile, base.String] = None,
+        tgs_sticker: base.InputFile = None,
+        webm_sticker: base.InputFile = None,
+        contains_masks: typing.Optional[base.Boolean] = None,
+        mask_position: typing.Optional[types.MaskPosition] = None
+
+    ) -> base.Boolean:
         """
         Use this method to create a new sticker set owned by a user.
         The bot will be able to edit the sticker set thus created.
-        You must use exactly one of the fields png_sticker or tgs_sticker.
 
         Source: https://core.telegram.org/bots/api#createnewstickerset
 
         :param user_id: User identifier of created sticker set owner
         :type user_id: :obj:`base.Integer`
-        :param name: Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals).
-            Can contain only english letters, digits and underscores.
-            Must begin with a letter, can't contain consecutive underscores and must end in “_by_<bot username>”.
-            <bot_username> is case insensitive. 1-64 characters.
+
+        :param name: Short name of sticker set, to be used in
+            t.me/addstickers/ URLs (e.g., animals). Can contain only
+            English letters, digits and underscores. Must begin with a
+            letter, can't contain consecutive underscores and must end
+            in "_by_<bot_username>". <bot_username> is case insensitive.
+            1-64 characters.
         :type name: :obj:`base.String`
+
         :param title: Sticker set title, 1-64 characters
         :type title: :obj:`base.String`
-        :param png_sticker: PNG image with the sticker, must be up to 512 kilobytes in size,
-            dimensions must not exceed 512px, and either width or height must be exactly 512px.
-            Pass a file_id as a String to send a file that already exists on the Telegram servers,
-            pass an HTTP URL as a String for Telegram to get a file from the Internet, or
-            upload a new one using multipart/form-data. More info on https://core.telegram.org/bots/api#sending-files
-        :type png_sticker: :obj:`typing.Union[base.InputFile, base.String]`
-        :param tgs_sticker: TGS animation with the sticker, uploaded using multipart/form-data.
-            See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
-        :type tgs_sticker: :obj:`base.InputFile`
-        :param webm_sticker: WEBM video with the sticker, uploaded using multipart/form-data.
-            See https://core.telegram.org/stickers#video-sticker-requirements for technical requirements
-        :type webm_sticker: :obj:`base.String`
-        :param sticker_type: Type of stickers in the set, pass “regular” or “mask”.
-            Custom emoji sticker sets can't be created via the Bot API at the moment.
-            By default, a regular sticker set is created.
-        :type sticker_type: :obj:`base.InputFile`
-        :param emojis: One or more emoji corresponding to the sticker
-        :type emojis: :obj:`base.String`
-        :param contains_masks: Pass True, if a set of mask stickers should be created
-        :type contains_masks: :obj:`typing.Optional[base.Boolean]`
-        :param mask_position: A JSON-serialized object for position where the mask should be placed on faces
-        :type mask_position: :obj:`typing.Optional[types.MaskPosition]`
+
+        :param stickers: A JSON-serialized list of 1-50 initial stickers
+            to be added to the sticker set
+        :type stickers: :obj:`typing.List[types.InputSticker]`
+
+        :param sticker_format: Format of stickers in the set, must be
+            one of “static”, “animated”, “video”
+        :type sticker_format: :obj:`base.String`
+
+        :param sticker_type: Type of stickers in the set, pass
+            “regular”, “mask”, or “custom_emoji”. By default, a regular
+            sticker set is created.
+        :type sticker_type: :obj:`typing.Optional[base.String]`
+
+        :param needs_repainting: Pass True if stickers in the sticker
+            set must be repainted to the color of text when used in
+            messages, the accent color if used as emoji status, white on
+            chat photos, or another appropriate color based on context;
+            for custom emoji sticker sets only
+        :type needs_repainting: :obj:`typing.Optional[base.Boolean]`
+
+        :param emojis: deprecated in API v6.6
+        :param png_sticker: deprecated in API v6.6
+        :param tgs_sticker: deprecated in API v6.6
+        :param webm_sticker: deprecated in API v6.6
+        :param contains_masks: deprecated in API v6.6
+        :param mask_position: deprecated in API v6.6
+
         :return: Returns True on success
         :rtype: :obj:`base.Boolean`
         """
         mask_position = prepare_arg(mask_position)
-        payload = generate_payload(**locals(), exclude=['png_sticker', 'tgs_sticker', 'webm_sticker'])
-        if contains_masks is not None:
-            warnings.warn(
-                message="The parameter `contains_masks` deprecated, use `sticker_type` instead.",
-                category=DeprecationWarning,
-                stacklevel=2
-            )
+        exclude = [
+            'stickers',
+            'png_sticker',
+            'tgs_sticker',
+            'webm_sticker'
+        ]
+        payload = generate_payload(**locals(), exclude=[])
+        deprecated_list = [emojis, png_sticker, tgs_sticker, webm_sticker, contains_masks, mask_position]
+        for param in deprecated_list:
+            if param is None:
+                warnings.warn(
+                    message=f"The parameter `{param}` deprecated, use updated method params instead.",
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
 
+        # TODO: make method works for old params
+        # TODO: prepare InputSticker
         files = {}
-        prepare_file(payload, files, 'png_sticker', png_sticker)
         prepare_file(payload, files, 'tgs_sticker', tgs_sticker)
+        prepare_file(payload, files, 'webm_sticker', webm_sticker)
         prepare_file(payload, files, 'webm_sticker', webm_sticker)
 
         return await self.request(api.Methods.CREATE_NEW_STICKER_SET, payload, files)

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3723,39 +3723,67 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.DELETE_STICKER_FROM_SET, payload)
 
-    async def set_sticker_set_thumb(self,
-                                    name: base.String,
-                                    user_id: base.Integer,
-                                    thumb: typing.Union[base.InputFile, base.String] = None) -> base.Boolean:
+    async def set_sticker_set_thumbnail(
+        self,
+        name: base.String,
+        user_id: base.Integer,
+        thumbnail: typing.Union[base.InputFile, base.String] = None
+    ) -> base.Boolean:
         """
-        Use this method to set the thumbnail of a sticker set.
-        Animated thumbnails can be set for animated sticker sets only.
+        Use this method to set the thumbnail of a regular or mask
+        sticker set. The format of the thumbnail file must match the
+        format of the stickers in the set.
 
-        Source: https://core.telegram.org/bots/api#setstickersetthumb
+        Source: https://core.telegram.org/bots/api#setcustomemojistickersetthumbnail
 
         :param name: Sticker set name
         :type name: :obj:`base.String`
+
         :param user_id: User identifier of the sticker set owner
         :type user_id: :obj:`base.Integer`
-        :param thumb: A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height
-            exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size;
-            see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical
-            requirements, or a WEBM video with the thumbnail up to 32 kilobytes in size;
-            see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements.
-            Pass a file_id as a String to send a file that already exists on the Telegram servers,
-            pass an HTTP URL as a String for Telegram to get a file from the Internet,
-            or upload a new one using multipart/form-data. More info on https://core.telegram.org/bots/api#sending-files.
-            Animated sticker set thumbnail can't be uploaded via HTTP URL.
-        :type thumb: :obj:`typing.Union[base.InputFile, base.String]`
+
+        :param thumbnail: A .WEBP or .PNG image with the thumbnail, must
+            be up to 128 kilobytes in size and have a width and height
+            of exactly 100px, or a .TGS animation with a thumbnail up to
+            32 kilobytes in size (see
+            https://core.telegram.org/stickers#animated-sticker-requirements
+            for animated sticker technical requirements), or a WEBM
+            video with the thumbnail up to 32 kilobytes in size; see
+            https://core.telegram.org/stickers#video-sticker-requirements
+            for video sticker technical requirements. Pass a file_id as
+            a String to send a file that already exists on the Telegram
+            servers, pass an HTTP URL as a String for Telegram to get a
+            file from the Internet, or upload a new one using
+            multipart/form-data. More information on Sending Files ».
+            Animated and video sticker set thumbnails can't be uploaded
+            via HTTP URL. If omitted, then the thumbnail is dropped and
+            the first sticker is used as the thumbnail.
+        :type thumbnail: :obj:`typing.Union[base.InputFile, base.String]`
+
         :return: Returns True on success
         :rtype: :obj:`base.Boolean`
         """
+        payload = generate_payload(**locals(), exclude=['thumbnail'])
+
+        files = {}
+        prepare_file(payload, files, 'thumbnail', thumbnail)
+
+        return await self.request(api.Methods.SET_STICKER_SET_THUMBNAIL, payload, files)
+
+    @deprecated("Use `set_sticker_set_thumbnail` method instead.")
+    async def set_sticker_set_thumb(
+        self,
+        name: base.String,
+        user_id: base.Integer,
+        thumb: typing.Union[base.InputFile, base.String] = None,
+    ) -> base.Boolean:
+        """Deprecated alias for `set_sticker_set_thumbnail` method."""
         payload = generate_payload(**locals(), exclude=['thumb'])
 
         files = {}
-        prepare_file(payload, files, 'thumb', thumb)
+        prepare_file(payload, files, 'thumbnail', thumb)
 
-        return await self.request(api.Methods.SET_STICKER_SET_THUMB, payload, files)
+        return await self.request(api.Methods.SET_STICKER_SET_THUMBNAIL, payload, files)
 
     async def answer_inline_query(self, inline_query_id: base.String,
                                   results: typing.List[types.InlineQueryResult],

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3034,6 +3034,35 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
         result = await self.request(api.Methods.GET_MY_DESCRIPTION, payload)
         return types.BotDescription(**result)
 
+    async def set_my_short_description(
+        self,
+        short_description: typing.Optional[base.String] = None,
+        language_code: typing.Optional[base.String] = None,
+    ) -> base.Boolean:
+        """
+        Use this method to change the bot's short description, which is
+        shown on the bot's profile page and is sent together with the
+        link when users share the bot.
+
+        Source: https://core.telegram.org/bots/api#setmyshortdescription
+
+        :param short_description: New short description for the bot;
+            0-120 characters. Pass an empty string to remove the
+            dedicated short description for the given language.
+        :type short_description: :obj: `typing.Optional[base.String]`
+
+        :param language_code: A two-letter ISO 639-1 language code. If
+            empty, the short description will be applied to all users
+            for whose language there is no dedicated short description.
+        :type language_code: :obj: `typing.Optional[base.String]`
+
+        :return: Returns True on success.
+        :rtype: :obj:`base.Boolean`
+        """
+        payload = generate_payload(**locals())
+
+        return await self.request(api.Methods.SET_MY_SHORT_DESCRIPTION, payload)
+
     async def set_chat_menu_button(self, chat_id: typing.Optional[base.Integer] = None,
                                    menu_button: typing.Optional[types.MenuButton] = None) -> bool:
         """

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3723,6 +3723,29 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.DELETE_STICKER_FROM_SET, payload)
 
+    async def set_sticker_set_title(
+        self,
+        name: base.String,
+        title: base.String,
+    ) -> base.Boolean:
+        """
+        Use this method to set the title of a created sticker set.
+
+        Source: https://core.telegram.org/bots/api#setstickersettitle
+
+        :param name: Sticker set name
+        :type name: :obj:`base.String`
+
+        :param title: Sticker set title, 1-64 characters
+        :type title: :obj:`base.Sticker`
+
+        :return: Returns True on success
+        :rtype: :obj:`base.Boolean`
+        """
+        payload = generate_payload(**locals())
+
+        return await self.request(api.Methods.SET_STICKER_SET_TITLE, payload)
+
     async def set_sticker_set_thumbnail(
         self,
         name: base.String,

--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3833,6 +3833,22 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
 
         return await self.request(api.Methods.SET_CUSTOM_EMOJI_STICKER_SET_THUMBNAIL, payload)
 
+    async def delete_sticker_set(self, name: base.String) -> base.Boolean:
+        """
+        Use this method to delete a sticker set that was created by the bot
+
+        Source: https://core.telegram.org/bots/api#deletestickerset
+
+        :param name: Sticker set name
+        :type name: :obj:`base.String`
+
+        :return: Returns True on success.
+        :rtype: :obj:`base.Boolean`
+        """
+        payload = generate_payload(**locals())
+
+        return await self.request(api.Methods.DELETE_STICKER_SET, payload)
+
     async def answer_inline_query(self, inline_query_id: base.String,
                                   results: typing.List[types.InlineQueryResult],
                                   cache_time: typing.Optional[base.Integer] = None,

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -9,6 +9,7 @@ from .bot_command_scope import BotCommandScope, BotCommandScopeAllChatAdministra
     BotCommandScopeChatAdministrators, BotCommandScopeChatMember, \
     BotCommandScopeDefault, BotCommandScopeType
 from .bot_description import BotDescription
+from .bot_short_description import BotShortDescription
 from .callback_game import CallbackGame
 from .callback_query import CallbackQuery
 from .chat import Chat, ChatActions, ChatType
@@ -120,6 +121,7 @@ __all__ = (
     'BotCommandScopeDefault',
     'BotCommandScopeType',
     'BotDescription',
+    'BotShortDescription',
     'CallbackGame',
     'CallbackQuery',
     'Chat',

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -8,6 +8,7 @@ from .bot_command_scope import BotCommandScope, BotCommandScopeAllChatAdministra
     BotCommandScopeAllGroupChats, BotCommandScopeAllPrivateChats, BotCommandScopeChat, \
     BotCommandScopeChatAdministrators, BotCommandScopeChatMember, \
     BotCommandScopeDefault, BotCommandScopeType
+from .bot_description import BotDescription
 from .callback_game import CallbackGame
 from .callback_query import CallbackQuery
 from .chat import Chat, ChatActions, ChatType
@@ -118,6 +119,7 @@ __all__ = (
     'BotCommandScopeChatMember',
     'BotCommandScopeDefault',
     'BotCommandScopeType',
+    'BotDescription',
     'CallbackGame',
     'CallbackQuery',
     'Chat',

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -54,6 +54,7 @@ from .input_media import InputMedia, InputMediaAnimation, InputMediaAudio, Input
     InputMediaVideo, MediaGroup
 from .input_message_content import InputContactMessageContent, InputLocationMessageContent, InputMessageContent, \
     InputTextMessageContent, InputVenueMessageContent, InputInvoiceMessageContent
+from .input_sticker import InputSticker
 from .invoice import Invoice
 from .labeled_price import LabeledPrice
 from .location import Location
@@ -191,6 +192,7 @@ __all__ = (
     'InputMediaPhoto',
     'InputMediaVideo',
     'InputMessageContent',
+    'InputSticker',
     'InputTextMessageContent',
     'InputVenueMessageContent',
     'Invoice',

--- a/aiogram/types/animation.py
+++ b/aiogram/types/animation.py
@@ -2,6 +2,7 @@ from . import base
 from . import fields
 from . import mixins
 from .photo_size import PhotoSize
+from ..utils.deprecated import warn_deprecated
 
 
 class Animation(base.TelegramObject, mixins.Downloadable):
@@ -18,7 +19,14 @@ class Animation(base.TelegramObject, mixins.Downloadable):
     width: base.Integer = fields.Field()
     height: base.Integer = fields.Field()
     duration: base.Integer = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
     file_name: base.String = fields.Field()
     mime_type: base.String = fields.Field()
     file_size: base.Integer = fields.Field()
+
+    @property
+    def thumb(self):
+        warn_deprecated(
+            "thumb is deprecated. Use thumbnail instead",
+        )
+        return self.thumbnail

--- a/aiogram/types/audio.py
+++ b/aiogram/types/audio.py
@@ -2,6 +2,7 @@ from . import base
 from . import fields
 from . import mixins
 from .photo_size import PhotoSize
+from ..utils.deprecated import warn_deprecated
 
 
 class Audio(base.TelegramObject, mixins.Downloadable):
@@ -18,4 +19,11 @@ class Audio(base.TelegramObject, mixins.Downloadable):
     file_name: base.String = fields.Field()
     mime_type: base.String = fields.Field()
     file_size: base.Integer = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
+
+    @property
+    def thumb(self):
+        warn_deprecated(
+            "thumb is deprecated. Use thumbnail instead",
+        )
+        return self.thumbnail

--- a/aiogram/types/bot_description.py
+++ b/aiogram/types/bot_description.py
@@ -1,0 +1,10 @@
+from . import base, fields
+
+
+class BotDescription(base.TelegramObject):
+    """
+    This object represents the bot's description.
+
+    https://core.telegram.org/bots/api#botdescription
+    """
+    description: base.String = fields.Field()

--- a/aiogram/types/bot_short_description.py
+++ b/aiogram/types/bot_short_description.py
@@ -1,0 +1,10 @@
+from . import base, fields
+
+
+class BotShortDescription(base.TelegramObject):
+    """
+    This object represents the bot's short description.
+
+    https://core.telegram.org/bots/api#botshortdescription
+    """
+    short_description: base.String = fields.Field()

--- a/aiogram/types/document.py
+++ b/aiogram/types/document.py
@@ -1,8 +1,11 @@
+import typing
+
 from . import base
 from . import fields
 from . import mixins
 from .photo_size import PhotoSize
 from ..utils import helper
+from ..utils.deprecated import warn_deprecated
 
 
 class Document(base.TelegramObject, mixins.Downloadable):
@@ -13,10 +16,15 @@ class Document(base.TelegramObject, mixins.Downloadable):
     """
     file_id: base.String = fields.Field()
     file_unique_id: base.String = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
     file_name: base.String = fields.Field()
     mime_type: base.String = fields.Field()
     file_size: base.Integer = fields.Field()
+
+    @property
+    def thumb(self):
+        warn_deprecated('thumb is deprecated, use thumbnail instead')
+        return self.thumbnail
 
     @property
     def mime_base(self) -> str:

--- a/aiogram/types/inline_query_result.py
+++ b/aiogram/types/inline_query_result.py
@@ -5,6 +5,7 @@ from . import fields
 from .inline_keyboard import InlineKeyboardMarkup
 from .input_message_content import InputMessageContent
 from .message_entity import MessageEntity
+from ..utils.deprecated import warn_deprecated
 
 
 class InlineQueryResult(base.TelegramObject):
@@ -42,9 +43,14 @@ class InlineQueryResultArticle(InlineQueryResult):
     url: base.String = fields.Field()
     hide_url: base.Boolean = fields.Field()
     description: base.String = fields.Field()
-    thumb_url: base.String = fields.Field()
-    thumb_width: base.Integer = fields.Field()
-    thumb_height: base.Integer = fields.Field()
+    # Deprecated fields
+    thumb_url: base.String = fields.Field()  # Deprecated, use thumbnail_url instead
+    thumb_width: base.Integer = fields.Field()  # Deprecated, use thumbnail_width instead
+    thumb_height: base.Integer = fields.Field()  # Deprecated, use thumbnail_height instead
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_width: base.Integer = fields.Field()
+    thumbnail_height: base.Integer = fields.Field()
 
     def __init__(self, *,
                  id: base.String,
@@ -54,14 +60,37 @@ class InlineQueryResultArticle(InlineQueryResult):
                  url: typing.Optional[base.String] = None,
                  hide_url: typing.Optional[base.Boolean] = None,
                  description: typing.Optional[base.String] = None,
-                 thumb_url: typing.Optional[base.String] = None,
-                 thumb_width: typing.Optional[base.Integer] = None,
-                 thumb_height: typing.Optional[base.Integer] = None):
-        super(InlineQueryResultArticle, self).__init__(id=id, title=title,
-                                                       input_message_content=input_message_content,
-                                                       reply_markup=reply_markup, url=url, hide_url=hide_url,
-                                                       description=description, thumb_url=thumb_url,
-                                                       thumb_width=thumb_width, thumb_height=thumb_height)
+                 thumb_url: typing.Optional[base.String] = None,  # Deprecated
+                 thumb_width: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumb_height: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumbnail_url: typing.Optional[base.String] = None,
+                 thumbnail_width: typing.Optional[base.Integer] = None,
+                 thumbnail_height: typing.Optional[base.Integer] = None):
+
+        if thumb_url and not thumbnail_url:
+            thumbnail_url = thumb_url
+            warn_deprecated(
+                "thumb_url parameter is deprecated, please use thumbnail_url."
+            )
+        if thumb_width and not thumbnail_width:
+            thumbnail_width = thumb_width
+            warn_deprecated(
+                "thumb_width parameter is deprecated, please use thumbnail_width."
+            )
+        if thumb_height and not thumbnail_height:
+            warn_deprecated(
+                "thumb_height parameter is deprecated, please use thumbnail_height."
+            )
+            thumbnail_height = thumb_height
+
+        super().__init__(id=id, title=title,
+                         input_message_content=input_message_content,
+                         reply_markup=reply_markup, url=url, hide_url=hide_url,
+                         description=description, thumb_url=thumb_url,
+                         thumb_width=thumb_width, thumb_height=thumb_height,
+                         thumbnail_url=thumbnail_url,
+                         thumbnail_width=thumbnail_width,
+                         thumbnail_height=thumbnail_height)
 
 
 class InlineQueryResultPhoto(InlineQueryResult):
@@ -76,7 +105,10 @@ class InlineQueryResultPhoto(InlineQueryResult):
     """
     type: base.String = fields.Field(alias='type', default='photo')
     photo_url: base.String = fields.Field()
+    # Deprecated field
     thumb_url: base.String = fields.Field()
+    # New field
+    thumbnail_url: base.String = fields.Field()
     photo_width: base.Integer = fields.Field()
     photo_height: base.Integer = fields.Field()
     title: base.String = fields.Field()
@@ -89,7 +121,8 @@ class InlineQueryResultPhoto(InlineQueryResult):
             *,
             id: base.String,
             photo_url: base.String,
-            thumb_url: base.String,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
             photo_width: typing.Optional[base.Integer] = None,
             photo_height: typing.Optional[base.Integer] = None,
             title: typing.Optional[base.String] = None,
@@ -100,8 +133,17 @@ class InlineQueryResultPhoto(InlineQueryResult):
             reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
     ):
+        if not thumbnail_url:
+            if thumb_url:
+                warn_deprecated(
+                    "thumb_url parameter is deprecated, please use thumbnail_url."
+                )
+                thumbnail_url = thumb_url
+            else:
+                raise ValueError("thumbnail_url argument is required")
+
         super().__init__(
-            id=id, photo_url=photo_url, thumb_url=thumb_url,
+            id=id, photo_url=photo_url, thumbnail_url=thumbnail_url,
             photo_width=photo_width, photo_height=photo_height, title=title,
             description=description, caption=caption,
             parse_mode=parse_mode, caption_entities=caption_entities,
@@ -124,8 +166,12 @@ class InlineQueryResultGif(InlineQueryResult):
     gif_width: base.Integer = fields.Field()
     gif_height: base.Integer = fields.Field()
     gif_duration: base.Integer = fields.Field()
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_mime_type: base.String = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_mime_type: base.String = fields.Field()
     title: base.String = fields.Field()
     caption: base.String = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
@@ -138,7 +184,10 @@ class InlineQueryResultGif(InlineQueryResult):
             gif_width: typing.Optional[base.Integer] = None,
             gif_height: typing.Optional[base.Integer] = None,
             gif_duration: typing.Optional[base.Integer] = None,
-            thumb_url: typing.Optional[base.String] = None,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumb_mime_type: typing.Optional[base.String] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
+            thumbnail_mime_type: typing.Optional[base.String] = None,
             title: typing.Optional[base.String] = None,
             caption: typing.Optional[base.String] = None,
             parse_mode: typing.Optional[base.String] = None,
@@ -146,9 +195,22 @@ class InlineQueryResultGif(InlineQueryResult):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
     ):
+        if not thumbnail_url and thumb_url:
+            warn_deprecated(
+                "thumb_url parameter is deprecated, please use thumbnail_url."
+            )
+            thumbnail_url = thumb_url
+        if not thumbnail_mime_type and thumb_mime_type:
+            warn_deprecated(
+                "thumb_mime_type parameter is deprecated, please use thumbnail_mime_type."
+            )
+            thumbnail_mime_type = thumb_mime_type
+
         super().__init__(
             id=id, gif_url=gif_url, gif_width=gif_width, gif_height=gif_height,
-            gif_duration=gif_duration, thumb_url=thumb_url, title=title,
+            gif_duration=gif_duration,
+            thumbnail_url=thumbnail_url, thumbnail_mime_type=thumbnail_mime_type,
+            title=title,
             caption=caption, parse_mode=parse_mode, reply_markup=reply_markup,
             caption_entities=caption_entities,
             input_message_content=input_message_content,
@@ -170,8 +232,12 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
     mpeg4_width: base.Integer = fields.Field()
     mpeg4_height: base.Integer = fields.Field()
     mpeg4_duration: base.Integer = fields.Field()
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_mime_type: base.String = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_mime_type: base.String = fields.Field()
     title: base.String = fields.Field()
     caption: base.String = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
@@ -181,7 +247,10 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
             *,
             id: base.String,
             mpeg4_url: base.String,
-            thumb_url: base.String,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumb_mime_type: typing.Optional[base.String] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
+            thumbnail_mime_type: typing.Optional[base.String] = None,
             mpeg4_width: typing.Optional[base.Integer] = None,
             mpeg4_height: typing.Optional[base.Integer] = None,
             mpeg4_duration: typing.Optional[base.Integer] = None,
@@ -192,10 +261,26 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
     ):
+        if not thumbnail_url:
+            if thumb_url:
+                warn_deprecated(
+                    "thumb_url parameter is deprecated, please use thumbnail_url."
+                )
+                thumbnail_url = thumb_url
+            else:
+                raise ValueError("thumbnail_url is required")
+        if not thumbnail_mime_type and thumb_mime_type:
+            warn_deprecated(
+                "thumb_mime_type parameter is deprecated, please use thumbnail_mime_type."
+            )
+            thumbnail_mime_type = thumb_mime_type
+
+
         super().__init__(
             id=id, mpeg4_url=mpeg4_url, mpeg4_width=mpeg4_width,
             mpeg4_height=mpeg4_height, mpeg4_duration=mpeg4_duration,
-            thumb_url=thumb_url, title=title, caption=caption,
+            thumbnail_url=thumbnail_url, thumbnail_mime_type=thumbnail_mime_type,
+            title=title, caption=caption,
             parse_mode=parse_mode, reply_markup=reply_markup,
             caption_entities=caption_entities,
             input_message_content=input_message_content,
@@ -218,7 +303,10 @@ class InlineQueryResultVideo(InlineQueryResult):
     type: base.String = fields.Field(alias='type', default='video')
     video_url: base.String = fields.Field()
     mime_type: base.String = fields.Field()
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
     title: base.String = fields.Field()
     caption: base.String = fields.Field()
     video_width: base.Integer = fields.Field()
@@ -233,7 +321,8 @@ class InlineQueryResultVideo(InlineQueryResult):
             id: base.String,
             video_url: base.String,
             mime_type: base.String,
-            thumb_url: base.String,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
             title: base.String,
             caption: typing.Optional[base.String] = None,
             parse_mode: typing.Optional[base.String] = None,
@@ -245,8 +334,17 @@ class InlineQueryResultVideo(InlineQueryResult):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
     ):
+        if not thumbnail_url:
+            if thumb_url:
+                warn_deprecated(
+                    "thumb_url parameter is deprecated, please use thumbnail_url."
+                )
+                thumbnail_url = thumb_url
+            else:
+                raise ValueError("thumbnail_url is required")
+
         super().__init__(
-            id=id, video_url=video_url, mime_type=mime_type, thumb_url=thumb_url,
+            id=id, video_url=video_url, mime_type=mime_type, thumbnail_url=thumbnail_url,
             title=title, caption=caption, video_width=video_width,
             video_height=video_height, video_duration=video_duration,
             description=description, parse_mode=parse_mode,
@@ -357,9 +455,14 @@ class InlineQueryResultDocument(InlineQueryResult):
     mime_type: base.String = fields.Field()
     description: base.String = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_width: base.Integer = fields.Field()
     thumb_height: base.Integer = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_width: base.Integer = fields.Field()
+    thumbnail_height: base.Integer = fields.Field()
 
     def __init__(
             self,
@@ -374,17 +477,36 @@ class InlineQueryResultDocument(InlineQueryResult):
             description: typing.Optional[base.String] = None,
             reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
-            thumb_url: typing.Optional[base.String] = None,
-            thumb_width: typing.Optional[base.Integer] = None,
-            thumb_height: typing.Optional[base.Integer] = None,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumb_width: typing.Optional[base.Integer] = None,  # Deprecated
+            thumb_height: typing.Optional[base.Integer] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
+            thumbnail_width: typing.Optional[base.Integer] = None,
+            thumbnail_height: typing.Optional[base.Integer] = None,
     ):
+        if thumb_url and not thumbnail_url:
+            thumbnail_url = thumb_url
+            warn_deprecated(
+                'thumb_url is deprecated, use thumbnail_url instead',
+            )
+        if thumb_width and not thumbnail_width:
+            thumbnail_width = thumb_width
+            warn_deprecated(
+                'thumb_width is deprecated, use thumbnail_width instead',
+            )
+        if thumb_height and not thumbnail_height:
+            thumbnail_height = thumb_height
+            warn_deprecated(
+                'thumb_height is deprecated, use thumbnail_height instead',
+            )
+
         super().__init__(
             id=id, title=title, caption=caption, parse_mode=parse_mode,
             caption_entities=caption_entities, document_url=document_url,
             mime_type=mime_type, description=description, reply_markup=reply_markup,
             input_message_content=input_message_content,
-            thumb_url=thumb_url, thumb_width=thumb_width,
-            thumb_height=thumb_height,
+            thumbnail_url=thumbnail_url, thumbnail_width=thumbnail_width,
+            thumbnail_height=thumbnail_height,
         )
 
 
@@ -407,9 +529,14 @@ class InlineQueryResultLocation(InlineQueryResult):
     heading: typing.Optional[base.Integer] = fields.Field()
     proximity_alert_radius: typing.Optional[base.Integer] = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_width: base.Integer = fields.Field()
     thumb_height: base.Integer = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_width: base.Integer = fields.Field()
+    thumbnail_height: base.Integer = fields.Field()
 
     def __init__(self, *,
                  id: base.String,
@@ -422,10 +549,29 @@ class InlineQueryResultLocation(InlineQueryResult):
                  proximity_alert_radius: typing.Optional[base.Integer] = None,
                  reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
                  input_message_content: typing.Optional[InputMessageContent] = None,
-                 thumb_url: typing.Optional[base.String] = None,
-                 thumb_width: typing.Optional[base.Integer] = None,
-                 thumb_height: typing.Optional[base.Integer] = None,
+                 thumb_url: typing.Optional[base.String] = None,  # Deprecated
+                 thumb_width: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumb_height: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumbnail_url: typing.Optional[base.String] = None,
+                 thumbnail_width: typing.Optional[base.Integer] = None,
+                 thumbnail_height: typing.Optional[base.Integer] = None,
                  ):
+        if thumb_url and not thumbnail_url:
+            thumbnail_url = thumb_url
+            warn_deprecated(
+                'thumb_url is deprecated, use thumbnail_url instead',
+            )
+        if thumb_width and not thumbnail_width:
+            thumbnail_width = thumb_width
+            warn_deprecated(
+                'thumb_width is deprecated, use thumbnail_width instead',
+            )
+        if thumb_height and not thumbnail_height:
+            thumbnail_height = thumb_height
+            warn_deprecated(
+                'thumb_height is deprecated, use thumbnail_height instead',
+            )
+
         super().__init__(
             id=id,
             latitude=latitude,
@@ -437,9 +583,9 @@ class InlineQueryResultLocation(InlineQueryResult):
             proximity_alert_radius=proximity_alert_radius,
             reply_markup=reply_markup,
             input_message_content=input_message_content,
-            thumb_url=thumb_url,
-            thumb_width=thumb_width,
-            thumb_height=thumb_height
+            thumbnail_url=thumbnail_url,
+            thumbnail_width=thumbnail_width,
+            thumbnail_height=thumbnail_height,
         )
 
 
@@ -465,9 +611,14 @@ class InlineQueryResultVenue(InlineQueryResult):
     google_place_id: base.String = fields.Field()
     google_place_type: base.String = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_width: base.Integer = fields.Field()
     thumb_height: base.Integer = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_width: base.Integer = fields.Field()
+    thumbnail_height: base.Integer = fields.Field()
 
     def __init__(
             self,
@@ -483,17 +634,36 @@ class InlineQueryResultVenue(InlineQueryResult):
             google_place_type: typing.Optional[base.String] = None,
             reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
             input_message_content: typing.Optional[InputMessageContent] = None,
-            thumb_url: typing.Optional[base.String] = None,
-            thumb_width: typing.Optional[base.Integer] = None,
-            thumb_height: typing.Optional[base.Integer] = None,
+            thumb_url: typing.Optional[base.String] = None,  # Deprecated
+            thumb_width: typing.Optional[base.Integer] = None,  # Deprecated
+            thumb_height: typing.Optional[base.Integer] = None,  # Deprecated
+            thumbnail_url: typing.Optional[base.String] = None,
+            thumbnail_width: typing.Optional[base.Integer] = None,
+            thumbnail_height: typing.Optional[base.Integer] = None,
     ):
+        if thumb_url and not thumbnail_url:
+            thumbnail_url = thumb_url
+            warn_deprecated(
+                'thumb_url is deprecated, use thumbnail_url instead',
+            )
+        if thumb_width and not thumbnail_width:
+            thumbnail_width = thumb_width
+            warn_deprecated(
+                'thumb_width is deprecated, use thumbnail_width instead',
+            )
+        if thumb_height and not thumbnail_height:
+            thumbnail_height = thumb_height
+            warn_deprecated(
+                'thumb_height is deprecated, use thumbnail_height instead',
+            )
+
         super().__init__(
             id=id, latitude=latitude, longitude=longitude, title=title,
             address=address, foursquare_id=foursquare_id,
             foursquare_type=foursquare_type, google_place_id=google_place_id,
             google_place_type=google_place_type, reply_markup=reply_markup,
-            input_message_content=input_message_content, thumb_url=thumb_url,
-            thumb_width=thumb_width, thumb_height=thumb_height,
+            input_message_content=input_message_content, thumbnail_url=thumbnail_url,
+            thumbnail_width=thumbnail_width, thumbnail_height=thumbnail_height,
         )
 
 
@@ -515,9 +685,14 @@ class InlineQueryResultContact(InlineQueryResult):
     last_name: base.String = fields.Field()
     vcard: base.String = fields.Field()
     input_message_content: InputMessageContent = fields.Field(base=InputMessageContent)
+    # Deprecated fields
     thumb_url: base.String = fields.Field()
     thumb_width: base.Integer = fields.Field()
     thumb_height: base.Integer = fields.Field()
+    # New fields
+    thumbnail_url: base.String = fields.Field()
+    thumbnail_width: base.Integer = fields.Field()
+    thumbnail_height: base.Integer = fields.Field()
     foursquare_type: base.String = fields.Field()
 
     def __init__(self, *,
@@ -527,15 +702,36 @@ class InlineQueryResultContact(InlineQueryResult):
                  last_name: typing.Optional[base.String] = None,
                  reply_markup: typing.Optional[InlineKeyboardMarkup] = None,
                  input_message_content: typing.Optional[InputMessageContent] = None,
-                 thumb_url: typing.Optional[base.String] = None,
-                 thumb_width: typing.Optional[base.Integer] = None,
-                 thumb_height: typing.Optional[base.Integer] = None,
+                 thumb_url: typing.Optional[base.String] = None,  # Deprecated
+                 thumb_width: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumb_height: typing.Optional[base.Integer] = None,  # Deprecated
+                 thumbnail_url: typing.Optional[base.String] = None,
+                 thumbnail_width: typing.Optional[base.Integer] = None,
+                 thumbnail_height: typing.Optional[base.Integer] = None,
                  foursquare_type: typing.Optional[base.String] = None):
+        if thumb_url and not thumbnail_url:
+            thumbnail_url = thumb_url
+            warn_deprecated(
+                'thumb_url is deprecated, use thumbnail_url instead',
+            )
+        if thumb_width and not thumbnail_width:
+            thumbnail_width = thumb_width
+            warn_deprecated(
+                'thumb_width is deprecated, use thumbnail_width instead',
+            )
+        if thumb_height and not thumbnail_height:
+            thumbnail_height = thumb_height
+            warn_deprecated(
+                'thumb_height is deprecated, use thumbnail_height instead',
+            )
+
         super(InlineQueryResultContact, self).__init__(id=id, phone_number=phone_number,
                                                        first_name=first_name, last_name=last_name,
                                                        reply_markup=reply_markup,
-                                                       input_message_content=input_message_content, thumb_url=thumb_url,
-                                                       thumb_width=thumb_width, thumb_height=thumb_height,
+                                                       input_message_content=input_message_content,
+                                                       thumbnail_url=thumbnail_url,
+                                                       thumbnail_width=thumbnail_width,
+                                                       thumbnail_height=thumbnail_height,
                                                        foursquare_type=foursquare_type)
 
 

--- a/aiogram/types/input_media.py
+++ b/aiogram/types/input_media.py
@@ -6,6 +6,7 @@ from . import base
 from . import fields
 from .input_file import InputFile
 from .message_entity import MessageEntity
+from ..utils.deprecated import warn_deprecated
 
 ATTACHMENT_PREFIX = 'attach://'
 
@@ -112,7 +113,8 @@ class InputMediaAnimation(InputMedia):
     def __init__(
             self,
             media: base.InputFile,
-            thumb: typing.Union[base.InputFile, base.String] = None,
+            thumb: typing.Union[base.InputFile, base.String] = None,  # Deprecated
+            thumbnail: typing.Union[base.InputFile, base.String] = None,
             caption: base.String = None,
             width: base.Integer = None,
             height: base.Integer = None,
@@ -122,8 +124,14 @@ class InputMediaAnimation(InputMedia):
             has_spoiler: typing.Optional[base.Boolean] = None,
             **kwargs,
     ):
+        if not thumbnail and thumb:
+            thumbnail = thumb
+            warn_deprecated(
+                'thumb argument is deprecated, use thumbnail instead',
+            )
+
         super().__init__(
-            type='animation', media=media, thumb=thumb, caption=caption, width=width,
+            type='animation', media=media, thumbnail=thumbnail, caption=caption, width=width,
             height=height, duration=duration, parse_mode=parse_mode,
             caption_entities=caption_entities, has_spoiler=has_spoiler, conf=kwargs,
         )
@@ -139,15 +147,21 @@ class InputMediaDocument(InputMedia):
     def __init__(
             self,
             media: base.InputFile,
-            thumb: typing.Union[base.InputFile, base.String, None] = None,
+            thumb: typing.Union[base.InputFile, base.String, None] = None,  # Deprecated
+            thumbnail: typing.Union[base.InputFile, base.String, None] = None,
             caption: base.String = None,
             parse_mode: base.String = None,
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             disable_content_type_detection: typing.Optional[base.Boolean] = None,
             **kwargs,
     ):
+        if not thumbnail and thumb:
+            thumbnail = thumb
+            warn_deprecated(
+                'thumb argument is deprecated, use thumbnail instead',
+            )
         super().__init__(
-            type='document', media=media, thumb=thumb, caption=caption,
+            type='document', media=media, thumbnail=thumbnail, caption=caption,
             parse_mode=parse_mode, caption_entities=caption_entities,
             disable_content_type_detection=disable_content_type_detection,
             conf=kwargs,
@@ -168,7 +182,8 @@ class InputMediaAudio(InputMedia):
     def __init__(
             self,
             media: base.InputFile,
-            thumb: typing.Union[base.InputFile, base.String] = None,
+            thumb: typing.Union[base.InputFile, base.String] = None, # Deprecated
+            thumbnail: typing.Union[base.InputFile, base.String] = None,
             caption: base.String = None,
             duration: base.Integer = None,
             performer: base.String = None,
@@ -177,8 +192,13 @@ class InputMediaAudio(InputMedia):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             **kwargs,
     ):
+        if not thumbnail and thumb:
+            thumbnail = thumb
+            warn_deprecated(
+                'thumb argument is deprecated, use thumbnail instead',
+            )
         super().__init__(
-            type='audio', media=media, thumb=thumb, caption=caption,
+            type='audio', media=media, thumbnail=thumbnail, caption=caption,
             duration=duration, performer=performer, title=title,
             parse_mode=parse_mode, caption_entities=caption_entities, conf=kwargs,
         )
@@ -216,6 +236,8 @@ class InputMediaVideo(InputMedia):
     width: base.Integer = fields.Field()
     height: base.Integer = fields.Field()
     duration: base.Integer = fields.Field()
+    thumb: typing.Union[base.InputFile, base.String] = fields.Field()  # Deprecated
+    thumbnail: typing.Union[base.InputFile, base.String] = fields.Field()
     supports_streaming: base.Boolean = fields.Field()
     has_spoiler: typing.Optional[base.Boolean] = fields.Field()
 
@@ -223,6 +245,7 @@ class InputMediaVideo(InputMedia):
             self,
             media: base.InputFile,
             thumb: typing.Union[base.InputFile, base.String] = None,
+            thumbnail: typing.Union[base.InputFile, base.String] = None,
             caption: base.String = None,
             width: base.Integer = None,
             height: base.Integer = None,
@@ -233,8 +256,13 @@ class InputMediaVideo(InputMedia):
             has_spoiler: typing.Optional[base.Boolean] = None,
             **kwargs,
     ):
+        if not thumbnail and thumb:
+            thumbnail = thumb
+            warn_deprecated(
+                'thumb argument is deprecated, use thumbnail instead',
+            )
         super().__init__(
-            type='video', media=media, thumb=thumb, caption=caption,
+            type='video', media=media, thumbnail=thumbnail, caption=caption,
             width=width, height=height, duration=duration,
             parse_mode=parse_mode, caption_entities=caption_entities,
             supports_streaming=supports_streaming, has_spoiler=has_spoiler, conf=kwargs
@@ -346,7 +374,7 @@ class MediaGroup(base.TelegramObject):
                                     caption_entities=caption_entities)
         self.attach(audio)
 
-    def attach_document(self, document: typing.Union[InputMediaDocument, base.InputFile], 
+    def attach_document(self, document: typing.Union[InputMediaDocument, base.InputFile],
                         thumb: typing.Union[base.InputFile, base.String] = None,
                         caption: base.String = None, parse_mode: base.String = None,
                         caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
@@ -362,7 +390,7 @@ class MediaGroup(base.TelegramObject):
         :param disable_content_type_detection:
         """
         if not isinstance(document, InputMedia):
-            document = InputMediaDocument(media=document, thumb=thumb, caption=caption, 
+            document = InputMediaDocument(media=document, thumb=thumb, caption=caption,
                                           parse_mode=parse_mode, caption_entities=caption_entities,
                                           disable_content_type_detection=disable_content_type_detection)
         self.attach(document)
@@ -386,7 +414,7 @@ class MediaGroup(base.TelegramObject):
     def attach_video(self, video: typing.Union[InputMediaVideo, base.InputFile],
                      thumb: typing.Union[base.InputFile, base.String] = None,
                      caption: base.String = None,
-                     width: base.Integer = None, height: base.Integer = None, 
+                     width: base.Integer = None, height: base.Integer = None,
                      duration: base.Integer = None, parse_mode: base.String = None,
                      caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
                      supports_streaming: base.Boolean = None):

--- a/aiogram/types/input_sticker.py
+++ b/aiogram/types/input_sticker.py
@@ -1,0 +1,32 @@
+import typing
+
+from . import base, fields
+from .input_file import InputFile
+from .mask_position import MaskPosition
+
+
+class InputSticker(base.TelegramObject):
+    """
+    This object describes a sticker to be added to a sticker set.
+
+    https://core.telegram.org/bots/api#inputsticker
+    """
+    sticker: typing.Union[InputFile, base.String] = fields.Field()
+    emoji_list: typing.List[base.String] = fields.ListField(base=base.String)
+    mask_position: MaskPosition = fields.Field(base=MaskPosition)
+    keywords: typing.Optional[typing.List[base.String]] = fields.ListField(base=base.String)
+
+    def __init__(
+        self,
+        *,
+        sticker: typing.Union[InputFile, base.String],
+        emoji_list: typing.List[base.String],
+        mask_position: typing.Optional[MaskPosition] = None,
+        keywords: typing.Optional[typing.List[base.String]] = None,
+    ):
+        super().__init__(
+            sticker=sticker,
+            emoji_list=emoji_list,
+            mask_position=mask_position,
+            keywords=keywords,
+        )

--- a/aiogram/types/mask_position.py
+++ b/aiogram/types/mask_position.py
@@ -4,7 +4,8 @@ from . import fields
 
 class MaskPosition(base.TelegramObject):
     """
-    This object describes the position on faces where a mask should be placed by default.
+    This object describes the position on faces where a mask should be
+    placed by default.
 
     https://core.telegram.org/bots/api#maskposition
     """

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -457,6 +457,7 @@ class Message(base.TelegramObject):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
             protect_content: typing.Optional[base.Boolean] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             allow_sending_without_reply: typing.Optional[base.Boolean] = None,
             reply_markup: typing.Union[
                 InlineKeyboardMarkup,
@@ -493,6 +494,9 @@ class Message(base.TelegramObject):
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
 
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
+
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`typing.Optional[base.Boolean]`
@@ -517,6 +521,7 @@ class Message(base.TelegramObject):
             caption_entities=caption_entities,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,
@@ -631,6 +636,7 @@ class Message(base.TelegramObject):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
             protect_content: typing.Optional[base.Boolean] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             allow_sending_without_reply: typing.Optional[base.Boolean] = None,
             reply_markup: typing.Union[
                 InlineKeyboardMarkup,
@@ -684,6 +690,9 @@ class Message(base.TelegramObject):
         :param protect_content: Protects the contents of sent messages
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
+        
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
 
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
@@ -713,6 +722,7 @@ class Message(base.TelegramObject):
             caption_entities=caption_entities,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,
@@ -817,6 +827,7 @@ class Message(base.TelegramObject):
             thumb: typing.Union[base.InputFile, base.String, None] = None,
             caption: typing.Optional[base.String] = None,
             parse_mode: typing.Optional[base.String] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             supports_streaming: typing.Optional[base.Boolean] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
@@ -874,6 +885,9 @@ class Message(base.TelegramObject):
         :param protect_content: Protects the contents of sent messages
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
+        
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
 
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
@@ -904,6 +918,7 @@ class Message(base.TelegramObject):
             supports_streaming=supports_streaming,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,

--- a/aiogram/types/sticker.py
+++ b/aiogram/types/sticker.py
@@ -25,6 +25,7 @@ class Sticker(base.TelegramObject, mixins.Downloadable):
     premium_animation: File = fields.Field(base=File)
     mask_position: MaskPosition = fields.Field(base=MaskPosition)
     custom_emoji_id: base.String = fields.Field()
+    needs_repainting: base.Boolean = fields.Field()
     file_size: base.Integer = fields.Field()
 
     async def set_position_in_set(self, position: base.Integer) -> base.Boolean:

--- a/aiogram/types/sticker.py
+++ b/aiogram/types/sticker.py
@@ -1,9 +1,12 @@
+import typing
+
 from . import base
 from . import fields
 from . import mixins
+from .file import File
 from .mask_position import MaskPosition
 from .photo_size import PhotoSize
-from .file import File
+from ..utils.deprecated import warn_deprecated
 
 
 class Sticker(base.TelegramObject, mixins.Downloadable):
@@ -19,7 +22,7 @@ class Sticker(base.TelegramObject, mixins.Downloadable):
     height: base.Integer = fields.Field()
     is_animated: base.Boolean = fields.Field()
     is_video: base.Boolean = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
     emoji: base.String = fields.Field()
     set_name: base.String = fields.Field()
     premium_animation: File = fields.Field(base=File)
@@ -27,6 +30,13 @@ class Sticker(base.TelegramObject, mixins.Downloadable):
     custom_emoji_id: base.String = fields.Field()
     needs_repainting: base.Boolean = fields.Field()
     file_size: base.Integer = fields.Field()
+
+    @property
+    def thumb(self) -> typing.Optional[PhotoSize]:
+        warn_deprecated(
+            "The 'thumb' property is deprecated, use 'thumbnail' instead."
+        )
+        return self.thumbnail
 
     async def set_position_in_set(self, position: base.Integer) -> base.Boolean:
         """

--- a/aiogram/types/sticker_set.py
+++ b/aiogram/types/sticker_set.py
@@ -4,6 +4,7 @@ from . import base
 from . import fields
 from .photo_size import PhotoSize
 from .sticker import Sticker
+from ..utils.deprecated import warn_deprecated
 
 
 class StickerSet(base.TelegramObject):
@@ -19,4 +20,9 @@ class StickerSet(base.TelegramObject):
     is_video: base.Boolean = fields.Field()
     contains_masks: base.Boolean = fields.Field()  # Deprecated
     stickers: typing.List[Sticker] = fields.ListField(base=Sticker)
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
+
+    @property
+    def thumb(self):
+        warn_deprecated('thumb is deprecated, use thumbnail instead')
+        return self.thumbnail

--- a/aiogram/types/video.py
+++ b/aiogram/types/video.py
@@ -1,7 +1,10 @@
+import typing
+
 from . import base
 from . import fields
 from . import mixins
 from .photo_size import PhotoSize
+from ..utils.deprecated import warn_deprecated
 
 
 class Video(base.TelegramObject, mixins.Downloadable):
@@ -15,7 +18,15 @@ class Video(base.TelegramObject, mixins.Downloadable):
     width: base.Integer = fields.Field()
     height: base.Integer = fields.Field()
     duration: base.Integer = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
     file_name: base.String = fields.Field()
     mime_type: base.String = fields.Field()
     file_size: base.Integer = fields.Field()
+
+
+    @property
+    def thumb(self):
+        warn_deprecated(
+            "thumb is deprecated. Use thumbnail instead",
+        )
+        return self.thumbnail

--- a/aiogram/types/video_note.py
+++ b/aiogram/types/video_note.py
@@ -1,7 +1,10 @@
+import typing
+
 from . import base
 from . import fields
 from . import mixins
 from .photo_size import PhotoSize
+from ..utils.deprecated import warn_deprecated
 
 
 class VideoNote(base.TelegramObject, mixins.Downloadable):
@@ -14,5 +17,12 @@ class VideoNote(base.TelegramObject, mixins.Downloadable):
     file_unique_id: base.String = fields.Field()
     length: base.Integer = fields.Field()
     duration: base.Integer = fields.Field()
-    thumb: PhotoSize = fields.Field(base=PhotoSize)
+    thumbnail: PhotoSize = fields.Field(base=PhotoSize)
     file_size: base.Integer = fields.Field()
+
+    @property
+    def thumb(self):
+        warn_deprecated(
+            "thumb is deprecated. Use thumbnail instead",
+        )
+        return self.thumbnail

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ Welcome to aiogram's documentation!
        :target: https://pypi.python.org/pypi/aiogram
        :alt: Supported python versions
 
-    .. image:: https://img.shields.io/badge/Telegram%20Bot%20API-6.4-blue.svg?style=flat-square&logo=telegram
+    .. image:: https://img.shields.io/badge/Telegram%20Bot%20API-6.6-blue.svg?style=flat-square&logo=telegram
        :target: https://core.telegram.org/bots/api
        :alt: Telegram Bot API
 


### PR DESCRIPTION
# Description

Fixes #1140

- [x] Added the ability to set different bot descriptions for different user languages using the method [setMyDescription](https://core.telegram.org/bots/api#setmydescription).
- [x] Added the ability to get the current bot description in the given language as the class [BotDescription](https://core.telegram.org/bots/api#botdescription) using the method [getMyDescription](https://core.telegram.org/bots/api#getmydescription).
- [x] Added the ability to set different bot short descriptions for different user languages using the method [setMyShortDescription](https://core.telegram.org/bots/api#setmyshortdescription).
- [x] Added the ability to get the current bot short description in the given language as the class [BotShortDescription](https://core.telegram.org/bots/api#botshortdescription) using the method [getMyShortDescription](https://core.telegram.org/bots/api#getmyshortdescription).
- [x] Added the parameter emoji to the method [sendSticker](https://core.telegram.org/bots/api#sendsticker) to specify an emoji for just uploaded stickers.
- [ ] Added support for the creation of custom emoji sticker sets in [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).
- [x] Added the parameter needs_repainting to the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset) to automatically change the color of emoji based on context (e.g., use text color in messages, accent color in statuses, etc.).
- [x] Added the field needs_repainting to the class [Sticker](https://core.telegram.org/bots/api#sticker).
- [ ] Replaced the parameters png_sticker, tgs_sticker, webm_sticker, emojis and mask_postion in the method [addStickerToSet](https://core.telegram.org/bots/api#addstickertoset) with the parameter sticker of the type [InputSticker](https://core.telegram.org/bots/api#inputsticker).
- [ ] Added support for the creation of sticker sets with multiple initial stickers in [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset) by replacing the parameters png_sticker, tgs_sticker, webm_sticker, emojis and mask_postion with the parameters stickers and sticker_format.
- [ ] Added support for .WEBP files in [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset) and [addStickerToSet](https://core.telegram.org/bots/api#addstickertoset).
- [ ] Added support for .WEBP, .TGS, and .WEBM files in [uploadStickerFile](https://core.telegram.org/bots/api#uploadstickerfile) by replacing the parameter png_sticker in the method [uploadStickerFile](https://core.telegram.org/bots/api#uploadstickerfile) with the parameters sticker and sticker_format.
- [ ] Added the ability to specify search keywords for stickers added to sticker sets.
- [x] Added the method [setCustomEmojiStickerSetThumbnail](https://core.telegram.org/bots/api#setcustomemojistickersetthumbnail) for editing the thumbnail of custom emoji sticker sets created by the bot.
- [x] Added the method [setStickerSetTitle](https://core.telegram.org/bots/api#setstickersettitle) for editing the title of sticker sets created by the bot.
- [x] Added the method [deleteStickerSet](https://core.telegram.org/bots/api#deletestickerset) for complete deletion of a given sticker set that was created by the bot.
- [ ] Added the method [setStickerEmojiList](https://core.telegram.org/bots/api#setstickeremojilist) for changing the list of emoji associated with a sticker.
- [ ] Added the method [setStickerKeywords](https://core.telegram.org/bots/api#setstickerkeywords) for changing the search keywords assigned to a sticker.
- [ ] Added the method [setStickerMaskPosition](https://core.telegram.org/bots/api#setstickermaskposition) for changing the [mask position](https://core.telegram.org/bots/api#maskposition) of a mask sticker.
- [ ] Renamed the field thumb in the classes [Animation](https://core.telegram.org/bots/api#animation), [Audio](https://core.telegram.org/bots/api#audio), [Document](https://core.telegram.org/bots/api#document), [Sticker](https://core.telegram.org/bots/api#sticker), [Video](https://core.telegram.org/bots/api#video), [VideoNote](https://core.telegram.org/bots/api#videonote), [InputMediaAnimation](https://core.telegram.org/bots/api#inputmediaanimation), [InputMediaAudio](https://core.telegram.org/bots/api#inputmediaaudio), [InputMediaDocument](https://core.telegram.org/bots/api#inputmediadocument), [InputMediaVideo](https://core.telegram.org/bots/api#inputmediavideo), [StickerSet](https://core.telegram.org/bots/api#stickerset) to thumbnail.
- [ ] Renamed the parameter thumb in the methods [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote) to thumbnail.
- [x] Renamed the method setStickerSetThumb to [setStickerSetThumbnail](https://core.telegram.org/bots/api#setstickersetthumbnail) and its parameter thumb to thumbnail.
- [ ] Renamed the fields thumb_url, thumb_width, and thumb_height in the classes [InlineQueryResultArticle](https://core.telegram.org/bots/api#inlinequeryresultarticle), [InlineQueryResultContact](https://core.telegram.org/bots/api#inlinequeryresultcontact), [InlineQueryResultDocument](https://core.telegram.org/bots/api#inlinequeryresultdocument), [InlineQueryResultLocation](https://core.telegram.org/bots/api#inlinequeryresultlocation), and [InlineQueryResultVenue](https://core.telegram.org/bots/api#inlinequeryresultvenue) to thumbnail_url, thumbnail_width, and thumbnail_height respectively.
- [ ] Renamed the field thumb_url in the classes [InlineQueryResultPhoto](https://core.telegram.org/bots/api#inlinequeryresultphoto) and [InlineQueryResultVideo](https://core.telegram.org/bots/api#inlinequeryresultvideo) to thumbnail_url.
- [ ] Renamed the fields thumb_url and thumb_mime_type in the classes [InlineQueryResultGif](https://core.telegram.org/bots/api#inlinequeryresultgif), and [InlineQueryResultMpeg4Gif](https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif) to thumbnail_url and thumbnail_mime_type respectively.


## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
