### PR TITLE
fix(docs): fix wrong page link in docs

### DIFF
--- a/docs/api/upload_file.rst
+++ b/docs/api/upload_file.rst
@@ -10,7 +10,7 @@ there are three ways to send files (photos, stickers, audio, media, etc.):
 If the file is already stored somewhere on the Telegram servers or file is available by the URL,
 you don't need to reupload it.
 
-But if you need to upload a new file just use subclasses of `InputFile <types/input_file.md>`__.
+But if you need to upload a new file just use subclasses of `InputFile <types/input_file.html>`__.
 
 Here are the three different available builtin types of input file:
 


### PR DESCRIPTION
# Description

Wrong link to input_file docs page.
Also, it was changed in #1133


## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
