### PR TITLE
Add contributing support for zsh and win

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,11 +73,19 @@ errors on next steps:
 Setup project
 -------------
 
-After activating the environment install `aiogram` from sources and their dependencies:
+After activating the environment install `aiogram` from sources and their dependencies.
+
+For Linux and MacOS:
 
 .. code-block:: bash
 
     pip install -e ."[dev,test,docs,fast,redis,proxy,i18n]"
+
+For Windows:
+
+.. code-block:: bash
+
+    pip install -e .[dev,test,docs,fast,redis,proxy,i18n]
 
 It will install :code:`aiogram` in editable mode into your virtual environment and all dependencies.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -41,26 +41,25 @@ Linux / macOS:
 
     source .venv/bin/activate
 
+Windows cmd
+
+.. code-block:: text
+
+    .\.venv\Scripts\activate
+
 Windows PowerShell
 
 .. code-block:: powershell
 
-    .\.venv\Scripts\Activate.ps1
+    .\.venv\Scripts\activate.ps1
 
-To check it worked, use described command, it should show the :code:`pip` location inside
-the isolated environment
-
-Linux / macOS:
+To check it worked, use described command, it should show the :code:`pip` version and location
+inside the isolated environment
 
 .. code-block::
 
-    which pip
+    pip -V
 
-Windows PowerShell
-
-.. code-block::
-
-    Get-Command pip
 
 Also make sure you have the latest pip version in your virtual environment to avoid
 errors on next steps:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,13 +35,13 @@ be able to install packages into that isolated environment.
 Activate the environment
 ------------------------
 
-Linux/ macOS:
+Linux / macOS:
 
 .. code-block:: bash
 
     source .venv/bin/activate
 
-Windows PoweShell
+Windows PowerShell
 
 .. code-block:: powershell
 
@@ -50,7 +50,7 @@ Windows PoweShell
 To check it worked, use described command, it should show the :code:`pip` location inside
 the isolated environment
 
-Linux, macOS:
+Linux / macOS:
 
 .. code-block::
 
@@ -62,7 +62,7 @@ Windows PowerShell
 
     Get-Command pip
 
-Also make you shure you have the latest pip version in your virtual environment to avoid
+Also make sure you have the latest pip version in your virtual environment to avoid
 errors on next steps:
 
 .. code-block::
@@ -75,13 +75,13 @@ Setup project
 
 After activating the environment install `aiogram` from sources and their dependencies.
 
-For Linux and MacOS:
+Linux / macOS:
 
 .. code-block:: bash
 
     pip install -e ."[dev,test,docs,fast,redis,proxy,i18n]"
 
-For Windows:
+Windows:
 
 .. code-block:: bash
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,7 +77,7 @@ After activating the environment install `aiogram` from sources and their depend
 
 .. code-block:: bash
 
-    pip install -e .[dev,test,docs,fast,redis,proxy,i18n]
+    pip install -e ."[dev,test,docs,fast,redis,proxy,i18n]"
 
 It will install :code:`aiogram` in editable mode into your virtual environment and all dependencies.
 


### PR DESCRIPTION
# Description

Got similar issue: https://github.com/mu-editor/mu/issues/852

```text
pip install -e .[dev,test,docs,fast,redis,proxy,i18n]
zsh: no matches found: .[dev,test,docs,fast,redis,proxy,i18n]

```

Also:
- added (and checked) Windows cmd examples
- fixed typos


## Type of change

- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

**Test Configuration**:
* Operating System: MacOS 13.4.1, Windows 11
