### PR TITLE
Change `InlineQueryResultType.MPEG` to more correct

### DIFF
--- a/.butcher/enums/InlineQueryResultType.yml
+++ b/.butcher/enums/InlineQueryResultType.yml
@@ -5,7 +5,7 @@ description: |
   Source: https://core.telegram.org/bots/api#inlinequeryresult
 multi_parse:
   attribute: type
-  regexp: "must be ([a-z_]+)"
+  regexp: "must be ([a-z_0-9]+)"
   entities:
   - InlineQueryResultCachedAudio
   - InlineQueryResultCachedDocument

--- a/CHANGES/1146.bugfix.rst
+++ b/CHANGES/1146.bugfix.rst
@@ -1,0 +1,4 @@
+Change type of result in InlineQueryResult enum for `InlineQueryResultCachedMpeg4Gif`
+and `InlineQueryResultMpeg4Gif` to more correct according to documentation.
+
+Change regexp for entities parsing to more correct (`InlineQueryResultType.yml`).

--- a/aiogram/enums/inline_query_result_type.py
+++ b/aiogram/enums/inline_query_result_type.py
@@ -11,7 +11,7 @@ class InlineQueryResultType(str, Enum):
     AUDIO = "audio"
     DOCUMENT = "document"
     GIF = "gif"
-    MPEG4GIF = "mpeg4_gif"
+    MPEG4_GIF = "mpeg4_gif"
     PHOTO = "photo"
     STICKER = "sticker"
     VIDEO = "video"

--- a/aiogram/enums/inline_query_result_type.py
+++ b/aiogram/enums/inline_query_result_type.py
@@ -11,7 +11,7 @@ class InlineQueryResultType(str, Enum):
     AUDIO = "audio"
     DOCUMENT = "document"
     GIF = "gif"
-    MPEG = "mpeg"
+    MPEG4GIF = "mpeg4_gif"
     PHOTO = "photo"
     STICKER = "sticker"
     VIDEO = "video"

--- a/aiogram/types/inline_query_result_cached_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_cached_mpeg4_gif.py
@@ -21,7 +21,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG4GIF, const=True)
+    type: str = Field(InlineQueryResultType.MPEG4_GIF, const=True)
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_cached_mpeg4_gif.py
@@ -21,7 +21,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG, const=True)
+    type: str = Field(InlineQueryResultType.MPEG4GIF, const=True)
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_mpeg4_gif.py
@@ -21,7 +21,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG4GIF, const=True)
+    type: str = Field(InlineQueryResultType.MPEG4_GIF, const=True)
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_mpeg4_gif.py
@@ -21,7 +21,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG, const=True)
+    type: str = Field(InlineQueryResultType.MPEG4GIF, const=True)
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""


### PR DESCRIPTION
# Description

Change type of result in `InlineQueryResult` enum for `InlineQueryResultCachedMpeg4Gif]` and `InlineQueryResultMpeg4Gif` to more correct according to documentation

## Type of change

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)