### PR TITLE
Fix magic operation `.as_` for values interpreted as False

### DIFF
--- a/CHANGES/1281.bugfix.rst
+++ b/CHANGES/1281.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed magic :code:`.as_(...)` operation for values that can be interpreted as `False` (e.g. `0`).

--- a/aiogram/utils/magic_filter.py
+++ b/aiogram/utils/magic_filter.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable
 
 from magic_filter import MagicFilter as _MagicFilter
 from magic_filter import MagicT as _MagicT
@@ -12,7 +12,7 @@ class AsFilterResultOperation(BaseOperation):
         self.name = name
 
     def resolve(self, value: Any, initial_value: Any) -> Any:
-        if not value:
+        if value is None or (isinstance(value, Iterable) and not value):
             return None
         return {self.name: value}
 

--- a/tests/test_utils/test_magic_filter.py
+++ b/tests/test_utils/test_magic_filter.py
@@ -19,3 +19,17 @@ class TestMagicFilter:
         result = magic.resolve(MyObject(text="123"))
         assert isinstance(result, dict)
         assert isinstance(result["match"], Match)
+
+    def test_operation_as_not_none(self):
+        # Issue: https://github.com/aiogram/aiogram/issues/1281
+        magic = F.cast(int).as_("value")
+
+        result = magic.resolve("0")
+        assert result == {"value": 0}
+
+    def test_operation_as_not_none_iterable(self):
+        # Issue: https://github.com/aiogram/aiogram/issues/1281
+        magic = F.as_("value")
+
+        result = magic.resolve([])
+        assert result is None


### PR DESCRIPTION
# Description

Modified the ".as_" method in the magic filter class to correctly handle values that are interpreted as `False` such as `0`. Previously, the method incorrectly dismissed these valid values. The issue was identified and fixed to ensure correct handling of all valid data inputs.

Fixes #1281