### PR TITLE
Add missing await in examples

### DIFF
--- a/examples/multibot.py
+++ b/examples/multibot.py
@@ -45,7 +45,7 @@ async def command_add_bot(message: Message, command: CommandObject, bot: Bot) ->
     try:
         bot_user = await new_bot.get_me()
     except TelegramUnauthorizedError:
-        return message.answer("Invalid token")
+        return await message.answer("Invalid token")
     await new_bot.delete_webhook(drop_pending_updates=True)
     await new_bot.set_webhook(OTHER_BOTS_URL.format(bot_token=command.args))
     return await message.answer(f"Bot @{bot_user.username} successful added")


### PR DESCRIPTION
# Description

Add missing `await` in multibot example


## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
