### PR TITLE
Fix markdown italic quote

### DIFF
--- a/CHANGES/1282.bugfix.rst
+++ b/CHANGES/1282.bugfix.rst
@@ -1,0 +1,1 @@
+Italic markdown from utils now uses correct decorators

--- a/aiogram/utils/markdown.py
+++ b/aiogram/utils/markdown.py
@@ -48,7 +48,7 @@ def italic(*content: Any, sep: str = " ") -> str:
     :param sep:
     :return:
     """
-    return markdown_decoration.italic(value=html_decoration.quote(_join(*content, sep=sep)))
+    return markdown_decoration.italic(value=markdown_decoration.quote(_join(*content, sep=sep)))
 
 
 def hitalic(*content: Any, sep: str = " ") -> str:


### PR DESCRIPTION
# Description

Small bugfix in `utils\markdown.py` which mistakenly applied `html_decoration.quote(...)` inside a Markdown italic variation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)