### PR TITLE
Fixed error overlapping when validation error is caused by remove_unset root validator in base types and methods.

### DIFF
--- a/CHANGES/1290.bugfix.rst
+++ b/CHANGES/1290.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed error overlapping when validation error is caused by remove_unset root validator in base types and methods.

--- a/aiogram/methods/base.py
+++ b/aiogram/methods/base.py
@@ -61,6 +61,8 @@ class TelegramMethod(BotContextController, BaseModel, Generic[TelegramType], ABC
         but UNSET might be passing to a model initialization from `Bot.method_name`,
         so we must take care of it and remove it before fields validation.
         """
+        if not isinstance(values, dict):
+            return values
         return {k: v for k, v in values.items() if not isinstance(v, UNSET_TYPE)}
 
     if TYPE_CHECKING:

--- a/aiogram/types/base.py
+++ b/aiogram/types/base.py
@@ -28,6 +28,8 @@ class TelegramObject(BotContextController, BaseModel):
         but UNSET might be passed to a model initialization from `Bot.method_name`,
         so we must take care of it and remove it before fields validation.
         """
+        if not isinstance(values, dict):
+            return values
         return {k: v for k, v in values.items() if not isinstance(v, UNSET_TYPE)}
 
 

--- a/tests/test_api/test_methods/test_base.py
+++ b/tests/test_api/test_methods/test_base.py
@@ -20,6 +20,9 @@ class TestTelegramMethodRemoveUnset:
         validated = TelegramMethod.remove_unset(values)
         assert set(validated.keys()) == names
 
+    def test_remove_unset_non_dict(self):
+        assert TelegramMethod.remove_unset("") == ""
+
 
 class TestTelegramMethodCall:
     async def test_async_emit_unsuccessful(self, bot: MockedBot):

--- a/tests/test_api/test_methods/test_base.py
+++ b/tests/test_api/test_methods/test_base.py
@@ -3,7 +3,7 @@ from unittest.mock import sentinel
 import pytest
 
 from aiogram.methods import GetMe, TelegramMethod
-from aiogram.types import User
+from aiogram.types import User, TelegramObject
 from tests.mocked_bot import MockedBot
 
 
@@ -16,12 +16,14 @@ class TestTelegramMethodRemoveUnset:
             [{"foo": "bar", "baz": sentinel.DEFAULT}, {"foo"}],
         ],
     )
-    def test_remove_unset(self, values, names):
-        validated = TelegramMethod.remove_unset(values)
+    @pytest.mark.parametrize("obj", [TelegramMethod, TelegramObject])
+    def test_remove_unset(self, values, names, obj):
+        validated = obj.remove_unset(values)
         assert set(validated.keys()) == names
 
-    def test_remove_unset_non_dict(self):
-        assert TelegramMethod.remove_unset("") == ""
+    @pytest.mark.parametrize("obj", [TelegramMethod, TelegramObject])
+    def test_remove_unset_non_dict(self, obj):
+        assert obj.remove_unset("") == ""
 
 
 class TestTelegramMethodCall:


### PR DESCRIPTION
# Description

Fixed error overlapping when validation error is caused by `remove_unset` root validator in base types and methods.


## Example:

```python
InlineKeyboardButton(
    text="Play with Friends",
    switch_inline_query_chosen_chat="test",
)
```
### Caused:
```
  .../aiogram/types/base.py", line 31, in remove_unset
    return {k: v for k, v in values.items() if not isinstance(v, UNSET_TYPE)}
AttributeError: 'str' object has no attribute 'items'                                                                                                                      
```

### Expected:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for InlineKeyboardButton
switch_inline_query_chosen_chat
  Input should be a valid dictionary or instance of SwitchInlineQueryChosenChat [type=model_type, input_value='test', input_type=str]
    For further information visit https://errors.pydantic.dev/2.1/v/model_type
```