### PR TITLE
Fix markdown spoiler

### DIFF
--- a/CHANGES/1176.bugfix.rst
+++ b/CHANGES/1176.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the markdown spoiler parser.

--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -233,7 +233,7 @@ class MarkdownDecoration(TextDecoration):
         return f"~{value}~"
 
     def spoiler(self, value: str) -> str:
-        return f"|{value}|"
+        return f"||{value}||"
 
     def quote(self, value: str) -> str:
         return re.sub(pattern=self.MARKDOWN_QUOTE_PATTERN, repl=r"\\\1", string=value)

--- a/tests/test_utils/test_text_decorations.py
+++ b/tests/test_utils/test_text_decorations.py
@@ -90,7 +90,7 @@ class TestTextDecoration:
             [markdown_decoration, MessageEntity(type="bot_command", offset=0, length=5), "test"],
             [markdown_decoration, MessageEntity(type="email", offset=0, length=5), "test"],
             [markdown_decoration, MessageEntity(type="phone_number", offset=0, length=5), "test"],
-            [markdown_decoration, MessageEntity(type="spoiler", offset=0, length=5), "|test|"],
+            [markdown_decoration, MessageEntity(type="spoiler", offset=0, length=5), "||test||"],
             [
                 markdown_decoration,
                 MessageEntity(type="custom_emoji", offset=0, length=5, custom_emoji_id="42"),


### PR DESCRIPTION
# Description
In [telegram bot api documentation](https://core.telegram.org/bots/api#markdownv2-style) said that need two characters, but there we have only one. I did catch a bug with this, but github issue I didn't find and don't want to create.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested it on my own project, but you can use this code:
```python
...
@router.message()
async def test(m: types.Message):
    return await m.answer(m.md_text)
```