### PR TITLE
Resolve  #1155: Different signature of startup/shutdown events on polling and webhooks 

### DIFF
--- a/CHANGES/1155.bugfix.rst
+++ b/CHANGES/1155.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed signature of startup/shutdown events to include the **dispatcher.workflow_data as the handler arguments.

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -80,9 +80,9 @@ class Dispatcher(Router):
         # FSM middleware should always be registered after User context middleware
         # because here is used context from previous step
         self.fsm = FSMContextMiddleware(
-            storage=storage if storage else MemoryStorage(),
+            storage=storage or MemoryStorage(),
             strategy=fsm_strategy,
-            events_isolation=events_isolation if events_isolation else DisabledEventIsolation(),
+            events_isolation=events_isolation or DisabledEventIsolation(),
         )
         if not disable_fsm:
             # Note that when FSM middleware is disabled, the event isolation is also disabled
@@ -251,14 +251,14 @@ class Dispatcher(Router):
         try:
             update_type = update.event_type
             event = update.event
-        except UpdateTypeLookupError:
+        except UpdateTypeLookupError as e:
             warnings.warn(
                 "Detected unknown update type.\n"
                 "Seems like Telegram Bot API was updated and you have "
                 "installed not latest version of aiogram framework",
                 RuntimeWarning,
             )
-            raise SkipHandler()
+            raise SkipHandler() from e
 
         kwargs.update(event_update=update)
 
@@ -373,7 +373,7 @@ class Dispatcher(Router):
         loop = asyncio.get_running_loop()
         waiter = loop.create_future()
 
-        def release_waiter(*args: Any) -> None:
+        def release_waiter(*_: Any) -> None:
             if not waiter.done():
                 waiter.set_result(None)
 

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -488,8 +488,13 @@ class Dispatcher(Router):
                         signal.SIGINT, self._signal_stop_polling, signal.SIGINT
                     )
 
-            workflow_data = {"dispatcher": self, "bots": bots, "bot": bots[-1]}
-            workflow_data.update(kwargs)
+            workflow_data = {
+                "dispatcher": self,
+                "bots": bots,
+                "bot": bots[-1],
+                **kwargs,
+                **self.workflow_data,
+            }
             await self.emit_startup(**workflow_data)
             loggers.dispatcher.info("Start polling")
             try:


### PR DESCRIPTION
# Description

I fixed bug by adding Dispatcher's workflow_data to the passed arguments of event handlers.
Webhook's signature:
https://github.com/aiogram/aiogram/blob/fea1b7b0a385e4dd701ea644fd6e9052ec95c587/aiogram/webhook/aiohttp_server.py#L28-L33
Current polling's signature:
https://github.com/aiogram/aiogram/blob/fea1b7b0a385e4dd701ea644fd6e9052ec95c587/aiogram/dispatcher/dispatcher.py#L491-L492
New polling's signature:
https://github.com/aiogram/aiogram/blob/c40c9dae67859ff50c58ec82c11fd146cfeae389/aiogram/dispatcher/dispatcher.py#L491-L497


Fixes #1155 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
No additional tests were created, as there is no tests testing passed arguments. It would be great, if they will be added.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (added changes file)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
