### PR TITLE
Fix missing message content types

### DIFF
--- a/CHANGES/1252.bugfix.rst
+++ b/CHANGES/1252.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing message content types

--- a/CHANGES/1252.bugfix.rst
+++ b/CHANGES/1252.bugfix.rst
@@ -1,1 +1,1 @@
-Fix missing message content types
+Fixed missing message content types (:code:`ContentType.USER_SHARED`, :code:`ContentType.CHAT_SHARED`)

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -492,7 +492,11 @@ class Message(TelegramObject):
             return ContentType.VIDEO_CHAT_PARTICIPANTS_INVITED
         if self.web_app_data:
             return ContentType.WEB_APP_DATA
-
+        if self.user_shared:
+            return ContentType.USER_SHARED
+        if self.chat_shared:
+            return ContentType.CHAT_SHARED
+        
         return ContentType.UNKNOWN
 
     def _unparse_entities(self, text_decoration: TextDecoration) -> str:

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -496,7 +496,7 @@ class Message(TelegramObject):
             return ContentType.USER_SHARED
         if self.chat_shared:
             return ContentType.CHAT_SHARED
-        
+
         return ContentType.UNKNOWN
 
     def _unparse_entities(self, text_decoration: TextDecoration) -> str:

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -38,6 +38,7 @@ from aiogram.types import (
     Animation,
     Audio,
     Chat,
+    ChatShared,
     Contact,
     Dice,
     Document,
@@ -62,6 +63,7 @@ from aiogram.types import (
     Sticker,
     SuccessfulPayment,
     User,
+    UserShared,
     Venue,
     Video,
     VideoChatEnded,
@@ -439,6 +441,20 @@ TEST_FORUM_TOPIC_REOPENED = Message(
     from_user=User(id=42, is_bot=False, first_name="Test"),
     forum_topic_reopened=ForumTopicReopened(),
 )
+TEST_USER_SHARED = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=False, first_name="Test"),
+    user_shared=UserShared(request_id=42, user_id=42),
+)
+TEST_CHAT_SHARED = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=False, first_name="Test"),
+    chat_shared=ChatShared(request_id=42, chat_id=42),
+)
 TEST_MESSAGE_UNKNOWN = Message(
     message_id=42,
     date=datetime.datetime.now(),
@@ -498,6 +514,8 @@ class TestMessage:
             [TEST_FORUM_TOPIC_EDITED, ContentType.FORUM_TOPIC_EDITED],
             [TEST_FORUM_TOPIC_CLOSED, ContentType.FORUM_TOPIC_CLOSED],
             [TEST_FORUM_TOPIC_REOPENED, ContentType.FORUM_TOPIC_REOPENED],
+            [TEST_USER_SHARED, ContentType.USER_SHARED],
+            [TEST_CHAT_SHARED, ContentType.CHAT_SHARED],
             [TEST_MESSAGE_UNKNOWN, ContentType.UNKNOWN],
         ],
     )
@@ -642,6 +660,8 @@ class TestMessage:
             [TEST_MESSAGE_VIDEO_CHAT_ENDED, None],
             [TEST_MESSAGE_VIDEO_CHAT_PARTICIPANTS_INVITED, None],
             [TEST_MESSAGE_DICE, SendDice],
+            [TEST_USER_SHARED, None],
+            [TEST_CHAT_SHARED, None],
             [TEST_MESSAGE_UNKNOWN, None],
         ],
     )


### PR DESCRIPTION
# Description

Telegram supports sharing users and chats through convenient UI since [February, 2023](https://core.telegram.org/bots/api#february-3-2023) and while aiogram has support for `user_shared` and `chat_shared` params, it doesn't detect them in `message.content_type` helper. This PR fixes this error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)