### PR TITLE
Fixed some typos in documentation

### DIFF
--- a/CHANGES/1268.doc.rst
+++ b/CHANGES/1268.doc.rst
@@ -1,0 +1,2 @@
+Removed extra param in docstring of TelegramEventObserver's filter method
+and fixed typo in I18n documentation.

--- a/aiogram/dispatcher/event/telegram.py
+++ b/aiogram/dispatcher/event/telegram.py
@@ -40,7 +40,6 @@ class TelegramEventObserver:
         Register filter for all handlers of this event observer
 
         :param filters: positional filters
-        :param bound_filters: keyword filters
         """
         if self._handler.filters is None:
             self._handler.filters = []

--- a/docs/utils/i18n.rst
+++ b/docs/utils/i18n.rst
@@ -63,7 +63,7 @@ Also if you want to use translated string in keyword- or magic- filters you will
     from aiogram import F
     from aiogram.utils.i18n import lazy_gettext as __
 
-    @router.message(F.text.lower() == __("My menu entry"))
+    @router.message(F.text == __("My menu entry"))
     ...
 
 


### PR DESCRIPTION
# Description

1) In the i18n LazyProxy example, there was a comparison of the lowercase text with "My menu entry".
2) The bound_filter parameter has been removed from the TelegramEventObserver filter method, so this parameter should not be in the docstring.

Fixes # (issue)

## Type of change

- [ ] Documentation (typos, code examples or any documentation update)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
