### PR TITLE
fixes #206 - emit warning if command starts with command prefix 

### DIFF
--- a/CHANGES/1263.feature
+++ b/CHANGES/1263.feature
@@ -1,0 +1,1 @@
+Added support for commands starting with command prefix by automatically removing user added prefix

--- a/aiogram/filters/command.py
+++ b/aiogram/filters/command.py
@@ -78,6 +78,17 @@ class Command(Filter):
                 " or their Iterable"
             )
 
+        prefixes = []
+        for char in prefix:
+            if char not in prefixes:
+                prefixes.append(char)
+
+        operations = {
+            BotCommand: lambda cmd, prefix: cmd.command.lstrip(prefix),
+            re.Pattern: lambda cmd, prefix: re.compile(cmd.pattern.lstrip(prefix)),
+            str: lambda cmd, prefix: cmd.lstrip(prefix),
+        }
+
         items = []
         for command in (*values, *commands):
             if isinstance(command, BotCommand):
@@ -89,6 +100,9 @@ class Command(Filter):
                 )
             if ignore_case and isinstance(command, str):
                 command = command.casefold()
+            for individual_prefix in prefixes:
+                if isinstance(command, (str, BotCommand, re.Pattern)):
+                    command = operations[type(command)](command, individual_prefix)
             items.append(command)
 
         if not items:

--- a/aiogram/filters/command.py
+++ b/aiogram/filters/command.py
@@ -78,17 +78,6 @@ class Command(Filter):
                 " or their Iterable"
             )
 
-        prefixes = []
-        for char in prefix:
-            if char not in prefixes:
-                prefixes.append(char)
-
-        operations = {
-            BotCommand: lambda cmd, prefix: cmd.command.lstrip(prefix),
-            re.Pattern: lambda cmd, prefix: re.compile(cmd.pattern.lstrip(prefix)),
-            str: lambda cmd, prefix: cmd.lstrip(prefix),
-        }
-
         items = []
         for command in (*values, *commands):
             if isinstance(command, BotCommand):
@@ -100,9 +89,8 @@ class Command(Filter):
                 )
             if ignore_case and isinstance(command, str):
                 command = command.casefold()
-            for individual_prefix in prefixes:
-                if isinstance(command, (str, BotCommand, re.Pattern)):
-                    command = operations[type(command)](command, individual_prefix)
+                for individual_prefix in prefix:
+                    command = command.lstrip(individual_prefix)
             items.append(command)
 
         if not items:
@@ -182,6 +170,9 @@ class Command(Filter):
                     return replace(command, regexp_match=result)
 
             command_name = command.command
+            for individual_prefix in self.prefix:
+                command_name = command.command.replace(individual_prefix, '', 1)
+
             if self.ignore_case:
                 command_name = command_name.casefold()
 

--- a/tests/test_filters/test_command.py
+++ b/tests/test_filters/test_command.py
@@ -38,11 +38,11 @@ class TestCommandFilter:
     @pytest.mark.parametrize(
         "commands,checklist",
         [
-            [("Test1", "tEst2", "teSt3"), ("test1", "test2", "test3")],
+            [("/Test1", "tEst2", "teSt3"), ("test1", "test2", "test3")],
             [("12TeSt", "3t4Est", "5TE6sT"), ("12test", "3t4est", "5te6st")],
-            [[BotCommand(command="Test", description="Test1")], ("test",)],
+            [[BotCommand(command="/Test", description="Test1")], ("test",)],
             [[BotCommand(command="tEsT", description="Test2")], ("test",)],
-            [(re.compile(r"test(\d+)"), "TeSt"), (re.compile(r"test(\d+)"), "test")],
+            [(re.compile(r"/test(\d+)"), "TeSt"), (re.compile(r"test(\d+)"), "test")],
         ],
     )
     def test_init_casefold(self, commands, checklist):

--- a/tests/test_filters/test_command.py
+++ b/tests/test_filters/test_command.py
@@ -42,7 +42,7 @@ class TestCommandFilter:
             [("12TeSt", "3t4Est", "5TE6sT"), ("12test", "3t4est", "5te6st")],
             [[BotCommand(command="/Test", description="Test1")], ("test",)],
             [[BotCommand(command="tEsT", description="Test2")], ("test",)],
-            [(re.compile(r"/test(\d+)"), "TeSt"), (re.compile(r"test(\d+)"), "test")],
+            [(re.compile(r"test(\d+)"), "TeSt"), (re.compile(r"test(\d+)"), "test")],
         ],
     )
     def test_init_casefold(self, commands, checklist):


### PR DESCRIPTION
# Description

Fixes #206 
If the command  starts with command prefix, it removes one prefix automatically and allows users to use both styles of commands: ['/start', '/help'] and ['start', 'help']

## Type of change

-  [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It was tested locally with pytest. Existing commands list was modified to test this feature.

**Test Configuration**:
* Operating System: NixOS 23.05
* Python version: 3.11.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Note:
I have made some changes in existing test cases in order to test this feature. I believe all functions are still checked as before. 
