### PR TITLE
Fix send_copy helper parse mode

### DIFF
--- a/CHANGES/1332.bugfix.rst
+++ b/CHANGES/1332.bugfix.rst
@@ -1,0 +1,1 @@
+ Fixed ``parse_mode`` in ``send_copy`` helper. Disable by default.

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -2803,6 +2803,7 @@ class Message(TelegramObject):
         reply_markup: Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, None] = None,
         allow_sending_without_reply: Optional[bool] = None,
         message_thread_id: Optional[int] = None,
+        parse_mode: Optional[str] = None,
     ) -> Union[
         ForwardMessage,
         SendAnimation,
@@ -2837,6 +2838,7 @@ class Message(TelegramObject):
         :param reply_markup:
         :param allow_sending_without_reply:
         :param message_thread_id:
+        :param parse_mode:
         :return:
         """
         from ..methods import (
@@ -2864,6 +2866,9 @@ class Message(TelegramObject):
             "reply_to_message_id": reply_to_message_id,
             "message_thread_id": message_thread_id,
             "allow_sending_without_reply": allow_sending_without_reply,
+            # when sending a copy, we don't need any parse mode
+            # because all entities are already prepared
+            "parse_mode": parse_mode,
         }
 
         if self.text:

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Type, Union
 
 import pytest
 
+from aiogram.enums import ParseMode
 from aiogram.methods import (
     CopyMessage,
     DeleteMessage,
@@ -74,6 +75,7 @@ from aiogram.types import (
     VideoNote,
     Voice,
     WebAppData,
+    UNSET_PARSE_MODE,
 )
 from aiogram.types.message import ContentType, Message
 
@@ -688,9 +690,43 @@ class TestMessage:
             return
 
         method = message.send_copy(chat_id=42)
-        if method:
-            assert isinstance(method, expected_method)
+        assert isinstance(method, expected_method)
+        if hasattr(method, "parse_mode"):
+            # default parse mode in send_copy
+            assert method.parse_mode is None
         # TODO: Check additional fields
+
+    @pytest.mark.parametrize(
+        "custom_parse_mode",
+        [
+            UNSET_PARSE_MODE,
+            *list(ParseMode),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "message,expected_method",
+        [
+            [TEST_MESSAGE_TEXT, SendMessage],
+            [TEST_MESSAGE_AUDIO, SendAudio],
+            [TEST_MESSAGE_ANIMATION, SendAnimation],
+            [TEST_MESSAGE_DOCUMENT, SendDocument],
+            [TEST_MESSAGE_PHOTO, SendPhoto],
+            [TEST_MESSAGE_VIDEO, SendVideo],
+            [TEST_MESSAGE_VOICE, SendVoice],
+        ],
+    )
+    def test_send_copy_custom_parse_mode(
+        self,
+        message: Message,
+        expected_method: Optional[Type[TelegramMethod]],
+        custom_parse_mode: Optional[str],
+    ):
+        method = message.send_copy(
+            chat_id=42,
+            parse_mode=custom_parse_mode,
+        )
+        assert isinstance(method, expected_method)
+        assert method.parse_mode == custom_parse_mode
 
     def test_edit_text(self):
         message = Message(


### PR DESCRIPTION
# Description

If you set default parse mode on Bot instance, this parse mode applies on all calls with UNSET parse mode, even on `send_copy`, where entities are already applied and no parse mode is required. It even breaks copying regular messages with 'special' characters like `.` or `!` when `MarkdownV2` is set by default. 
Parse mode should not be sent, but we need to have an option to override it. So, by default `parse_mode` in `send_copy` should be `None.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Added autotests
- [X] Created a Bot instance with default parse_mode = `MarkdownV2`

**Test Configuration**:
* Operating System: macOS
* Python version: 3.11

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
