### PR TITLE
fix: add has_spoiler param 

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -457,6 +457,7 @@ class Message(base.TelegramObject):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
             protect_content: typing.Optional[base.Boolean] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             allow_sending_without_reply: typing.Optional[base.Boolean] = None,
             reply_markup: typing.Union[
                 InlineKeyboardMarkup,
@@ -493,6 +494,9 @@ class Message(base.TelegramObject):
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
 
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
+
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
         :type allow_sending_without_reply: :obj:`typing.Optional[base.Boolean]`
@@ -517,6 +521,7 @@ class Message(base.TelegramObject):
             caption_entities=caption_entities,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,
@@ -631,6 +636,7 @@ class Message(base.TelegramObject):
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
             protect_content: typing.Optional[base.Boolean] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             allow_sending_without_reply: typing.Optional[base.Boolean] = None,
             reply_markup: typing.Union[
                 InlineKeyboardMarkup,
@@ -684,6 +690,9 @@ class Message(base.TelegramObject):
         :param protect_content: Protects the contents of sent messages
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
+        
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
 
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
@@ -713,6 +722,7 @@ class Message(base.TelegramObject):
             caption_entities=caption_entities,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,
@@ -817,6 +827,7 @@ class Message(base.TelegramObject):
             thumb: typing.Union[base.InputFile, base.String, None] = None,
             caption: typing.Optional[base.String] = None,
             parse_mode: typing.Optional[base.String] = None,
+            has_spoiler: typing.Optional[base.Boolean] = None,
             caption_entities: typing.Optional[typing.List[MessageEntity]] = None,
             supports_streaming: typing.Optional[base.Boolean] = None,
             disable_notification: typing.Optional[base.Boolean] = None,
@@ -874,6 +885,9 @@ class Message(base.TelegramObject):
         :param protect_content: Protects the contents of sent messages
             from forwarding and saving
         :type protect_content: :obj:`typing.Optional[base.Boolean]`
+        
+        :param has_spoiler: Hide the content like a spoiler
+        :type has_spoiler: :obj:`typing.Optional[base.Boolean]`
 
         :param allow_sending_without_reply: Pass True, if the message should be sent
             even if the specified replied-to message is not found
@@ -904,6 +918,7 @@ class Message(base.TelegramObject):
             supports_streaming=supports_streaming,
             disable_notification=disable_notification,
             protect_content=protect_content,
+            has_spoiler=has_spoiler,
             reply_to_message_id=self.message_id if reply else None,
             allow_sending_without_reply=allow_sending_without_reply,
             reply_markup=reply_markup,


### PR DESCRIPTION
…ation methods

Bot API 6.4

Added the parameter has_spoiler to the methods sendPhoto, sendVideo, and sendAnimation.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:
* Operating System: 
* Python version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
