### PR TITLE
Auto-update LICENSE file every year automatically (#1055)

### DIFF
--- a/.github/workflows/autoupdate-license.yaml
+++ b/.github/workflows/autoupdate-license.yaml
@@ -1,0 +1,25 @@
+name: Update License Year
+
+on:
+  schedule:
+    - cron: '0 0 1 1 *'
+
+jobs:
+  update-year:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Update year in license file
+        run: |
+          year=$(date +%Y)
+          sed -i "s/2017-[0-9]*/2017-$year/g" LICENSE
+
+      - name: Set git config
+        run: |
+          git config user.name "Automated"
+          git config user.email "actions@users.noreply.github.com"
+          git add LICENSE
+          git commit -m "Update license years" || exit 1
+          git push


### PR DESCRIPTION
# Description

This pull request adds a new feature to automatically update the LICENSE years using GitHub Actions. The update is scheduled to run on the first day of January at midnight.

The update is performed by finding the pattern "2017-re with any digit" and replacing it with "2017-current year" using the sed command. The actions/checkout@v3 is used to checkout the source code as described in [this issue](https://github.com/actions/checkout/issues/959).

This pull request is related to issue #1055 in the aiogram repository.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project. 
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

P.S. link to style guidelines does not work https://docs.aiogram.dev/en/dev-3.x/contributing/
 
