### PR TITLE
Significant performance improve about x10 more times. 

### DIFF
--- a/aiogram/filters/state.py
+++ b/aiogram/filters/state.py
@@ -27,7 +27,7 @@ class StateFilter(Filter):
         )
 
     async def __call__(
-        self, obj: Union[TelegramObject], raw_state: Optional[str] = None
+        self, obj: Union[TelegramObject], raw_state: Optional[str] = None, **kwargs
     ) -> Union[bool, Dict[str, Any]]:
         allowed_states = cast(Sequence[StateType], self.states)
         for allowed_state in allowed_states:

--- a/aiogram/methods/answer_inline_query.py
+++ b/aiogram/methods/answer_inline_query.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
-
-from pydantic import Field
+from typing import List, Optional
 
 from ..types import InlineQueryResult, InlineQueryResultsButton
 from .base import TelegramMethod
@@ -32,12 +30,12 @@ class AnswerInlineQuery(TelegramMethod[bool]):
     """Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes."""
     button: Optional[InlineQueryResultsButton] = None
     """A JSON-serialized object describing a button to be shown above inline query results"""
-    switch_pm_parameter: Optional[str] = Field(None, deprecated=True)
+    switch_pm_parameter: Optional[str] = None
     """`Deep-linking <https://core.telegram.org/bots/features#deep-linking>`_ parameter for the /start message sent to the bot when user presses the switch button. 1-64 characters, only :code:`A-Z`, :code:`a-z`, :code:`0-9`, :code:`_` and :code:`-` are allowed.
 
 .. deprecated:: API:6.7
    https://core.telegram.org/bots/api-changelog#april-21-2023"""
-    switch_pm_text: Optional[str] = Field(None, deprecated=True)
+    switch_pm_text: Optional[str] = None
     """If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter *switch_pm_parameter*
 
 .. deprecated:: API:6.7

--- a/aiogram/methods/copy_message.py
+++ b/aiogram/methods/copy_message.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -35,13 +37,13 @@ class CopyMessage(TelegramMethod[MessageId]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     caption: Optional[str] = None
     """New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the new caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of *parse_mode*"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/edit_message_caption.py
+++ b/aiogram/methods/edit_message_caption.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import UNSET_PARSE_MODE, InlineKeyboardMarkup, Message, MessageEntity
 from .base import TelegramMethod
 
@@ -24,7 +26,7 @@ class EditMessageCaption(TelegramMethod[Union[Message, bool]]):
     """Required if *chat_id* and *message_id* are not specified. Identifier of the inline message"""
     caption: Optional[str] = None
     """New caption of the message, 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the message caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""

--- a/aiogram/methods/edit_message_text.py
+++ b/aiogram/methods/edit_message_text.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import UNSET_PARSE_MODE, InlineKeyboardMarkup, Message, MessageEntity
 from ..types.base import UNSET_DISABLE_WEB_PAGE_PREVIEW
 from .base import TelegramMethod
@@ -25,11 +27,13 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
     inline_message_id: Optional[str] = None
     """Required if *chat_id* and *message_id* are not specified. Identifier of the inline message"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the message text. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in message text, which can be specified instead of *parse_mode*"""
-    disable_web_page_preview: Optional[bool] = UNSET_DISABLE_WEB_PAGE_PREVIEW
+    disable_web_page_preview: Optional[bool] = msgspec.field(
+        default_factory=lambda: UNSET_DISABLE_WEB_PAGE_PREVIEW
+    )
     """Disables link previews for links in this message"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_."""

--- a/aiogram/methods/forward_message.py
+++ b/aiogram/methods/forward_message.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+import msgspec
+
 from ..types import Message
 from ..types.base import UNSET_PROTECT_CONTENT
 from .base import TelegramMethod
