### PR TITLE
Fix bot instance passing in Dispatcher startup

### DIFF
--- a/CHANGES/1242.bugfix.rst
+++ b/CHANGES/1242.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed polling startup when "bot" key is passed manually into dispatcher workflow data

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -516,6 +516,9 @@ class Dispatcher(Router):
                 **self.workflow_data,
                 **kwargs,
             }
+            if "bot" in workflow_data:
+                workflow_data.pop("bot")
+
             await self.emit_startup(bot=bots[-1], **workflow_data)
             loggers.dispatcher.info("Start polling")
             try:

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -675,6 +675,7 @@ class TestDispatcher:
 
     async def test_start_polling(self, bot: MockedBot):
         dispatcher = Dispatcher()
+        dispatcher.workflow_data["bot"] = 42
         with pytest.raises(
             ValueError, match="At least one bot instance is required to start polling"
         ):
@@ -708,6 +709,8 @@ class TestDispatcher:
             mocked_emit_startup.assert_awaited()
             mocked_process_update.assert_awaited()
             mocked_emit_shutdown.assert_awaited()
+            assert dispatcher.workflow_data["bot"] == 42
+            assert mocked_emit_shutdown.call_args.kwargs["bot"] == bot
 
     async def test_stop_polling(self):
         dispatcher = Dispatcher()


### PR DESCRIPTION
# Description

Modified the Dispatcher to remove the "bot" key from workflow_data if found, prior to emitting startup in order to allow manual addition of "bot" to workflow data. This change was necessary as a bot instance is required to start polling, and therefore must be passed correctly. This logic is now tested in the 'test_start_polling' function. The change also includes an update to the changelog.

Fixes #1242
