### PR TITLE
Add `__str__` formatting to the `TelegramObject`

### DIFF
--- a/CHANGES/1192.misc.rst
+++ b/CHANGES/1192.misc.rst
@@ -1,0 +1,1 @@
+Added the `__str__` method to the `TelegramObject` with formatting from its `__repr__`

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -17,6 +17,9 @@ class TelegramObject(ContextInstanceMixin["TelegramObject"], BaseModel):
         allow_population_by_field_name = True
         json_encoders = {datetime.datetime: lambda dt: int(dt.timestamp())}
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
 
 class MutableTelegramObject(TelegramObject):
     class Config:


### PR DESCRIPTION
# Description

Add the `__str__` method to the `TelegramObject` to print an object type with braces.
Before, for this code
```python3
print(Chat(id=1, type="private"), Chat(id=2, type="private"))
```
An output was: `id=1 type='private' title=None username=None ... id=2 type='private'`
Now it's the `__repr__` output: `Chat(id=1, type='private', ...) Chat(id=2, type='private', ...)`

It's more readable for the case if you're going to print, or log telegram events

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] I has executed `print(Chat(id=1, type="private"))`

**Test Configuration**:
* Operating System: Manjaro
* Python version: 3.10.10

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