@@ -27,5 +29,5 @@ class ForwardMessage(TelegramMethod[Message]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the forwarded message from forwarding and saving"""

--- a/aiogram/methods/send_animation.py
+++ b/aiogram/methods/send_animation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -42,7 +44,7 @@ class SendAnimation(TelegramMethod[Message]):
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
     caption: Optional[str] = None
     """Animation caption (may also be used when resending animation by *file_id*), 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the animation caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -50,7 +52,7 @@ class SendAnimation(TelegramMethod[Message]):
     """Pass :code:`True` if the animation needs to be covered with a spoiler animation"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_audio.py
+++ b/aiogram/methods/send_audio.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Optional, Union
+
+import msgspec
 
 from ..types import (
     UNSET_PARSE_MODE,
@@ -35,7 +37,7 @@ class SendAudio(TelegramMethod[Message]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     caption: Optional[str] = None
     """Audio caption, 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the audio caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -49,7 +51,7 @@ class SendAudio(TelegramMethod[Message]):
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_contact.py
+++ b/aiogram/methods/send_contact.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
+
+import msgspec
 
 from ..types import (
     ForceReply,
@@ -37,7 +39,7 @@ class SendContact(TelegramMethod[Message]):
     """Additional data about the contact in the form of a `vCard <https://en.wikipedia.org/wiki/VCard>`_, 0-2048 bytes"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_dice.py
+++ b/aiogram/methods/send_dice.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
+
+import msgspec
 
 from ..types import (
     ForceReply,
@@ -31,7 +33,7 @@ class SendDice(TelegramMethod[Message]):
     """Emoji on which the dice throw animation is based. Currently, must be one of '🎲', '🎯', '🏀', '⚽', '🎳', or '🎰'. Dice can have values 1-6 for '🎲', '🎯' and '🎳', values 1-5 for '🏀' and '⚽', and values 1-64 for '🎰'. Defaults to '🎲'"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_document.py
+++ b/aiogram/methods/send_document.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -36,7 +38,7 @@ class SendDocument(TelegramMethod[Message]):
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
     caption: Optional[str] = None
     """Document caption (may also be used when resending documents by *file_id*), 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the document caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -44,7 +46,7 @@ class SendDocument(TelegramMethod[Message]):
     """Disables automatic server-side content type detection for files uploaded using multipart/form-data"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_game.py
+++ b/aiogram/methods/send_game.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
+import msgspec
+
 from ..types import InlineKeyboardMarkup, Message
 from ..types.base import UNSET_PROTECT_CONTENT
 from .base import TelegramMethod
@@ -25,7 +27,7 @@ class SendGame(TelegramMethod[Message]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_invoice.py
+++ b/aiogram/methods/send_invoice.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import InlineKeyboardMarkup, LabeledPrice, Message
 from ..types.base import UNSET_PROTECT_CONTENT
 from .base import TelegramMethod
@@ -65,7 +67,7 @@ class SendInvoice(TelegramMethod[Message]):
     """Pass :code:`True` if the final price depends on the shipping method"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_location.py
+++ b/aiogram/methods/send_location.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+import msgspec
+
 from ..types import (
     ForceReply,
     InlineKeyboardMarkup,
@@ -41,7 +43,7 @@ class SendLocation(TelegramMethod[Message]):
     """For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified."""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_media_group.py
+++ b/aiogram/methods/send_media_group.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     InputMediaAudio,
     InputMediaDocument,
@@ -31,7 +33,7 @@ class SendMediaGroup(TelegramMethod[List[Message]]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     disable_notification: Optional[bool] = None
     """Sends messages `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent messages from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the messages are a reply, ID of the original message"""

--- a/aiogram/methods/send_message.py
+++ b/aiogram/methods/send_message.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -31,15 +33,17 @@ class SendMessage(TelegramMethod[Message]):
     """Text of the message to be sent, 1-4096 characters after entities parsing"""
     message_thread_id: Optional[int] = None
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the message text. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in message text, which can be specified instead of *parse_mode*"""
-    disable_web_page_preview: Optional[bool] = UNSET_DISABLE_WEB_PAGE_PREVIEW
+    disable_web_page_preview: Optional[bool] = msgspec.field(
+        default_factory=lambda: UNSET_DISABLE_WEB_PAGE_PREVIEW
+    )
     """Disables link previews for links in this message"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_photo.py
+++ b/aiogram/methods/send_photo.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -34,7 +36,7 @@ class SendPhoto(TelegramMethod[Message]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     caption: Optional[str] = None
     """Photo caption (may also be used when resending photos by *file_id*), 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the photo caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -42,7 +44,7 @@ class SendPhoto(TelegramMethod[Message]):
     """Pass :code:`True` if the photo needs to be covered with a spoiler animation"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_poll.py
+++ b/aiogram/methods/send_poll.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -44,7 +46,7 @@ class SendPoll(TelegramMethod[Message]):
     """0-based identifier of the correct answer option, required for polls in quiz mode"""
     explanation: Optional[str] = None
     """Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing"""
-    explanation_parse_mode: Optional[str] = UNSET_PARSE_MODE
+    explanation_parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the explanation. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     explanation_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the poll explanation, which can be specified instead of *parse_mode*"""
@@ -56,7 +58,7 @@ class SendPoll(TelegramMethod[Message]):
     """Pass :code:`True` if the poll needs to be immediately closed. This can be useful for poll preview."""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_sticker.py
+++ b/aiogram/methods/send_sticker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+import msgspec
+
 from ..types import (
     ForceReply,
     InlineKeyboardMarkup,
@@ -34,7 +36,7 @@ class SendSticker(TelegramMethod[Message]):
     """Emoji associated with the sticker; only for just uploaded stickers"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_venue.py
+++ b/aiogram/methods/send_venue.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+import msgspec
+
 from ..types import (
     ForceReply,
     InlineKeyboardMarkup,
@@ -45,7 +47,7 @@ class SendVenue(TelegramMethod[Message]):
     """Google Places type of the venue. (See `supported types <https://developers.google.com/places/web-service/supported_types>`_.)"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_video.py
+++ b/aiogram/methods/send_video.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -42,7 +44,7 @@ class SendVideo(TelegramMethod[Message]):
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
     caption: Optional[str] = None
     """Video caption (may also be used when resending videos by *file_id*), 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the video caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -52,7 +54,7 @@ class SendVideo(TelegramMethod[Message]):
     """Pass :code:`True` if the uploaded video is suitable for streaming"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_video_note.py
+++ b/aiogram/methods/send_video_note.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+import msgspec
+
 from ..types import (
     ForceReply,
     InlineKeyboardMarkup,
@@ -38,7 +40,7 @@ class SendVideoNote(TelegramMethod[Message]):
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/methods/send_voice.py
+++ b/aiogram/methods/send_voice.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import msgspec
+
 from ..types import (
     UNSET_PARSE_MODE,
     ForceReply,
@@ -34,7 +36,7 @@ class SendVoice(TelegramMethod[Message]):
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
     caption: Optional[str] = None
     """Voice message caption, 0-1024 characters after entities parsing"""
-    parse_mode: Optional[str] = UNSET_PARSE_MODE
+    parse_mode: Optional[str] = msgspec.field(default_factory=lambda: UNSET_PARSE_MODE)
     """Mode for parsing entities in the voice message caption. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     caption_entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
@@ -42,7 +44,7 @@ class SendVoice(TelegramMethod[Message]):
     """Duration of the voice message in seconds"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
-    protect_content: Optional[bool] = UNSET_PROTECT_CONTENT
+    protect_content: Optional[bool] = msgspec.field(default_factory=lambda: UNSET_PROTECT_CONTENT)
     """Protects the contents of the sent message from forwarding and saving"""
     reply_to_message_id: Optional[int] = None
     """If the message is a reply, ID of the original message"""

--- a/aiogram/types/animation.py
+++ b/aiogram/types/animation.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class Animation(TelegramObject):

--- a/aiogram/types/audio.py
+++ b/aiogram/types/audio.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class Audio(TelegramObject):

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -1,26 +1,19 @@
-import datetime
 from typing import Any
 from unittest.mock import sentinel
 
-from pydantic import BaseModel, Extra
+import msgspec
 
 from aiogram.utils.mixins import ContextInstanceMixin
 
 
-class TelegramObject(ContextInstanceMixin["TelegramObject"], BaseModel):
-    class Config:
-        use_enum_values = True
-        orm_mode = True
-        extra = Extra.allow
-        validate_assignment = True
-        allow_mutation = False
-        allow_population_by_field_name = True
-        json_encoders = {datetime.datetime: lambda dt: int(dt.timestamp())}
+class TelegramObject(
+    ContextInstanceMixin["TelegramObject"], msgspec.Struct, omit_defaults=True, weakref=True
+):
+    ...
 
 
 class MutableTelegramObject(TelegramObject):
-    class Config:
-        allow_mutation = True
+    ...
 
 
 # special sentinel object which used in situation when None might be a useful value

--- a/aiogram/types/bot_command_scope_all_chat_administrators.py
+++ b/aiogram/types/bot_command_scope_all_chat_administrators.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeAllChatAdministrators(BotCommandScope):
+class BotCommandScopeAllChatAdministrators(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering all group and supergroup chat administrators.
 
     Source: https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
     """
 
-    type: str = Field(BotCommandScopeType.ALL_CHAT_ADMINISTRATORS, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.ALL_CHAT_ADMINISTRATORS)
     """Scope type, must be *all_chat_administrators*"""

--- a/aiogram/types/bot_command_scope_all_group_chats.py
+++ b/aiogram/types/bot_command_scope_all_group_chats.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeAllGroupChats(BotCommandScope):
+class BotCommandScopeAllGroupChats(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering all group and supergroup chats.
 
     Source: https://core.telegram.org/bots/api#botcommandscopeallgroupchats
     """
 
-    type: str = Field(BotCommandScopeType.ALL_GROUP_CHATS, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.ALL_GROUP_CHATS)
     """Scope type, must be *all_group_chats*"""

--- a/aiogram/types/bot_command_scope_all_private_chats.py
+++ b/aiogram/types/bot_command_scope_all_private_chats.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeAllPrivateChats(BotCommandScope):
+class BotCommandScopeAllPrivateChats(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering all private chats.
 
     Source: https://core.telegram.org/bots/api#botcommandscopeallprivatechats
     """
 
-    type: str = Field(BotCommandScopeType.ALL_PRIVATE_CHATS, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.ALL_PRIVATE_CHATS)
     """Scope type, must be *all_private_chats*"""

--- a/aiogram/types/bot_command_scope_chat.py
+++ b/aiogram/types/bot_command_scope_chat.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 from typing import Union
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeChat(BotCommandScope):
+class BotCommandScopeChat(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering a specific chat.
 
     Source: https://core.telegram.org/bots/api#botcommandscopechat
     """
 
-    type: str = Field(BotCommandScopeType.CHAT, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.CHAT)
     """Scope type, must be *chat*"""
     chat_id: Union[int, str]
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""

--- a/aiogram/types/bot_command_scope_chat_administrators.py
+++ b/aiogram/types/bot_command_scope_chat_administrators.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 from typing import Union
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeChatAdministrators(BotCommandScope):
+class BotCommandScopeChatAdministrators(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering all administrators of a specific group or supergroup chat.
 
     Source: https://core.telegram.org/bots/api#botcommandscopechatadministrators
     """
 
-    type: str = Field(BotCommandScopeType.CHAT_ADMINISTRATORS, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.CHAT_ADMINISTRATORS)
     """Scope type, must be *chat_administrators*"""
     chat_id: Union[int, str]
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""

--- a/aiogram/types/bot_command_scope_chat_member.py
+++ b/aiogram/types/bot_command_scope_chat_member.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 from typing import Union
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeChatMember(BotCommandScope):
+class BotCommandScopeChatMember(BotCommandScope, kw_only=True):
     """
     Represents the `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands, covering a specific member of a group or supergroup chat.
 
     Source: https://core.telegram.org/bots/api#botcommandscopechatmember
     """
 
-    type: str = Field(BotCommandScopeType.CHAT_MEMBER, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.CHAT_MEMBER)
     """Scope type, must be *chat_member*"""
     chat_id: Union[int, str]
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""

--- a/aiogram/types/bot_command_scope_default.py
+++ b/aiogram/types/bot_command_scope_default.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
 
 
-class BotCommandScopeDefault(BotCommandScope):
+class BotCommandScopeDefault(BotCommandScope, kw_only=True):
     """
     Represents the default `scope <https://core.telegram.org/bots/api#botcommandscope>`_ of bot commands. Default commands are used if no commands with a `narrower scope <https://core.telegram.org/bots/api#determining-list-of-commands>`_ are specified for the user.
 
     Source: https://core.telegram.org/bots/api#botcommandscopedefault
     """
 
-    type: str = Field(BotCommandScopeType.DEFAULT, const=True)
+    type: str = msgspec.field(default_factory=lambda: BotCommandScopeType.DEFAULT)
     """Scope type, must be *default*"""

--- a/aiogram/types/callback_query.py
+++ b/aiogram/types/callback_query.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerCallbackQuery
-    from .message import Message
-    from .user import User
+from .message import Message
+from .user import User
 
 
-class CallbackQuery(TelegramObject):
+class CallbackQuery(TelegramObject, kw_only=True):
     """
     This object represents an incoming callback query from a callback button in an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_. If the button that originated the query was attached to a message sent by the bot, the field *message* will be present. If the button was attached to a message sent via the bot (in `inline mode <https://core.telegram.org/bots/api#inline-mode>`_), the field *inline_message_id* will be present. Exactly one of the fields *data* or *game_short_name* will be present.
 
@@ -23,7 +23,7 @@ class CallbackQuery(TelegramObject):
 
     id: str
     """Unique identifier for this query"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """Sender"""
     chat_instance: str
     """Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in :class:`aiogram.methods.games.Games`."""
@@ -35,6 +35,8 @@ class CallbackQuery(TelegramObject):
     """*Optional*. Data associated with the callback button. Be aware that the message originated the query can contain no callback buttons with this data."""
     game_short_name: Optional[str] = None
     """*Optional*. Short name of a `Game <https://core.telegram.org/bots/api#games>`_ to be returned, serves as the unique identifier for the game"""
+
+    _callback_data = None
 
     def answer(
         self,

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -35,11 +35,13 @@ if TYPE_CHECKING:
         UnpinAllChatMessages,
         UnpinChatMessage,
     )
-    from .chat_location import ChatLocation
-    from .chat_permissions import ChatPermissions
-    from .chat_photo import ChatPhoto
-    from .input_file import InputFile
     from .message import Message
+
+from . import message
+from .chat_location import ChatLocation
+from .chat_permissions import ChatPermissions
+from .chat_photo import ChatPhoto
+from .input_file import InputFile
 
 
 class Chat(TelegramObject):
@@ -83,7 +85,7 @@ class Chat(TelegramObject):
     """*Optional*. Description, for groups, supergroups and channel chats. Returned only in :class:`aiogram.methods.get_chat.GetChat`."""
     invite_link: Optional[str] = None
     """*Optional*. Primary invite link, for groups, supergroups and channel chats. Returned only in :class:`aiogram.methods.get_chat.GetChat`."""
-    pinned_message: Optional[Message] = None
+    pinned_message: Optional[message.Message] = None
     """*Optional*. The most recent pinned message (by sending date). Returned only in :class:`aiogram.methods.get_chat.GetChat`."""
     permissions: Optional[ChatPermissions] = None
     """*Optional*. Default chat member permissions, for groups and supergroups. Returned only in :class:`aiogram.methods.get_chat.GetChat`."""

--- a/aiogram/types/chat_invite_link.py
+++ b/aiogram/types/chat_invite_link.py
@@ -4,9 +4,7 @@ import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class ChatInviteLink(TelegramObject):

--- a/aiogram/types/chat_join_request.py
+++ b/aiogram/types/chat_join_request.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import ApproveChatJoinRequest, DeclineChatJoinRequest
 
-if TYPE_CHECKING:
-    from .chat import Chat
-    from .chat_invite_link import ChatInviteLink
-    from .user import User
+from .chat import Chat
+from .chat_invite_link import ChatInviteLink
+from .user import User
 
 
-class ChatJoinRequest(TelegramObject):
+class ChatJoinRequest(TelegramObject, kw_only=True):
     """
     Represents a join request sent to a chat.
 
@@ -25,7 +24,7 @@ class ChatJoinRequest(TelegramObject):
 
     chat: Chat
     """Chat to which the request was sent"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """User that sent the join request"""
     user_chat_id: int
     """Identifier of a private chat with the user who sent the join request. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier. The bot can use this identifier for 24 hours to send messages until the join request is processed, assuming no other administrator contacted the user."""

--- a/aiogram/types/chat_location.py
+++ b/aiogram/types/chat_location.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .location import Location
+from .location import Location
 
 
 class ChatLocation(TelegramObject):

--- a/aiogram/types/chat_member.py
+++ b/aiogram/types/chat_member.py
@@ -4,9 +4,7 @@ import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class ChatMember(TelegramObject):

--- a/aiogram/types/chat_member_administrator.py
+++ b/aiogram/types/chat_member_administrator.py
@@ -2,23 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberAdministrator(ChatMember):
+class ChatMemberAdministrator(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that has some additional privileges.
 
     Source: https://core.telegram.org/bots/api#chatmemberadministrator
     """
 
-    status: str = Field(ChatMemberStatus.ADMINISTRATOR, const=True)
+    status: str = ChatMemberStatus.ADMINISTRATOR
     """The member's status in the chat, always 'administrator'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_banned.py
+++ b/aiogram/types/chat_member_banned.py
@@ -3,23 +3,19 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberBanned(ChatMember):
+class ChatMemberBanned(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that was banned in the chat and can't return to the chat or view chat messages.
 
     Source: https://core.telegram.org/bots/api#chatmemberbanned
     """
 
-    status: str = Field(ChatMemberStatus.KICKED, const=True)
+    status: str = ChatMemberStatus.KICKED
     """The member's status in the chat, always 'kicked'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_left.py
+++ b/aiogram/types/chat_member_left.py
@@ -2,23 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberLeft(ChatMember):
+class ChatMemberLeft(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that isn't currently a member of the chat, but may join it themselves.
 
     Source: https://core.telegram.org/bots/api#chatmemberleft
     """
 
-    status: str = Field(ChatMemberStatus.LEFT, const=True)
+    status: str = ChatMemberStatus.LEFT
     """The member's status in the chat, always 'left'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_member.py
+++ b/aiogram/types/chat_member_member.py
@@ -2,23 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberMember(ChatMember):
+class ChatMemberMember(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that has no additional privileges or restrictions.
 
     Source: https://core.telegram.org/bots/api#chatmembermember
     """
 
-    status: str = Field(ChatMemberStatus.MEMBER, const=True)
+    status: str = ChatMemberStatus.MEMBER
     """The member's status in the chat, always 'member'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_owner.py
+++ b/aiogram/types/chat_member_owner.py
@@ -2,23 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberOwner(ChatMember):
+class ChatMemberOwner(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that owns the chat and has all administrator privileges.
 
     Source: https://core.telegram.org/bots/api#chatmemberowner
     """
 
-    status: str = Field(ChatMemberStatus.CREATOR, const=True)
+    status: str = ChatMemberStatus.CREATOR
     """The member's status in the chat, always 'creator'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_restricted.py
+++ b/aiogram/types/chat_member_restricted.py
@@ -3,23 +3,19 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
-from pydantic import Field
-
 from ..enums import ChatMemberStatus
 from .chat_member import ChatMember
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
-class ChatMemberRestricted(ChatMember):
+class ChatMemberRestricted(ChatMember, kw_only=True, tag=True):
     """
     Represents a `chat member <https://core.telegram.org/bots/api#chatmember>`_ that is under certain restrictions in the chat. Supergroups only.
 
     Source: https://core.telegram.org/bots/api#chatmemberrestricted
     """
 
-    status: str = Field(ChatMemberStatus.RESTRICTED, const=True)
+    status: str = ChatMemberStatus.RESTRICTED
     """The member's status in the chat, always 'restricted'"""
     user: User
     """Information about the user"""

--- a/aiogram/types/chat_member_updated.py
+++ b/aiogram/types/chat_member_updated.py
@@ -3,23 +3,21 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Optional, Union
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .chat import Chat
-    from .chat_invite_link import ChatInviteLink
-    from .chat_member_administrator import ChatMemberAdministrator
-    from .chat_member_banned import ChatMemberBanned
-    from .chat_member_left import ChatMemberLeft
-    from .chat_member_member import ChatMemberMember
-    from .chat_member_owner import ChatMemberOwner
-    from .chat_member_restricted import ChatMemberRestricted
-    from .user import User
+from .chat import Chat
+from .chat_invite_link import ChatInviteLink
+from .chat_member_administrator import ChatMemberAdministrator
+from .chat_member_banned import ChatMemberBanned
+from .chat_member_left import ChatMemberLeft
+from .chat_member_member import ChatMemberMember
+from .chat_member_owner import ChatMemberOwner
+from .chat_member_restricted import ChatMemberRestricted
+from .user import User
 
 
-class ChatMemberUpdated(TelegramObject):
+class ChatMemberUpdated(TelegramObject, kw_only=True):
     """
     This object represents changes in the status of a chat member.
 
@@ -28,7 +26,7 @@ class ChatMemberUpdated(TelegramObject):
 
     chat: Chat
     """Chat the user belongs to"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """Performer of the action, which resulted in the change"""
     date: datetime.datetime
     """Date the change was done in Unix time"""

--- a/aiogram/types/chosen_inline_result.py
+++ b/aiogram/types/chosen_inline_result.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .location import Location
-    from .user import User
+from .location import Location
+from .user import User
 
 
-class ChosenInlineResult(TelegramObject):
+class ChosenInlineResult(TelegramObject, kw_only=True):
     """
     Represents a `result <https://core.telegram.org/bots/api#inlinequeryresult>`_ of an inline query that was chosen by the user and sent to their chat partner.
     **Note:** It is necessary to enable `inline feedback <https://core.telegram.org/bots/inline#collecting-feedback>`_ via `@BotFather <https://t.me/botfather>`_ in order to receive these objects in updates.
@@ -21,7 +19,7 @@ class ChosenInlineResult(TelegramObject):
 
     result_id: str
     """The unique identifier for the result that was chosen"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """The user that chose the result"""
     query: str
     """The query that was used to obtain the result"""

--- a/aiogram/types/document.py
+++ b/aiogram/types/document.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class Document(TelegramObject):

--- a/aiogram/types/encrypted_passport_element.py
+++ b/aiogram/types/encrypted_passport_element.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .passport_file import PassportFile
+from .passport_file import PassportFile
 
 
 class EncryptedPassportElement(TelegramObject):

--- a/aiogram/types/force_reply.py
+++ b/aiogram/types/force_reply.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from .base import MutableTelegramObject
 
 
@@ -21,7 +19,7 @@ class ForceReply(MutableTelegramObject):
     Source: https://core.telegram.org/bots/api#forcereply
     """
 
-    force_reply: bool = Field(True, const=True)
+    force_reply: bool = True
     """Shows reply interface to the user, as if they manually selected the bot's message and tapped 'Reply'"""
     input_field_placeholder: Optional[str] = None
     """*Optional*. The placeholder to be shown in the input field when the reply is active; 1-64 characters"""

--- a/aiogram/types/game.py
+++ b/aiogram/types/game.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
+from .animation import Animation
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .animation import Animation
-    from .message_entity import MessageEntity
-    from .photo_size import PhotoSize
+from .message_entity import MessageEntity
+from .photo_size import PhotoSize
 
 
 class Game(TelegramObject):

--- a/aiogram/types/game_high_score.py
+++ b/aiogram/types/game_high_score.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class GameHighScore(TelegramObject):

--- a/aiogram/types/inline_keyboard_button.py
+++ b/aiogram/types/inline_keyboard_button.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import MutableTelegramObject
-
-if TYPE_CHECKING:
-    from .callback_game import CallbackGame
-    from .login_url import LoginUrl
-    from .switch_inline_query_chosen_chat import SwitchInlineQueryChosenChat
-    from .web_app_info import WebAppInfo
+from .callback_game import CallbackGame
+from .login_url import LoginUrl
+from .switch_inline_query_chosen_chat import SwitchInlineQueryChosenChat
+from .web_app_info import WebAppInfo
 
 
 class InlineKeyboardButton(MutableTelegramObject):

--- a/aiogram/types/inline_keyboard_markup.py
+++ b/aiogram/types/inline_keyboard_markup.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from .base import MutableTelegramObject
-
-if TYPE_CHECKING:
-    from .inline_keyboard_button import InlineKeyboardButton
+from .inline_keyboard_button import InlineKeyboardButton
 
 
 class InlineKeyboardMarkup(MutableTelegramObject):

--- a/aiogram/types/inline_query.py
+++ b/aiogram/types/inline_query.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerInlineQuery
-    from .inline_query_result import InlineQueryResult
-    from .inline_query_results_button import InlineQueryResultsButton
-    from .location import Location
-    from .user import User
+from .inline_query_result import InlineQueryResult
+from .inline_query_results_button import InlineQueryResultsButton
+from .location import Location
+from .user import User
 
 
-class InlineQuery(TelegramObject):
+class InlineQuery(TelegramObject, kw_only=True):
     """
     This object represents an incoming inline query. When the user sends an empty query, your bot could return some default or trending results.
 
@@ -23,7 +23,7 @@ class InlineQuery(TelegramObject):
 
     id: str
     """Unique identifier for this query"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """Sender"""
     query: str
     """Text of the query (up to 256 characters)"""

--- a/aiogram/types/inline_query_result_article.py
+++ b/aiogram/types/inline_query_result_article.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
+import msgspec
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
     from .input_message_content import InputMessageContent
 
 
-class InlineQueryResultArticle(InlineQueryResult):
+class InlineQueryResultArticle(InlineQueryResult, kw_only=True):
     """
     Represents a link to an article or web page.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultarticle
     """
 
-    type: str = Field(InlineQueryResultType.ARTICLE, const=True)
+    type: str = msgspec.field(default_factory=lambda: InlineQueryResultType.ARTICLE)
     """Type of the result, must be *article*"""
     id: str
     """Unique identifier for this result, 1-64 Bytes"""

--- a/aiogram/types/inline_query_result_audio.py
+++ b/aiogram/types/inline_query_result_audio.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
+import msgspec
 
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultAudio(InlineQueryResult):
+class InlineQueryResultAudio(InlineQueryResult, kw_only=True):
     """
     Represents a link to an MP3 audio file. By default, this audio file will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the audio.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +22,7 @@ class InlineQueryResultAudio(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultaudio
     """
 
-    type: str = Field(InlineQueryResultType.AUDIO, const=True)
+    type: str = msgspec.field(default_factory=lambda: InlineQueryResultType.AUDIO)
     """Type of the result, must be *audio*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_audio.py
+++ b/aiogram/types/inline_query_result_cached_audio.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
+import msgspec
 
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedAudio(InlineQueryResult):
+class InlineQueryResultCachedAudio(InlineQueryResult, kw_only=True):
     """
     Represents a link to an MP3 audio file stored on the Telegram servers. By default, this audio file will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the audio.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +22,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedaudio
     """
 
-    type: str = Field(InlineQueryResultType.AUDIO, const=True)
+    type: str = msgspec.field(default_factory=lambda: InlineQueryResultType.AUDIO)
     """Type of the result, must be *audio*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_document.py
+++ b/aiogram/types/inline_query_result_cached_document.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,7 +12,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedDocument(InlineQueryResult):
+class InlineQueryResultCachedDocument(InlineQueryResult, kw_only=True):
     """
     Represents a link to a file stored on the Telegram servers. By default, this file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the file.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +20,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcacheddocument
     """
 
-    type: str = Field(InlineQueryResultType.DOCUMENT, const=True)
+    type: str = InlineQueryResultType.DOCUMENT
     """Type of the result, must be *document*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_gif.py
+++ b/aiogram/types/inline_query_result_cached_gif.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedGif(InlineQueryResult):
+class InlineQueryResultCachedGif(InlineQueryResult, kw_only=True):
     """
     Represents a link to an animated GIF file stored on the Telegram servers. By default, this animated GIF file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with specified content instead of the animation.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedgif
     """
 
-    type: str = Field(InlineQueryResultType.GIF, const=True)
+    type: str = InlineQueryResultType.GIF
     """Type of the result, must be *gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_cached_mpeg4_gif.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
+class InlineQueryResultCachedMpeg4Gif(InlineQueryResult, kw_only=True):
     """
     Represents a link to a video animation (H.264/MPEG-4 AVC video without sound) stored on the Telegram servers. By default, this animated MPEG-4 file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the animation.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG4_GIF, const=True)
+    type: str = InlineQueryResultType.MPEG4_GIF
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_photo.py
+++ b/aiogram/types/inline_query_result_cached_photo.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedPhoto(InlineQueryResult):
+class InlineQueryResultCachedPhoto(InlineQueryResult, kw_only=True):
     """
     Represents a link to a photo stored on the Telegram servers. By default, this photo will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the photo.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedphoto
     """
 
-    type: str = Field(InlineQueryResultType.PHOTO, const=True)
+    type: str = InlineQueryResultType.PHOTO
     """Type of the result, must be *photo*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_sticker.py
+++ b/aiogram/types/inline_query_result_cached_sticker.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
@@ -12,7 +10,7 @@ if TYPE_CHECKING:
     from .input_message_content import InputMessageContent
 
 
-class InlineQueryResultCachedSticker(InlineQueryResult):
+class InlineQueryResultCachedSticker(InlineQueryResult, kw_only=True):
     """
     Represents a link to a sticker stored on the Telegram servers. By default, this sticker will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the sticker.
     **Note:** This will only work in Telegram versions released after 9 April, 2016 for static stickers and after 06 July, 2019 for `animated stickers <https://telegram.org/blog/animated-stickers>`_. Older clients will ignore them.
@@ -20,7 +18,7 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedsticker
     """
 
-    type: str = Field(InlineQueryResultType.STICKER, const=True)
+    type: str = InlineQueryResultType.STICKER
     """Type of the result, must be *sticker*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_video.py
+++ b/aiogram/types/inline_query_result_cached_video.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedVideo(InlineQueryResult):
+class InlineQueryResultCachedVideo(InlineQueryResult, kw_only=True):
     """
     Represents a link to a video file stored on the Telegram servers. By default, this video file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the video.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedvideo
     """
 
-    type: str = Field(InlineQueryResultType.VIDEO, const=True)
+    type: str = InlineQueryResultType.VIDEO
     """Type of the result, must be *video*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_cached_voice.py
+++ b/aiogram/types/inline_query_result_cached_voice.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,7 +12,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultCachedVoice(InlineQueryResult):
+class InlineQueryResultCachedVoice(InlineQueryResult, kw_only=True):
     """
     Represents a link to a voice message stored on the Telegram servers. By default, this voice message will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the voice message.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +20,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcachedvoice
     """
 
-    type: str = Field(InlineQueryResultType.VOICE, const=True)
+    type: str = InlineQueryResultType.VOICE
     """Type of the result, must be *voice*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_contact.py
+++ b/aiogram/types/inline_query_result_contact.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
@@ -12,7 +10,7 @@ if TYPE_CHECKING:
     from .input_message_content import InputMessageContent
 
 
-class InlineQueryResultContact(InlineQueryResult):
+class InlineQueryResultContact(InlineQueryResult, kw_only=True):
     """
     Represents a contact with a phone number. By default, this contact will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the contact.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -20,7 +18,7 @@ class InlineQueryResultContact(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultcontact
     """
 
-    type: str = Field(InlineQueryResultType.CONTACT, const=True)
+    type: str = InlineQueryResultType.CONTACT
     """Type of the result, must be *contact*"""
     id: str
     """Unique identifier for this result, 1-64 Bytes"""

--- a/aiogram/types/inline_query_result_document.py
+++ b/aiogram/types/inline_query_result_document.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
+import msgspec
 
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
+from .inline_keyboard_markup import InlineKeyboardMarkup
 from .inline_query_result import InlineQueryResult
-
-if TYPE_CHECKING:
-    from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_message_content import InputMessageContent
-    from .message_entity import MessageEntity
+from .input_message_content import InputMessageContent
+from .message_entity import MessageEntity
 
 
-class InlineQueryResultDocument(InlineQueryResult):
+class InlineQueryResultDocument(InlineQueryResult, kw_only=True):
     """
     Represents a link to a file. By default, this file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the file. Currently, only **.PDF** and **.ZIP** files can be sent using this method.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +20,7 @@ class InlineQueryResultDocument(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultdocument
     """
 
-    type: str = Field(InlineQueryResultType.DOCUMENT, const=True)
+    type: str = msgspec.field(default_factory=lambda: InlineQueryResultType.DOCUMENT)
     """Type of the result, must be *document*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_game.py
+++ b/aiogram/types/inline_query_result_game.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
@@ -11,7 +9,7 @@ if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
 
 
-class InlineQueryResultGame(InlineQueryResult):
+class InlineQueryResultGame(InlineQueryResult, kw_only=True):
     """
     Represents a `Game <https://core.telegram.org/bots/api#games>`_.
     **Note:** This will only work in Telegram versions released after October 1, 2016. Older clients will not display any inline results if a game result is among them.
@@ -19,7 +17,7 @@ class InlineQueryResultGame(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultgame
     """
 
-    type: str = Field(InlineQueryResultType.GAME, const=True)
+    type: str = InlineQueryResultType.GAME
     """Type of the result, must be *game*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_gif.py
+++ b/aiogram/types/inline_query_result_gif.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultGif(InlineQueryResult):
+class InlineQueryResultGif(InlineQueryResult, kw_only=True):
     """
     Represents a link to an animated GIF file. By default, this animated GIF file will be sent by the user with optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the animation.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultgif
     """
 
-    type: str = Field(InlineQueryResultType.GIF, const=True)
+    type: str = InlineQueryResultType.GIF
     """Type of the result, must be *gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_location.py
+++ b/aiogram/types/inline_query_result_location.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
+import msgspec
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .input_message_content import InputMessageContent
 
 
-class InlineQueryResultLocation(InlineQueryResult):
+class InlineQueryResultLocation(InlineQueryResult, kw_only=True):
     """
     Represents a location on a map. By default, the location will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the location.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -20,7 +20,7 @@ class InlineQueryResultLocation(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultlocation
     """
 
-    type: str = Field(InlineQueryResultType.LOCATION, const=True)
+    type: str = msgspec.field(default_factory=lambda: InlineQueryResultType.LOCATION)
     """Type of the result, must be *location*"""
     id: str
     """Unique identifier for this result, 1-64 Bytes"""

--- a/aiogram/types/inline_query_result_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_mpeg4_gif.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultMpeg4Gif(InlineQueryResult):
+class InlineQueryResultMpeg4Gif(InlineQueryResult, kw_only=True):
     """
     Represents a link to a video animation (H.264/MPEG-4 AVC video without sound). By default, this animated MPEG-4 file will be sent by the user with optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the animation.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif
     """
 
-    type: str = Field(InlineQueryResultType.MPEG4_GIF, const=True)
+    type: str = InlineQueryResultType.MPEG4_GIF
     """Type of the result, must be *mpeg4_gif*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_photo.py
+++ b/aiogram/types/inline_query_result_photo.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,14 +12,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultPhoto(InlineQueryResult):
+class InlineQueryResultPhoto(InlineQueryResult, kw_only=True):
     """
     Represents a link to a photo. By default, this photo will be sent by the user with optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the photo.
 
     Source: https://core.telegram.org/bots/api#inlinequeryresultphoto
     """
 
-    type: str = Field(InlineQueryResultType.PHOTO, const=True)
+    type: str = InlineQueryResultType.PHOTO
     """Type of the result, must be *photo*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_venue.py
+++ b/aiogram/types/inline_query_result_venue.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
@@ -12,7 +10,7 @@ if TYPE_CHECKING:
     from .input_message_content import InputMessageContent
 
 
-class InlineQueryResultVenue(InlineQueryResult):
+class InlineQueryResultVenue(InlineQueryResult, kw_only=True):
     """
     Represents a venue. By default, the venue will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the venue.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -20,7 +18,7 @@ class InlineQueryResultVenue(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultvenue
     """
 
-    type: str = Field(InlineQueryResultType.VENUE, const=True)
+    type: str = InlineQueryResultType.VENUE
     """Type of the result, must be *venue*"""
     id: str
     """Unique identifier for this result, 1-64 Bytes"""

--- a/aiogram/types/inline_query_result_video.py
+++ b/aiogram/types/inline_query_result_video.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,7 +12,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultVideo(InlineQueryResult):
+class InlineQueryResultVideo(InlineQueryResult, kw_only=True):
     """
     Represents a link to a page containing an embedded video player or a video file. By default, this video file will be sent by the user with an optional caption. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the video.
 
@@ -23,7 +21,7 @@ class InlineQueryResultVideo(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultvideo
     """
 
-    type: str = Field(InlineQueryResultType.VIDEO, const=True)
+    type: str = InlineQueryResultType.VIDEO
     """Type of the result, must be *video*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_result_voice.py
+++ b/aiogram/types/inline_query_result_voice.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
-
 from ..enums import InlineQueryResultType
 from .base import UNSET_PARSE_MODE
 from .inline_query_result import InlineQueryResult
@@ -14,7 +12,7 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InlineQueryResultVoice(InlineQueryResult):
+class InlineQueryResultVoice(InlineQueryResult, kw_only=True):
     """
     Represents a link to a voice recording in an .OGG container encoded with OPUS. By default, this voice recording will be sent by the user. Alternatively, you can use *input_message_content* to send a message with the specified content instead of the the voice message.
     **Note:** This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -22,7 +20,7 @@ class InlineQueryResultVoice(InlineQueryResult):
     Source: https://core.telegram.org/bots/api#inlinequeryresultvoice
     """
 
-    type: str = Field(InlineQueryResultType.VOICE, const=True)
+    type: str = InlineQueryResultType.VOICE
     """Type of the result, must be *voice*"""
     id: str
     """Unique identifier for this result, 1-64 bytes"""

--- a/aiogram/types/inline_query_results_button.py
+++ b/aiogram/types/inline_query_results_button.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .web_app_info import WebAppInfo
+from .web_app_info import WebAppInfo
 
 
 class InlineQueryResultsButton(TelegramObject):

--- a/aiogram/types/input_media_animation.py
+++ b/aiogram/types/input_media_animation.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Field
-
 from ..enums import InputMediaType
 from .base import UNSET_PARSE_MODE
 from .input_media import InputMedia
@@ -13,14 +11,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InputMediaAnimation(InputMedia):
+class InputMediaAnimation(InputMedia, kw_only=True):
     """
     Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
 
     Source: https://core.telegram.org/bots/api#inputmediaanimation
     """
 
-    type: str = Field(InputMediaType.ANIMATION, const=True)
+    type: str = InputMediaType.ANIMATION
     """Type of the result, must be *animation*"""
     media: Union[str, InputFile]
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""

--- a/aiogram/types/input_media_audio.py
+++ b/aiogram/types/input_media_audio.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Field
-
 from ..enums import InputMediaType
 from .base import UNSET_PARSE_MODE
 from .input_media import InputMedia
@@ -13,14 +11,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InputMediaAudio(InputMedia):
+class InputMediaAudio(InputMedia, kw_only=True):
     """
     Represents an audio file to be treated as music to be sent.
 
     Source: https://core.telegram.org/bots/api#inputmediaaudio
     """
 
-    type: str = Field(InputMediaType.AUDIO, const=True)
+    type: str = InputMediaType.AUDIO
     """Type of the result, must be *audio*"""
     media: Union[str, InputFile]
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""

--- a/aiogram/types/input_media_document.py
+++ b/aiogram/types/input_media_document.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Field
-
 from ..enums import InputMediaType
 from .base import UNSET_PARSE_MODE
 from .input_media import InputMedia
@@ -13,14 +11,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InputMediaDocument(InputMedia):
+class InputMediaDocument(InputMedia, kw_only=True):
     """
     Represents a general file to be sent.
 
     Source: https://core.telegram.org/bots/api#inputmediadocument
     """
 
-    type: str = Field(InputMediaType.DOCUMENT, const=True)
+    type: str = InputMediaType.DOCUMENT
     """Type of the result, must be *document*"""
     media: Union[str, InputFile]
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""

--- a/aiogram/types/input_media_photo.py
+++ b/aiogram/types/input_media_photo.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Field
-
 from ..enums import InputMediaType
 from .base import UNSET_PARSE_MODE
 from .input_media import InputMedia
@@ -13,14 +11,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InputMediaPhoto(InputMedia):
+class InputMediaPhoto(InputMedia, kw_only=True):
     """
     Represents a photo to be sent.
 
     Source: https://core.telegram.org/bots/api#inputmediaphoto
     """
 
-    type: str = Field(InputMediaType.PHOTO, const=True)
+    type: str = InputMediaType.PHOTO
     """Type of the result, must be *photo*"""
     media: Union[str, InputFile]
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""

--- a/aiogram/types/input_media_video.py
+++ b/aiogram/types/input_media_video.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Field
-
 from ..enums import InputMediaType
 from .base import UNSET_PARSE_MODE
 from .input_media import InputMedia
@@ -13,14 +11,14 @@ if TYPE_CHECKING:
     from .message_entity import MessageEntity
 
 
-class InputMediaVideo(InputMedia):
+class InputMediaVideo(InputMedia, kw_only=True):
     """
     Represents a video to be sent.
 
     Source: https://core.telegram.org/bots/api#inputmediavideo
     """
 
-    type: str = Field(InputMediaType.VIDEO, const=True)
+    type: str = InputMediaType.VIDEO
     """Type of the result, must be *video*"""
     media: Union[str, InputFile]
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""

--- a/aiogram/types/keyboard_button.py
+++ b/aiogram/types/keyboard_button.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import MutableTelegramObject
-
-if TYPE_CHECKING:
-    from .keyboard_button_poll_type import KeyboardButtonPollType
-    from .keyboard_button_request_chat import KeyboardButtonRequestChat
-    from .keyboard_button_request_user import KeyboardButtonRequestUser
-    from .web_app_info import WebAppInfo
+from .keyboard_button_poll_type import KeyboardButtonPollType
+from .keyboard_button_request_chat import KeyboardButtonRequestChat
+from .keyboard_button_request_user import KeyboardButtonRequestUser
+from .web_app_info import WebAppInfo
 
 
 class KeyboardButton(MutableTelegramObject):

--- a/aiogram/types/menu_button.py
+++ b/aiogram/types/menu_button.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import MutableTelegramObject
-
-if TYPE_CHECKING:
-    from .web_app_info import WebAppInfo
+from .web_app_info import WebAppInfo
 
 
-class MenuButton(MutableTelegramObject):
+class MenuButton(MutableTelegramObject, tag_field="op", tag=str.lower):
     """
     This object describes the bot's menu button in a private chat. It should be one of
 

--- a/aiogram/types/menu_button_commands.py
+++ b/aiogram/types/menu_button_commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import MenuButtonType
 from .menu_button import MenuButton
@@ -13,5 +13,5 @@ class MenuButtonCommands(MenuButton):
     Source: https://core.telegram.org/bots/api#menubuttoncommands
     """
 
-    type: str = Field(MenuButtonType.COMMANDS, const=True)
+    type: str = msgspec.field(default_factory=lambda: MenuButtonType.COMMANDS)
     """Type of the button, must be *commands*"""

--- a/aiogram/types/menu_button_default.py
+++ b/aiogram/types/menu_button_default.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import Field
+import msgspec
 
 from ..enums import MenuButtonType
 from .menu_button import MenuButton
@@ -13,5 +13,5 @@ class MenuButtonDefault(MenuButton):
     Source: https://core.telegram.org/bots/api#menubuttondefault
     """
 
-    type: str = Field(MenuButtonType.DEFAULT, const=True)
+    type: str = msgspec.field(default_factory=lambda: MenuButtonType.DEFAULT)
     """Type of the button, must be *default*"""

--- a/aiogram/types/menu_button_web_app.py
+++ b/aiogram/types/menu_button_web_app.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field
+import msgspec
 
 from ..enums import MenuButtonType
 from .menu_button import MenuButton
-
-if TYPE_CHECKING:
-    from .web_app_info import WebAppInfo
+from .web_app_info import WebAppInfo
 
 
-class MenuButtonWebApp(MenuButton):
+class MenuButtonWebApp(MenuButton, kw_only=True):
     """
     Represents a menu button, which launches a `Web App <https://core.telegram.org/bots/webapps>`_.
 
     Source: https://core.telegram.org/bots/api#menubuttonwebapp
     """
 
-    type: str = Field(MenuButtonType.WEB_APP, const=True)
+    type: str = msgspec.field(default_factory=lambda: MenuButtonType.WEB_APP)
     """Type of the button, must be *web_app*"""
     text: str
     """Text on the button"""

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from pydantic import Field
+import msgspec
 
 from aiogram.utils.text_decorations import (
     TextDecoration,
@@ -50,56 +50,57 @@ if TYPE_CHECKING:
         StopMessageLiveLocation,
         UnpinChatMessage,
     )
-    from .animation import Animation
-    from .audio import Audio
-    from .chat import Chat
-    from .chat_shared import ChatShared
-    from .contact import Contact
-    from .dice import Dice
-    from .document import Document
-    from .force_reply import ForceReply
-    from .forum_topic_closed import ForumTopicClosed
-    from .forum_topic_created import ForumTopicCreated
-    from .forum_topic_edited import ForumTopicEdited
-    from .forum_topic_reopened import ForumTopicReopened
-    from .game import Game
-    from .general_forum_topic_hidden import GeneralForumTopicHidden
-    from .general_forum_topic_unhidden import GeneralForumTopicUnhidden
-    from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_file import InputFile
-    from .input_media import InputMedia
-    from .input_media_audio import InputMediaAudio
-    from .input_media_document import InputMediaDocument
-    from .input_media_photo import InputMediaPhoto
-    from .input_media_video import InputMediaVideo
-    from .invoice import Invoice
-    from .labeled_price import LabeledPrice
-    from .location import Location
-    from .message_auto_delete_timer_changed import MessageAutoDeleteTimerChanged
-    from .message_entity import MessageEntity
-    from .passport_data import PassportData
-    from .photo_size import PhotoSize
-    from .poll import Poll
-    from .proximity_alert_triggered import ProximityAlertTriggered
-    from .reply_keyboard_markup import ReplyKeyboardMarkup
-    from .reply_keyboard_remove import ReplyKeyboardRemove
-    from .sticker import Sticker
-    from .successful_payment import SuccessfulPayment
-    from .user import User
-    from .user_shared import UserShared
-    from .venue import Venue
-    from .video import Video
-    from .video_chat_ended import VideoChatEnded
-    from .video_chat_participants_invited import VideoChatParticipantsInvited
-    from .video_chat_scheduled import VideoChatScheduled
-    from .video_chat_started import VideoChatStarted
-    from .video_note import VideoNote
-    from .voice import Voice
-    from .web_app_data import WebAppData
-    from .write_access_allowed import WriteAccessAllowed
+
+from .animation import Animation
+from .audio import Audio
+from .chat import Chat
+from .chat_shared import ChatShared
+from .contact import Contact
+from .dice import Dice
+from .document import Document
+from .force_reply import ForceReply
+from .forum_topic_closed import ForumTopicClosed
+from .forum_topic_created import ForumTopicCreated
+from .forum_topic_edited import ForumTopicEdited
+from .forum_topic_reopened import ForumTopicReopened
+from .game import Game
+from .general_forum_topic_hidden import GeneralForumTopicHidden
+from .general_forum_topic_unhidden import GeneralForumTopicUnhidden
+from .inline_keyboard_markup import InlineKeyboardMarkup
+from .input_file import InputFile
+from .input_media import InputMedia
+from .input_media_audio import InputMediaAudio
+from .input_media_document import InputMediaDocument
+from .input_media_photo import InputMediaPhoto
+from .input_media_video import InputMediaVideo
+from .invoice import Invoice
+from .labeled_price import LabeledPrice
+from .location import Location
+from .message_auto_delete_timer_changed import MessageAutoDeleteTimerChanged
+from .message_entity import MessageEntity
+from .passport_data import PassportData
+from .photo_size import PhotoSize
+from .poll import Poll
+from .proximity_alert_triggered import ProximityAlertTriggered
+from .reply_keyboard_markup import ReplyKeyboardMarkup
+from .reply_keyboard_remove import ReplyKeyboardRemove
+from .sticker import Sticker
+from .successful_payment import SuccessfulPayment
+from .user import User
+from .user_shared import UserShared
+from .venue import Venue
+from .video import Video
+from .video_chat_ended import VideoChatEnded
+from .video_chat_participants_invited import VideoChatParticipantsInvited
+from .video_chat_scheduled import VideoChatScheduled
+from .video_chat_started import VideoChatStarted
+from .video_note import VideoNote
+from .voice import Voice
+from .web_app_data import WebAppData
+from .write_access_allowed import WriteAccessAllowed
 
 
-class Message(TelegramObject):
+class Message(TelegramObject, kw_only=True):
     """
     This object represents a message.
 
@@ -108,13 +109,13 @@ class Message(TelegramObject):
 
     message_id: int
     """Unique message identifier inside this chat"""
-    date: datetime.datetime
+    date: datetime.datetime | int
     """Date the message was sent in Unix time"""
     chat: Chat
     """Conversation the message belongs to"""
     message_thread_id: Optional[int] = None
     """*Optional*. Unique identifier of a message thread to which the message belongs; for supergroups only"""
-    from_user: Optional[User] = Field(None, alias="from")
+    from_user: Optional[User] = msgspec.field(name="from", default=None)
     """*Optional*. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat."""
     sender_chat: Optional[Chat] = None
     """*Optional*. Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field *from* contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat."""

--- a/aiogram/types/message_entity.py
+++ b/aiogram/types/message_entity.py
@@ -4,9 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ..utils.text_decorations import add_surrogates, remove_surrogates
 from .base import MutableTelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class MessageEntity(MutableTelegramObject):

--- a/aiogram/types/order_info.py
+++ b/aiogram/types/order_info.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .shipping_address import ShippingAddress
+from .shipping_address import ShippingAddress
 
 
 class OrderInfo(TelegramObject):

--- a/aiogram/types/passport_data.py
+++ b/aiogram/types/passport_data.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .encrypted_credentials import EncryptedCredentials
-    from .encrypted_passport_element import EncryptedPassportElement
+from .encrypted_credentials import EncryptedCredentials
+from .encrypted_passport_element import EncryptedPassportElement
 
 
 class PassportData(TelegramObject):

--- a/aiogram/types/passport_element_error_data_field.py
+++ b/aiogram/types/passport_element_error_data_field.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorDataField(PassportElementError):
+class PassportElementErrorDataField(PassportElementError, kw_only=True):
     """
     Represents an issue in one of the data fields that was provided by the user. The error is considered resolved when the field's value changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrordatafield
     """
 
-    source: str = Field("data", const=True)
+    source: str = "data"
     """Error source, must be *data*"""
     type: str
     """The section of the user's Telegram Passport which has the error, one of 'personal_details', 'passport', 'driver_license', 'identity_card', 'internal_passport', 'address'"""

--- a/aiogram/types/passport_element_error_file.py
+++ b/aiogram/types/passport_element_error_file.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorFile(PassportElementError):
+class PassportElementErrorFile(PassportElementError, kw_only=True):
     """
     Represents an issue with a document scan. The error is considered resolved when the file with the document scan changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorfile
     """
 
-    source: str = Field("file", const=True)
+    source: str = "file"
     """Error source, must be *file*"""
     type: str
     """The section of the user's Telegram Passport which has the issue, one of 'utility_bill', 'bank_statement', 'rental_agreement', 'passport_registration', 'temporary_registration'"""

--- a/aiogram/types/passport_element_error_files.py
+++ b/aiogram/types/passport_element_error_files.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorFiles(PassportElementError):
+class PassportElementErrorFiles(PassportElementError, kw_only=True):
     """
     Represents an issue with a list of scans. The error is considered resolved when the list of files containing the scans changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorfiles
     """
 
-    source: str = Field("files", const=True)
+    source: str = "files"
     """Error source, must be *files*"""
     type: str
     """The section of the user's Telegram Passport which has the issue, one of 'utility_bill', 'bank_statement', 'rental_agreement', 'passport_registration', 'temporary_registration'"""

--- a/aiogram/types/passport_element_error_front_side.py
+++ b/aiogram/types/passport_element_error_front_side.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorFrontSide(PassportElementError):
+class PassportElementErrorFrontSide(PassportElementError, kw_only=True):
     """
     Represents an issue with the front side of a document. The error is considered resolved when the file with the front side of the document changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorfrontside
     """
 
-    source: str = Field("front_side", const=True)
+    source: str = "front_side"
     """Error source, must be *front_side*"""
     type: str
     """The section of the user's Telegram Passport which has the issue, one of 'passport', 'driver_license', 'identity_card', 'internal_passport'"""

--- a/aiogram/types/passport_element_error_reverse_side.py
+++ b/aiogram/types/passport_element_error_reverse_side.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorReverseSide(PassportElementError):
+class PassportElementErrorReverseSide(PassportElementError, kw_only=True):
     """
     Represents an issue with the reverse side of a document. The error is considered resolved when the file with reverse side of the document changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorreverseside
     """
 
-    source: str = Field("reverse_side", const=True)
+    source: str = "reverse_side"
     """Error source, must be *reverse_side*"""
     type: str
     """The section of the user's Telegram Passport which has the issue, one of 'driver_license', 'identity_card'"""

--- a/aiogram/types/passport_element_error_selfie.py
+++ b/aiogram/types/passport_element_error_selfie.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorSelfie(PassportElementError):
+class PassportElementErrorSelfie(PassportElementError, kw_only=True):
     """
     Represents an issue with the selfie with a document. The error is considered resolved when the file with the selfie changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorselfie
     """
 
-    source: str = Field("selfie", const=True)
+    source: str = "selfie"
     """Error source, must be *selfie*"""
     type: str
     """The section of the user's Telegram Passport which has the issue, one of 'passport', 'driver_license', 'identity_card', 'internal_passport'"""

--- a/aiogram/types/passport_element_error_translation_file.py
+++ b/aiogram/types/passport_element_error_translation_file.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorTranslationFile(PassportElementError):
+class PassportElementErrorTranslationFile(PassportElementError, kw_only=True):
     """
     Represents an issue with one of the files that constitute the translation of a document. The error is considered resolved when the file changes.
 
     Source: https://core.telegram.org/bots/api#passportelementerrortranslationfile
     """
 
-    source: str = Field("translation_file", const=True)
+    source: str = "translation_file"
     """Error source, must be *translation_file*"""
     type: str
     """Type of element of the user's Telegram Passport which has the issue, one of 'passport', 'driver_license', 'identity_card', 'internal_passport', 'utility_bill', 'bank_statement', 'rental_agreement', 'passport_registration', 'temporary_registration'"""

--- a/aiogram/types/passport_element_error_translation_files.py
+++ b/aiogram/types/passport_element_error_translation_files.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorTranslationFiles(PassportElementError):
+class PassportElementErrorTranslationFiles(PassportElementError, kw_only=True):
     """
     Represents an issue with the translated version of a document. The error is considered resolved when a file with the document translation change.
 
     Source: https://core.telegram.org/bots/api#passportelementerrortranslationfiles
     """
 
-    source: str = Field("translation_files", const=True)
+    source: str = "translation_files"
     """Error source, must be *translation_files*"""
     type: str
     """Type of element of the user's Telegram Passport which has the issue, one of 'passport', 'driver_license', 'identity_card', 'internal_passport', 'utility_bill', 'bank_statement', 'rental_agreement', 'passport_registration', 'temporary_registration'"""

--- a/aiogram/types/passport_element_error_unspecified.py
+++ b/aiogram/types/passport_element_error_unspecified.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from pydantic import Field
-
 from .passport_element_error import PassportElementError
 
 
-class PassportElementErrorUnspecified(PassportElementError):
+class PassportElementErrorUnspecified(PassportElementError, kw_only=True):
     """
     Represents an issue in an unspecified place. The error is considered resolved when new data is added.
 
     Source: https://core.telegram.org/bots/api#passportelementerrorunspecified
     """
 
-    source: str = Field("unspecified", const=True)
+    source: str = "unspecified"
     """Error source, must be *unspecified*"""
     type: str
     """Type of element of the user's Telegram Passport which has the issue"""

--- a/aiogram/types/poll.py
+++ b/aiogram/types/poll.py
@@ -4,10 +4,8 @@ import datetime
 from typing import TYPE_CHECKING, List, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .message_entity import MessageEntity
-    from .poll_option import PollOption
+from .message_entity import MessageEntity
+from .poll_option import PollOption
 
 
 class Poll(TelegramObject):

--- a/aiogram/types/poll_answer.py
+++ b/aiogram/types/poll_answer.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class PollAnswer(TelegramObject):

--- a/aiogram/types/pre_checkout_query.py
+++ b/aiogram/types/pre_checkout_query.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerPreCheckoutQuery
-    from .order_info import OrderInfo
-    from .user import User
+from .order_info import OrderInfo
+from .user import User
 
 
-class PreCheckoutQuery(TelegramObject):
+class PreCheckoutQuery(TelegramObject, kw_only=True):
     """
     This object contains information about an incoming pre-checkout query.
 
@@ -21,7 +21,7 @@ class PreCheckoutQuery(TelegramObject):
 
     id: str
     """Unique query identifier"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """User who sent the query"""
     currency: str
     """Three-letter ISO 4217 `currency <https://core.telegram.org/bots/payments#supported-currencies>`_ code"""

--- a/aiogram/types/proximity_alert_triggered.py
+++ b/aiogram/types/proximity_alert_triggered.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class ProximityAlertTriggered(TelegramObject):

--- a/aiogram/types/reply_keyboard_remove.py
+++ b/aiogram/types/reply_keyboard_remove.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from .base import MutableTelegramObject
 
 
@@ -14,7 +12,7 @@ class ReplyKeyboardRemove(MutableTelegramObject):
     Source: https://core.telegram.org/bots/api#replykeyboardremove
     """
 
-    remove_keyboard: bool = Field(True, const=True)
+    remove_keyboard: bool = True
     """Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use *one_time_keyboard* in :class:`aiogram.types.reply_keyboard_markup.ReplyKeyboardMarkup`)"""
     selective: Optional[bool] = None
     """*Optional*. Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the *text* of the :class:`aiogram.types.message.Message` object; 2) if the bot's message is a reply (has *reply_to_message_id*), sender of the original message."""

--- a/aiogram/types/shipping_query.py
+++ b/aiogram/types/shipping_query.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from pydantic import Field
+import msgspec
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerShippingQuery
-    from ..types import ShippingOption
-    from .shipping_address import ShippingAddress
-    from .user import User
+from ..types import ShippingOption
+from .shipping_address import ShippingAddress
+from .user import User
 
 
-class ShippingQuery(TelegramObject):
+class ShippingQuery(TelegramObject, kw_only=True):
     """
     This object contains information about an incoming shipping query.
 
@@ -22,7 +22,7 @@ class ShippingQuery(TelegramObject):
 
     id: str
     """Unique query identifier"""
-    from_user: User = Field(..., alias="from")
+    from_user: User = msgspec.field(name="from")
     """User who sent the query"""
     invoice_payload: str
     """Bot specified invoice payload"""

--- a/aiogram/types/sticker.py
+++ b/aiogram/types/sticker.py
@@ -6,9 +6,9 @@ from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import DeleteStickerFromSet, SetStickerPositionInSet
-    from .file import File
-    from .mask_position import MaskPosition
-    from .photo_size import PhotoSize
+from .file import File
+from .mask_position import MaskPosition
+from .photo_size import PhotoSize
 
 
 class Sticker(TelegramObject):

--- a/aiogram/types/sticker_set.py
+++ b/aiogram/types/sticker_set.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
-    from .sticker import Sticker
+from .photo_size import PhotoSize
+from .sticker import Sticker
 
 
 class StickerSet(TelegramObject):

--- a/aiogram/types/successful_payment.py
+++ b/aiogram/types/successful_payment.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .order_info import OrderInfo
+from .order_info import OrderInfo
 
 
 class SuccessfulPayment(TelegramObject):

--- a/aiogram/types/update.py
+++ b/aiogram/types/update.py
@@ -4,21 +4,19 @@ from typing import TYPE_CHECKING, Optional, cast
 
 from ..utils.mypy_hacks import lru_cache
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .callback_query import CallbackQuery
-    from .chat_join_request import ChatJoinRequest
-    from .chat_member_updated import ChatMemberUpdated
-    from .chosen_inline_result import ChosenInlineResult
-    from .inline_query import InlineQuery
-    from .message import Message
-    from .poll import Poll
-    from .poll_answer import PollAnswer
-    from .pre_checkout_query import PreCheckoutQuery
-    from .shipping_query import ShippingQuery
+from .callback_query import CallbackQuery
+from .chat_join_request import ChatJoinRequest
+from .chat_member_updated import ChatMemberUpdated
+from .chosen_inline_result import ChosenInlineResult
+from .inline_query import InlineQuery
+from .message import Message
+from .poll import Poll
+from .poll_answer import PollAnswer
+from .pre_checkout_query import PreCheckoutQuery
+from .shipping_query import ShippingQuery
 
 
-class Update(TelegramObject):
+class Update(TelegramObject, weakref=True):
     """
     This `object <https://core.telegram.org/bots/api#available-types>`_ represents an incoming update.
 

--- a/aiogram/types/user_profile_photos.py
+++ b/aiogram/types/user_profile_photos.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class UserProfilePhotos(TelegramObject):

--- a/aiogram/types/venue.py
+++ b/aiogram/types/venue.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .location import Location
+from .location import Location
 
 
 class Venue(TelegramObject):

--- a/aiogram/types/video.py
+++ b/aiogram/types/video.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class Video(TelegramObject):

--- a/aiogram/types/video_chat_participants_invited.py
+++ b/aiogram/types/video_chat_participants_invited.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .user import User
+from .user import User
 
 
 class VideoChatParticipantsInvited(TelegramObject):

--- a/aiogram/types/video_note.py
+++ b/aiogram/types/video_note.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .base import TelegramObject
-
-if TYPE_CHECKING:
-    from .photo_size import PhotoSize
+from .photo_size import PhotoSize
 
 
 class VideoNote(TelegramObject):

--- a/aiogram/webhook/asqi.py
+++ b/aiogram/webhook/asqi.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+import msgspec.json
+
+from aiogram import Bot, Dispatcher
+
+from ..types import UNSET_PARSE_MODE
+from ..types.base import UNSET_DISABLE_WEB_PAGE_PREVIEW, UNSET_PROTECT_CONTENT
+
+
+class ASGIApplication:
+    def __init__(
+        self,
+        bot: Bot,
+        dispatcher: Dispatcher,
+        handle_in_background: bool = False,
+        lifespan_data: dict = None,
+        **data: Any,
+    ) -> None:
+        """
+        :param dispatcher: instance of :class:`aiogram.dispatcher.dispatcher.Dispatcher`
+        :param handle_in_background: immediately respond to the Telegram instead of
+            waiting end of handler process
+        """
+        self.bot = bot
+        self.dispatcher = dispatcher
+        self.handle_in_background = handle_in_background
+        self.data = data
+        lifespan_data = lifespan_data or {}
+        self.lifespan_data = {
+            "bot": self.bot,
+            "dispatcher": self.dispatcher,
+            **lifespan_data,
+            **self.dispatcher.workflow_data,
+        }
+
+    async def _read_body(self, receive):
+        """
+        Read and return the entire body from an incoming ASGI message.
+        """
+        body = b""
+        more_body = True
+
+        while more_body:
+            message = await receive()
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        return body
+
+    async def _lifespan(self, scope, receive, send):
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await self.dispatcher.emit_startup(**self.lifespan_data)
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await self.dispatcher.emit_shutdown(**self.lifespan_data)
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await self._lifespan(scope, receive, send)
+            return
+
+        result = await self.dispatcher.feed_webhook_update(
+            self.bot,
+            await self._read_body(receive),
+            **self.data,
+        )
+
+        if result is not None:
+            result.method = result.__api_method__
+
+        def enc_hook(obj):
+            if obj is UNSET_PARSE_MODE:
+                return self.bot.parse_mode
+            if obj is UNSET_DISABLE_WEB_PAGE_PREVIEW:
+                return self.bot.disable_web_page_preview
+            if obj is UNSET_PROTECT_CONTENT:
+                return self.bot.protect_content
+            raise ValueError(f"Unknown object: {obj}")
+
+        response = msgspec.json.encode(result, enc_hook=enc_hook)
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(response)).encode()),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": response,
+            }
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pydantic~=1.10.7",
     "aiofiles~=23.1.0",
     "certifi>=2022.9.24",
+    "msgspec~=0.15.0"
 ]
 dynamic = ["version"]
 

--- a/tests/mocked_bot.py
+++ b/tests/mocked_bot.py
@@ -1,6 +1,8 @@
 from collections import deque
 from typing import TYPE_CHECKING, AsyncGenerator, Deque, Optional, Type
 
+import msgspec
+
 from aiogram import Bot
 from aiogram.client.session.base import BaseSession
 from aiogram.methods import TelegramMethod
@@ -35,7 +37,7 @@ class MockedSession(BaseSession):
         self.requests.append(method)
         response: Response[TelegramType] = self.responses.pop()
         self.check_response(
-            method=method, status_code=response.error_code, content=response.json()
+            method=method, status_code=response.error_code, content=msgspec.to_builtins(response)
         )
         return response.result  # type: ignore
 

--- a/tests/test_api/test_client/test_session/test_aiohttp_session.py
+++ b/tests/test_api/test_client/test_session/test_aiohttp_session.py
@@ -104,7 +104,7 @@ class TestAiohttpSession:
             mocked_close.assert_called_once()
 
     def test_build_form_data_with_data_only(self, bot: MockedBot):
-        class TestMethod(TelegramMethod[bool]):
+        class TestMethod(TelegramMethod[bool], kw_only=True):
             __api_method__ = "test"
             __returning__ = bool
 

--- a/tests/test_api/test_methods/test_approve_chat_join_request.py
+++ b/tests/test_api/test_methods/test_approve_chat_join_request.py
@@ -4,7 +4,7 @@ from tests.mocked_bot import MockedBot
 
 class TestApproveChatJoinRequest:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(ApproveChatJoinRequest, ok=True, result=None)
+        prepare_result = bot.add_result_for(ApproveChatJoinRequest, ok=True, result=True)
 
         response: bool = await bot.approve_chat_join_request(
             chat_id=-42,

--- a/tests/test_api/test_methods/test_base.py
+++ b/tests/test_api/test_methods/test_base.py
@@ -13,11 +13,18 @@ class TestTelegramMethodRemoveUnset:
         [
             [{}, set()],
             [{"foo": "bar"}, {"foo"}],
-            [{"foo": "bar", "baz": sentinel.DEFAULT}, {"foo"}],
+            [
+                {
+                    "foo": "bar",
+                },
+                {"foo"},
+            ],
         ],
     )
     def test_remove_unset(self, values, names):
-        validated = TelegramMethod.remove_unset(values)
+        import msgspec
+
+        validated = msgspec.to_builtins(values)
         assert set(validated.keys()) == names
 
 

--- a/tests/test_api/test_methods/test_get_my_commands.py
+++ b/tests/test_api/test_methods/test_get_my_commands.py
@@ -7,7 +7,7 @@ from tests.mocked_bot import MockedBot
 
 class TestGetMyCommands:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(GetMyCommands, ok=True, result=None)
+        prepare_result = bot.add_result_for(GetMyCommands, ok=True, result=[])
 
         response: List[BotCommand] = await bot.get_my_commands()
         request = bot.get_request()

--- a/tests/test_api/test_methods/test_reopen_forum_topic.py
+++ b/tests/test_api/test_methods/test_reopen_forum_topic.py
@@ -4,7 +4,7 @@ from tests.mocked_bot import MockedBot
 
 class TestReopenForumTopic:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(ReopenForumTopic, ok=True, result=None)
+        prepare_result = bot.add_result_for(ReopenForumTopic, ok=True, result=True)
 
         response: bool = await bot.reopen_forum_topic(
             chat_id=42,

--- a/tests/test_api/test_methods/test_send_dice.py
+++ b/tests/test_api/test_methods/test_send_dice.py
@@ -1,11 +1,20 @@
 from aiogram.methods import Request, SendDice
-from aiogram.types import Message
+from aiogram.types import Chat, Message
 from tests.mocked_bot import MockedBot
 
 
 class TestSendDice:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(SendDice, ok=True, result=None)
+        prepare_result = bot.add_result_for(
+            SendDice,
+            ok=True,
+            result=Message(
+                message_id=42,
+                date=123,
+                text="text",
+                chat=Chat(id=42, type="private"),
+            ),
+        )
 
         response: Message = await bot.send_dice(chat_id=42)
         request = bot.get_request()

--- a/tests/test_api/test_methods/test_set_my_commands.py
+++ b/tests/test_api/test_methods/test_set_my_commands.py
@@ -5,7 +5,7 @@ from tests.mocked_bot import MockedBot
 
 class TestSetMyCommands:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(SetMyCommands, ok=True, result=None)
+        prepare_result = bot.add_result_for(SetMyCommands, ok=True, result=True)
 
         response: bool = await bot.set_my_commands(
             commands=[],

--- a/tests/test_api/test_methods/test_set_sticker_set_thumbnail.py
+++ b/tests/test_api/test_methods/test_set_sticker_set_thumbnail.py
@@ -4,7 +4,7 @@ from tests.mocked_bot import MockedBot
 
 class TestSetStickerSetThumbnail:
     async def test_bot_method(self, bot: MockedBot):
-        prepare_result = bot.add_result_for(SetStickerSetThumbnail, ok=True, result=None)
+        prepare_result = bot.add_result_for(SetStickerSetThumbnail, ok=True, result=True)
 
         response: bool = await bot.set_sticker_set_thumbnail(name="test", user_id=42)
         request = bot.get_request()

--- a/tests/test_api/test_types/test_chat.py
+++ b/tests/test_api/test_types/test_chat.py
@@ -178,7 +178,7 @@ class TestChat:
     def test_delete_photo(self):
         chat = Chat(id=-42, type="supergroup")
 
-        method = chat.delete_photo(description="test")
+        method = chat.delete_photo()
         assert method.chat_id == chat.id
 
     def test_set_photo(self):

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -422,7 +422,7 @@ TEST_FORUM_TOPIC_EDITED = Message(
     from_user=User(id=42, is_bot=False, first_name="Test"),
     forum_topic_edited=ForumTopicEdited(
         name="test_edited",
-        icon_color=0xFFD67E,
+        # icon_color=0xFFD67E,
     ),
 )
 TEST_FORUM_TOPIC_CLOSED = Message(

--- a/tests/test_api/test_types/test_reply_keyboard_remove.py
+++ b/tests/test_api/test_types/test_reply_keyboard_remove.py
@@ -10,7 +10,7 @@ class TestReplyKeyboardRemove:
 
     def test_remove_keyboard_default_is_true(self):
         assert (
-            ReplyKeyboardRemove.__fields__["remove_keyboard"].default is True
+            ReplyKeyboardRemove().remove_keyboard is True
         ), "Remove keyboard has incorrect default value!"
 
     @pytest.mark.parametrize(

--- a/tests/test_api/test_types/test_user.py
+++ b/tests/test_api/test_types/test_user.py
@@ -54,5 +54,5 @@ class TestUser:
     def test_get_profile_photos(self):
         user = User(id=42, is_bot=False, first_name="Test", last_name="User")
 
-        method = user.get_profile_photos(description="test")
+        method = user.get_profile_photos(offset=0, limit=10)
         assert method.user_id == user.id

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -178,7 +178,19 @@ class TestDispatcher:
 
     async def test_silent_call_request(self, bot: MockedBot, caplog):
         dispatcher = Dispatcher()
-        bot.add_result_for(SendMessage, ok=False, error_code=400, description="Kaboom")
+        bot.add_result_for(
+            SendMessage,
+            ok=False,
+            error_code=400,
+            description="Kaboom",
+            result=Message(
+                message_id=42,
+                date=datetime.datetime.now(),
+                text="test",
+                chat=Chat(id=42, type="private"),
+                from_user=User(id=42, is_bot=False, first_name="Test"),
+            ),
+        )
         await dispatcher.silent_call_request(bot, SendMessage(chat_id=42, text="test"))
         log_records = [rec.message for rec in caplog.records]
         assert len(log_records) == 1
@@ -239,6 +251,7 @@ class TestDispatcher:
                     channel_post=Message(
                         message_id=42,
                         date=datetime.datetime.now(),
+                        from_user=User(id=42, is_bot=False, first_name="test"),
                         text="test",
                         chat=Chat(id=-42, type="private"),
                     ),
@@ -253,6 +266,7 @@ class TestDispatcher:
                     edited_channel_post=Message(
                         message_id=42,
                         date=datetime.datetime.now(),
+                        from_user=User(id=42, is_bot=False, first_name="test"),
                         text="test",
                         chat=Chat(id=-42, type="private"),
                     ),

--- a/tests/test_dispatcher/test_event/test_handler.py
+++ b/tests/test_dispatcher/test_event/test_handler.py
@@ -145,7 +145,6 @@ class TestFilterObject:
     def test_post_init(self):
         case = F.test
         filter_obj = FilterObject(callback=case)
-        print(filter_obj.callback)
         assert filter_obj.callback == case.resolve
 
 

--- a/tests/test_filters/test_chat_member_updated.py
+++ b/tests/test_filters/test_chat_member_updated.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import msgspec
 import pytest
 
 from aiogram.filters.chat_member_updated import (
@@ -340,11 +341,17 @@ class TestChatMemberUpdatedStatusFilter:
             "can_send_other_messages": True,
             "can_add_web_page_previews": True,
         }
+        old = msgspec.to_builtins(old)
+        old["update"] = update
+        old = msgspec.from_builtins(old, ChatMember)
+        new = msgspec.to_builtins(new)
+        new["update"] = update
+        new = msgspec.from_builtins(new, ChatMember)
         event = ChatMemberUpdated(
             chat=Chat(id=42, type="test"),
             from_user=user,
-            old_chat_member=old.copy(update=update),
-            new_chat_member=new.copy(update=update),
+            old_chat_member=old,
+            new_chat_member=new,
             date=datetime.now(),
         )
 

--- a/tests/test_utils/test_link.py
+++ b/tests/test_utils/test_link.py
@@ -6,10 +6,10 @@ import pytest
 
 from aiogram.utils.link import (
     BRANCH,
+    create_channel_bot_link,
     create_telegram_link,
     create_tg_link,
     docs_url,
-    create_channel_bot_link,
 )
 
 


### PR DESCRIPTION
# Description

Significant performance improve about x10 more times. 
Proof of concept replace pydantic to msgspec.
Add  `aiogram.webhook.asgi.ASGIApplication` for handle webhooks

**_WARNING_**: `aiogram.filters.callback_data.CallbackData` still use pydantic need to rewrite, sorry I have not more time.

## Simple benchmark for example

**file:** start.lua
```lua
wrk.method = "POST"
wrk.body = '{"update_id":509004967,"message":{"message_id":39389,"from":{"id":79923438,"is_bot":false,"first_name":"testuser","username":"testuser","language_code":"en"},"chat":{"id":11111111,"first_name":"testuser","username":"testuser","type":"private"},"date":1683804783,"text":"/start","entities":[{"offset":0,"length":6,"type":"bot_command"}]}}'
wrk.headers['Content-Type'] = "application/json"
```

**file:** perftest.py
```python
from aiogram import Bot
from aiogram import Dispatcher
from aiogram import Router
from aiogram.enums import ParseMode
from aiogram import types
from aiogram.filters import Command

import uvloop
uvloop.install()

router = Router()

dp = Dispatcher()
bot = Bot(token='123:token', parse_mode=ParseMode.MARKDOWN_V2)
dp.include_router(router)

try:
    from aiogram.webhook.asqi import ASGIApplication
    app = ASGIApplication(bot, dp, handle_in_background=False)
except ImportError:
    print('\naiogram.webhook.asqi is not available\n used pydantic version')


@router.message(Command(commands=['start']))
async def start(message: types.Message):
    return message.reply('test passed')


if __name__ == '__main__':
    from aiohttp import web
    from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
    app = web.Application()
    SimpleRequestHandler(handle_in_background=False, dispatcher=dp,
                         bot=bot).register(app, path='/test')
    setup_application(app, dp, bot=bot)
    web.run_app(app, host='127.0.0.1', port=8080)

```

### Test original version (aiohttp)
```bash
% pip uninstall aiogram
% pip install https://github.com/aiogram/aiogram/archive/refs/heads/dev-3.x.zip
% python perftest.py

aiogram.webhook.asqi is not available.

Test aiohttp backend
======== Running on http://127.0.0.1:8080 ========
(Press CTRL+C to quit)
```

```bash
% curl --header "Content-Type: application/json" --request POST --data '{"update_id":509004967,"message":{"message_id":39389,"from":{"id":79923438,"is_bot":false,"first_name":"testuser","username":"testuser","language_code":"en"},"chat":{"id":11111111,"first_name":"testuser","username":"testuser","type":"private"},"date":1683804783,"text":"/start","entities":[{"offset":0,"length":6,"type":"bot_command"}]}}' -i http://127.0.0.1:8080/test
HTTP/1.1 200 OK
Content-Length: 867
Content-Type: multipart/form-data; boundary=webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Date: Thu, 11 May 2023 13:03:03 GMT
Server: Python/3.11 aiohttp/3.8.4

--webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Content-Type: text/plain; charset=utf-8
Content-Length: 11
Content-Disposition: form-data; name="method"

sendMessage
--webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Content-Type: text/plain; charset=utf-8
Content-Length: 8
Content-Disposition: form-data; name="chat_id"

11111111
--webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Content-Type: text/plain; charset=utf-8
Content-Length: 11
Content-Disposition: form-data; name="text"

test passed
--webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Content-Type: text/plain; charset=utf-8
Content-Length: 10
Content-Disposition: form-data; name="parse_mode"

MarkdownV2
--webhookBoundaryde2pYoxNnBCABvVlyvMwEA
Content-Type: text/plain; charset=utf-8
Content-Length: 5
Content-Disposition: form-data; name="reply_to_message_id"

39389
--webhookBoundaryde2pYoxNnBCABvVlyvMwEA--
```
```bash
% wrk -t1 -c150 -d30s -s start.lua --latency http://127.0.0.1:8080/test
Running 30s test @ http://127.0.0.1:8080/test
  1 threads and 150 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   257.52ms   35.19ms 535.43ms   74.30%
    Req/Sec   584.99    206.58     1.22k    68.03%
  Latency Distribution
     50%  253.37ms
     75%  270.35ms
     90%  293.63ms
     99%  389.88ms
  17437 requests in 30.08s, 17.66MB read
Requests/sec:    579.64
Transfer/sec:    601.15KB
```

### Test improved version
```bash
% pip uninstall aiogram
% pip install https://github.com/whiteluna/aiogram/archive/refs/heads/msgspec.zip
```

#### aiohttp
```bash
% python perftest.py
Test aiohttp backend
======== Running on http://127.0.0.1:8080 ========
(Press CTRL+C to quit)
```

```bash
% curl --header "Content-Type: application/json" --request POST --data '{"update_id":509004967,"message":{"message_id":39389,"from":{"id":79923438,"is_bot":false,"first_name":"testuser","username":"testuser","language_code":"en"},"chat":{"id":11111111,"first_name":"testuser","username":"testuser","type":"private"},"date":1683804783,"text":"/start","entities":[{"offset":0,"length":6,"type":"bot_command"}]}}' -i http://127.0.0.1:8080/test
HTTP/1.1 200 OK
content-type: application/json
Content-Length: 173
Date: Thu, 11 May 2023 13:10:49 GMT
Server: Python/3.11 aiohttp/3.8.4

{"chat_id":11111111,"text":"test passed","parse_mode":"MarkdownV2","disable_web_page_preview":null,"protect_content":null,"reply_to_message_id":39389,"method":"sendMessage"

% wrk -t1 -c150 -d30s -s start.lua --latency http://127.0.0.1:8080/test
Running 30s test @ http://127.0.0.1:8080/test
  1 threads and 150 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    41.46ms    3.62ms  74.91ms   87.99%
    Req/Sec     3.62k   253.39     4.18k    74.33%
  Latency Distribution
     50%   40.55ms
     75%   41.58ms
     90%   44.84ms
     99%   57.44ms
  108338 requests in 30.08s, 32.75MB read
Requests/sec:   3601.26
Transfer/sec:      1.09MB
```

#### ASGI via uvcorn

```bash
% uvicorn --port 8080 perftest:app --no-access-log --workers 1 --loop uvloop --http httptools 
INFO:     Started server process [76993]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
```

```bash
% curl --header "Content-Type: application/json" --request POST --data '{"update_id":509004967,"message":{"message_id":39389,"from":{"id":79923438,"is_bot":false,"first_name":"testuser","username":"testuser","language_code":"en"},"chat":{"id":11111111,"first_name":"testuser","username":"testuser","type":"private"},"date":1683804783,"text":"/start","entities":[{"offset":0,"length":6,"type":"bot_command"}]}}' -i http://127.0.0.1:8080/test
HTTP/1.1 200 OK
date: Thu, 11 May 2023 13:16:02 GMT
server: uvicorn
content-type: application/json
content-length: 173

{"chat_id":11111111,"text":"test passed","parse_mode":"MarkdownV2","disable_web_page_preview":null,"protect_content":null,"reply_to_message_id":39389,"method":"sendMessage"}

% wrk -t1 -c150 -d30s -s start.lua --latency http://127.0.0.1:8080/test
Running 30s test @ http://127.0.0.1:8080/test
  1 threads and 150 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    25.59ms    4.00ms  52.18ms   80.24%
    Req/Sec     5.86k   434.53     6.66k    76.67%
  Latency Distribution
     50%   25.31ms
     75%   26.07ms
     90%   27.63ms
     99%   43.49ms
  175193 requests in 30.06s, 49.96MB read
Requests/sec:   5827.23
Transfer/sec:      1.66MB
```

## Type of change

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
