### PR TITLE
Automatically Resolve Update Types in `start_polling` method.

### DIFF
--- a/CHANGES/1178.feature
+++ b/CHANGES/1178.feature
@@ -1,0 +1,1 @@
+Add auto_resolve_update_types argument to start_polling method to collect the used update types automatically.

--- a/CHANGES/1178.feature
+++ b/CHANGES/1178.feature
@@ -1,1 +1,1 @@
-Add auto_resolve_update_types argument to start_polling method to collect the used update types automatically.
+Made allowed_updates list to revolve automatically in start_polling method if not set explicitly.

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -451,7 +451,7 @@ class Dispatcher(Router):
         polling_timeout: int = 10,
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
-        allowed_updates: Optional[Union[List[str], Literal[UNSET_TYPE]]] = UNSET_TYPE,
+        allowed_updates: Optional[Union[List[str], UNSET_TYPE]] = UNSET_TYPE,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -551,7 +551,6 @@ class Dispatcher(Router):
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
         allowed_updates: Optional[List[str]] = None,
-        auto_resolve_update_types: Optional[bool] = False,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,
@@ -564,7 +563,6 @@ class Dispatcher(Router):
         :param handle_as_tasks: Run task for each event and no wait result
         :param backoff_config: backoff-retry config
         :param allowed_updates: List of the update types you want your bot to receive
-        :param auto_resolve_update_types: auto resolve update types from handlers
         :param handle_signals: handle signals (SIGINT/SIGTERM)
         :param close_bot_session: close bot sessions on shutdown
         :param kwargs: contextual data
@@ -579,7 +577,6 @@ class Dispatcher(Router):
                     handle_as_tasks=handle_as_tasks,
                     backoff_config=backoff_config,
                     allowed_updates=allowed_updates,
-                    auto_resolve_update_types=auto_resolve_update_types,
                     handle_signals=handle_signals,
                     close_bot_session=close_bot_session,
                 )

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -451,6 +451,7 @@ class Dispatcher(Router):
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
         allowed_updates: Optional[List[str]] = None,
+        auto_resolve_update_types: Optional[bool] = False,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,
@@ -463,6 +464,7 @@ class Dispatcher(Router):
         :param handle_as_tasks: Run task for each event and no wait result
         :param backoff_config: backoff-retry config
         :param allowed_updates: List of the update types you want your bot to receive
+        :param auto_resolve_update_types: automatically resolve used update types in handlers
         :param handle_signals: handle signals (SIGINT/SIGTERM)
         :param close_bot_session: close bot sessions on shutdown
         :param kwargs: contextual data
@@ -496,6 +498,15 @@ class Dispatcher(Router):
                     loop.add_signal_handler(
                         signal.SIGINT, self._signal_stop_polling, signal.SIGINT
                     )
+
+            if auto_resolve_update_types:
+                if allowed_updates:
+                    loggers.dispatcher.warning(
+                        "auto_resolve_update_types and allowed_updates "
+                        "arguments are mutually exclusive, allowed_updates will be used instead"
+                    )
+                else:
+                    allowed_updates = self.resolve_used_update_types()
 
             workflow_data = {
                 "dispatcher": self,
@@ -547,6 +558,7 @@ class Dispatcher(Router):
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
         allowed_updates: Optional[List[str]] = None,
+        auto_resolve_update_types: Optional[bool] = False,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,
@@ -559,6 +571,7 @@ class Dispatcher(Router):
         :param handle_as_tasks: Run task for each event and no wait result
         :param backoff_config: backoff-retry config
         :param allowed_updates: List of the update types you want your bot to receive
+        :param auto_resolve_update_types: auto resolve update types from handlers
         :param handle_signals: handle signals (SIGINT/SIGTERM)
         :param close_bot_session: close bot sessions on shutdown
         :param kwargs: contextual data
@@ -573,6 +586,7 @@ class Dispatcher(Router):
                     handle_as_tasks=handle_as_tasks,
                     backoff_config=backoff_config,
                     allowed_updates=allowed_updates,
+                    auto_resolve_update_types=auto_resolve_update_types,
                     handle_signals=handle_signals,
                     close_bot_session=close_bot_session,
                 )

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -451,7 +451,7 @@ class Dispatcher(Router):
         polling_timeout: int = 10,
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
-        allowed_updates: Optional[List[str]] = UNSET_TYPE,
+        allowed_updates: Optional[Union[List[str], Literal[UNSET_TYPE]]] = UNSET_TYPE,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -451,7 +451,6 @@ class Dispatcher(Router):
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
         allowed_updates: Optional[List[str]] = None,
-        auto_resolve_update_types: Optional[bool] = False,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,
@@ -464,7 +463,6 @@ class Dispatcher(Router):
         :param handle_as_tasks: Run task for each event and no wait result
         :param backoff_config: backoff-retry config
         :param allowed_updates: List of the update types you want your bot to receive
-        :param auto_resolve_update_types: automatically resolve used update types in handlers
         :param handle_signals: handle signals (SIGINT/SIGTERM)
         :param close_bot_session: close bot sessions on shutdown
         :param kwargs: contextual data
@@ -499,14 +497,8 @@ class Dispatcher(Router):
                         signal.SIGINT, self._signal_stop_polling, signal.SIGINT
                     )
 
-            if auto_resolve_update_types:
-                if allowed_updates:
-                    loggers.dispatcher.warning(
-                        "auto_resolve_update_types and allowed_updates "
-                        "arguments are mutually exclusive, allowed_updates will be used instead"
-                    )
-                else:
-                    allowed_updates = self.resolve_used_update_types()
+            if allowed_updates is None:
+                allowed_updates = self.resolve_used_update_types()
 
             workflow_data = {
                 "dispatcher": self,

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -18,6 +18,7 @@ from ..fsm.strategy import FSMStrategy
 from ..methods import GetUpdates, TelegramMethod
 from ..methods.base import TelegramType
 from ..types import Update, User
+from ..types.base import UNSET_TYPE
 from ..types.update import UpdateTypeLookupError
 from ..utils.backoff import Backoff, BackoffConfig
 from .event.bases import UNHANDLED, SkipHandler
@@ -450,7 +451,7 @@ class Dispatcher(Router):
         polling_timeout: int = 10,
         handle_as_tasks: bool = True,
         backoff_config: BackoffConfig = DEFAULT_BACKOFF_CONFIG,
-        allowed_updates: Optional[List[str]] = None,
+        allowed_updates: Optional[List[str]] = UNSET_TYPE,
         handle_signals: bool = True,
         close_bot_session: bool = True,
         **kwargs: Any,
@@ -497,7 +498,7 @@ class Dispatcher(Router):
                         signal.SIGINT, self._signal_stop_polling, signal.SIGINT
                     )
 
-            if allowed_updates is None:
+            if allowed_updates is UNSET_TYPE:
                 allowed_updates = self.resolve_used_update_types()
 
             workflow_data = {


### PR DESCRIPTION
# Description

Currently, the method `dp.resolve_used_update_types` can be improved for better readability and understandability, a better name for this function could be "get_registered_event_names", or "get_registered_update_types". 

So I changed the logic, that the dispatcher would automatically collect the update types used in handlers, if `allowed_updates` parameter is not specified.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
