### PR TITLE
Fix `Message.send_copy` method for stories

### DIFF
--- a/CHANGES/1286.bugfi.rst
+++ b/CHANGES/1286.bugfi.rst
@@ -1,0 +1,1 @@
+Fixed :code:`Message.send_copy` method, which was not working properly with stories, so not you can copy stories too (forwards messages).

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -2804,6 +2804,7 @@ class Message(TelegramObject):
         allow_sending_without_reply: Optional[bool] = None,
         message_thread_id: Optional[int] = None,
     ) -> Union[
+        ForwardMessage,
         SendAnimation,
         SendAudio,
         SendContact,
@@ -2839,6 +2840,7 @@ class Message(TelegramObject):
         :return:
         """
         from ..methods import (
+            ForwardMessage,
             SendAnimation,
             SendAudio,
             SendContact,
@@ -2955,6 +2957,12 @@ class Message(TelegramObject):
             ).as_(self._bot)
         if self.dice:  # Dice value can't be controlled
             return SendDice(
+                **kwargs,
+            ).as_(self._bot)
+        if self.story:
+            return ForwardMessage(
+                from_chat_id=self.chat.id,
+                message_id=self.message_id,
                 **kwargs,
             ).as_(self._bot)
 

--- a/docs/dispatcher/dispatcher.rst
+++ b/docs/dispatcher/dispatcher.rst
@@ -4,14 +4,14 @@ Dispatcher
 
 Dispatcher is root :obj:`Router` and in code Dispatcher can be used directly for routing updates or attach another routers into dispatcher.
 
-Here is only listed base information about Dispatcher. All about writing handlers, filters and etc. you can found in next pages:
+Here is only listed base information about Dispatcher. All about writing handlers, filters and etc. you can find in next pages:
 
 - :ref:`Router <Router>`
 - :ref:`Filtering events`
 
 
 .. autoclass:: aiogram.dispatcher.dispatcher.Dispatcher
-    :members: __init__, feed_update, feed_raw_update, feed_webhook_update, start_polling, run_polling
+    :members: __init__, feed_update, feed_raw_update, feed_webhook_update, start_polling, run_polling, stop_polling
 
 
 Simple usage

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -649,6 +649,7 @@ class TestMessage:
             [TEST_MESSAGE_CONTACT, SendContact],
             [TEST_MESSAGE_VENUE, SendVenue],
             [TEST_MESSAGE_LOCATION, SendLocation],
+            [TEST_MESSAGE_STORY, ForwardMessage],
             [TEST_MESSAGE_NEW_CHAT_MEMBERS, None],
             [TEST_MESSAGE_LEFT_CHAT_MEMBER, None],
             [TEST_MESSAGE_INVOICE, None],


### PR DESCRIPTION
# Description

Fixed an issue with the `Message.send_copy` method, which was not functioning properly with story-type messages. The `ForwardMessage` logic has been added to the method to enable copying of stories, in addition to other types. 

Fixes #1286
