### PR TITLE
Fix broken link in MessageHandler (CBH) documentation

### DIFF
--- a/docs/dispatcher/class_based_handlers/message.rst
+++ b/docs/dispatcher/class_based_handlers/message.rst
@@ -21,7 +21,7 @@ Simple usage
 Extension
 =========
 
-This base handler is subclass of [BaseHandler](basics.md#basehandler) with some extensions:
+This base handler is subclass of :ref:`BaseHandler <cbh-base-handler>` with some extensions:
 
 - :code:`self.chat` is alias for :code:`self.event.chat`
 - :code:`self.from_user` is alias for :code:`self.event.from_user`


### PR DESCRIPTION
# Description

I've found a broken link in `MessageHandler` (Class based handlers) documentation. Here's a fix for it.

## Type of change

- [X] Documentation (typos, code examples or any documentation update)

# Checklist:

- [x] I have made corresponding changes to the documentation
