### PR TITLE
Update typing-extensions version range in dependencies

### DIFF
--- a/CHANGES/1347.misc.rst
+++ b/CHANGES/1347.misc.rst
@@ -1,0 +1,1 @@
+Updated :code:`typing-extensions` package version range in dependencies to fix compatibility with :code:`FastAPI`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pydantic>=2.4.1,<2.5",
     "aiofiles~=23.2.1",
     "certifi>=2023.7.22",
-    "typing-extensions~=4.8.0",
+    "typing-extensions>=4.7.0,<=5.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
# Description

This commit changes the version requirements for typing-extensions in the dependencies section of pyproject.toml file. This change now requires versions that are greater than or equal to 4.7.0 and less than or equal to 5.0. The previous version, 4.8.0, has been found to cause compatibility issues with some other libraries.

Fixes #1347
