### PR TITLE
Added model validation to remove UNSET before field validation

### DIFF
--- a/CHANGES/1233.bugfix.rst
+++ b/CHANGES/1233.bugfix.rst
@@ -1,0 +1,4 @@
+Added model validation to remove UNSET before field validation.
+This change was necessary to correctly handle parse_mode where 'UNSET' is used as a sentinel value.
+Without the removal of 'UNSET', it would create issues when passed to model initialization from Bot.method_name.
+'UNSET' was also added to typing.


### PR DESCRIPTION
# Description

Updated aiogram/types/base.py to include a model validator which removes any 'UNSET' before field validation. This change was necessary to correctly handle `parse_mode` where 'UNSET' is used as a sentinel value. Without the removal of 'UNSET', it would create issues when passed to model initialization from `Bot.method_name`. 'UNSET' was also added to typing. Tiny documentation fix was made.