### PR TITLE
Add new FSM strategy CHAT_TOPIC to strategy.py

### DIFF
--- a/aiogram/fsm/strategy.py
+++ b/aiogram/fsm/strategy.py
@@ -7,7 +7,7 @@ class FSMStrategy(Enum):
     CHAT = auto()
     GLOBAL_USER = auto()
     USER_IN_TOPIC = auto()
-
+    CHAT_TOPIC = auto()
 
 def apply_strategy(
     strategy: FSMStrategy,
@@ -21,4 +21,6 @@ def apply_strategy(
         return user_id, user_id, None
     if strategy == FSMStrategy.USER_IN_TOPIC:
         return chat_id, user_id, thread_id
+    if strategy == FSMStrategy.CHAT_TOPIC:
+        return chat_id, None, thread_id
     return chat_id, user_id, None


### PR DESCRIPTION
The new FSM strategy, which sets the state for the entire topic in the chat, also works in private messages and regular groups without topics.

# Description

Aiogram did not have an FSM strategy that would set state only for a specific topic in the chat. This strategy is quite reasonable and it has many applications. 
The work of state in private messages remains unchanged
The work of state in groups / super groups without topics, state will be established for all groups
The work of state in groups /super groups with topics, State will be established only for one topic, other topics will not have a state until it is installed, state can be set separately for each topic, and state_data will be separate in all topics where state is installed.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- Run tests/test_fsm/test_strategy.py
- You can run bot with FSMStrategy.CHAT_TOPIC, and make sure that the strategy is working correctly:

   - Check the work of state in private messages
   - Check the work of state in groups/super groups without topics, State should be set for the whole group, since the topic value will be None
   - Check the work of state in groups/super groups with topics, State should be installed only for one topic, other topics will not have a state until it is installed, state can be set separately for each topic, and state_data for should be separate in all topics where state is installed.


**Test Configuration**:
* Operating System: windows 11
* Python version: 3.11

# Checklist:

- [+] My code follows the style guidelines of this project
- [+] I have performed a self-review of my own code
- [-] I have made corresponding changes to the documentation
- [+] I have added tests that prove my fix is effective or that my feature works
- [+] New and existing unit tests pass locally with my changes
