### PR TITLE
Prevent update handling task pointers from being garbage collected, backport of #1328

### DIFF
--- a/CHANGES/1331.misc
+++ b/CHANGES/1331.misc
@@ -1,0 +1,1 @@
+Prevent update handling task pointers from being garbage collected, backport from 2.x

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -6,7 +6,7 @@ import signal
 import warnings
 from asyncio import CancelledError, Event, Future, Lock
 from contextlib import suppress
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Union
 
 from .. import loggers
 from ..client.bot import Bot
@@ -95,7 +95,7 @@ class Dispatcher(Router):
         self._running_lock = Lock()
         self._stop_signal: Optional[Event] = None
         self._stopped_signal: Optional[Event] = None
-        self._handle_update_tasks = set()
+        self._handle_update_tasks: Set[asyncio.Task[Any]] = set()
 
     def __getitem__(self, item: str) -> Any:
         return self.workflow_data[item]

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -95,6 +95,7 @@ class Dispatcher(Router):
         self._running_lock = Lock()
         self._stop_signal: Optional[Event] = None
         self._stopped_signal: Optional[Event] = None
+        self._handle_update_tasks = set()
 
     def __getitem__(self, item: str) -> Any:
         return self.workflow_data[item]
@@ -349,7 +350,9 @@ class Dispatcher(Router):
             ):
                 handle_update = self._process_update(bot=bot, update=update, **kwargs)
                 if handle_as_tasks:
-                    asyncio.create_task(handle_update)
+                    handle_update_task = asyncio.create_task(handle_update)
+                    self._handle_update_tasks.add(handle_update_task)
+                    handle_update_task.add_done_callback(self._handle_update_tasks.discard)
                 else:
                     await handle_update
         finally:

--- a/aiogram/webhook/aiohttp_server.py
+++ b/aiogram/webhook/aiohttp_server.py
@@ -2,7 +2,7 @@ import asyncio
 import secrets
 from abc import ABC, abstractmethod
 from asyncio import Transport
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, cast
+from typing import Any, Awaitable, Callable, Dict, Optional, Set, Tuple, cast
 
 from aiohttp import MultipartWriter, web
 from aiohttp.abc import Application
@@ -98,7 +98,7 @@ class BaseRequestHandler(ABC):
         self.dispatcher = dispatcher
         self.handle_in_background = handle_in_background
         self.data = data
-        self._background_feed_update_tasks = set()
+        self._background_feed_update_tasks: Set[asyncio.Task[Any]] = set()
 
     def register(self, app: Application, /, path: str, **kwargs: Any) -> None:
         """


### PR DESCRIPTION
# Description

This is a backport of #1328 to mitigate possible issues like #628, #927. As in #1328, this PR preserves asyncio `Task` pointers until the task is completed to ensure `Task` will not be garbage collected and disappear. See recommendations in [Python docs](https://docs.python.org/3/library/asyncio-task.html#creating-tasks).

> **Important**: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Honestly, I don't have a v3-based bot with workload I have in v2. But want to admit once again, it's a pretty rare case and we're handling it as the docs says.

**Test Configuration**:
* Operating System: Macos, Linux
* Python version: 3.11.1
