### PR TITLE
Bump magic-filter to 1.0.10

### DIFF
--- a/CHANGES/1221.misc.rst
+++ b/CHANGES/1221.misc.rst
@@ -1,0 +1,4 @@
+Updated magic-filter with new features
+
+- Added hint for len(F) error
+- Added not in operation

--- a/aiogram/filters/command.py
+++ b/aiogram/filters/command.py
@@ -191,7 +191,7 @@ class Command(Filter):
         return command  # noqa: RET504
 
     def do_magic(self, command: CommandObject) -> Any:
-        if not self.magic:
+        if self.magic is None:
             return command
         result = self.magic.resolve(command)
         if not result:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Topic :: Communications :: Chat",
 ]
 dependencies = [
-    "magic-filter~=1.0.9",
+    "magic-filter~=1.0.10",
     "aiohttp~=3.8.4",
     "pydantic~=2.0.0",
     "aiofiles~=23.1.0",


### PR DESCRIPTION
# Description

Updated magic filter to 1.0.10
Changelog: https://github.com/aiogram/magic-filter/releases/tag/v1.0.10