### PR TITLE
Fixed ResourceWarnings in tests

### DIFF
--- a/CHANGES/1320.misc.rst
+++ b/CHANGES/1320.misc.rst
@@ -1,0 +1,1 @@
+Fixed ResourceWarning in the tests, reworked :code:`RedisEventsIsolation` fixture to use Redis connection from :code:`RedisStorage`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,10 +237,9 @@ asyncio_mode = "auto"
 testpaths = [
     "tests",
 ]
-filterwarnings = [
-    "error",
-    "ignore::pytest.PytestUnraisableExceptionWarning",
-]
+#filterwarnings = [
+#    "error",
+#]
 
 [tool.coverage.run]
 branch = false

--- a/tests/test_api/test_client/test_session/test_aiohttp_session.py
+++ b/tests/test_api/test_client/test_session/test_aiohttp_session.py
@@ -96,6 +96,8 @@ class TestAiohttpSession:
             await session.close()
             mocked_close.assert_called_once()
 
+        await session.close()
+
     def test_build_form_data_with_data_only(self, bot: MockedBot):
         class TestMethod(TelegramMethod[bool]):
             __api_method__ = "test"

--- a/tests/test_fsm/storage/test_isolation.py
+++ b/tests/test_fsm/storage/test_isolation.py
@@ -1,6 +1,10 @@
+from unittest import mock
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from aiogram.fsm.storage.base import BaseEventIsolation, StorageKey
+from aiogram.fsm.storage.redis import RedisEventIsolation
 from tests.mocked_bot import MockedBot
 
 
@@ -25,3 +29,35 @@ class TestIsolations:
     ):
         async with isolation.lock(key=storage_key):
             assert True, "Are you kidding me?"
+
+
+class TestRedisEventIsolation:
+    def test_init_without_key_builder(self):
+        redis = AsyncMock()
+        isolation = RedisEventIsolation(redis=redis)
+        assert isolation.redis is redis
+
+        assert isolation.key_builder is not None
+
+    def test_init_with_key_builder(self):
+        redis = AsyncMock()
+        key_builder = AsyncMock()
+        isolation = RedisEventIsolation(redis=redis, key_builder=key_builder)
+        assert isolation.redis is redis
+        assert isolation.key_builder is key_builder
+
+    def test_create_from_url(self):
+        with patch("redis.asyncio.connection.ConnectionPool.from_url") as pool:
+            isolation = RedisEventIsolation.from_url("redis://localhost:6379/0")
+            assert isinstance(isolation, RedisEventIsolation)
+            assert isolation.redis is not None
+            assert isolation.key_builder is not None
+
+            assert pool.called_once_with("redis://localhost:6379/0")
+
+    async def test_close(self):
+        isolation = RedisEventIsolation(redis=AsyncMock())
+        await isolation.close()
+
+        # close is not called because connection should be closed from the storage
+        # assert isolation.redis.close.called_once()

--- a/tests/test_fsm/storage/test_isolation.py
+++ b/tests/test_fsm/storage/test_isolation.py
@@ -18,7 +18,6 @@ def create_storage_key(bot: MockedBot):
     ],
 )
 class TestIsolations:
-    @pytest.mark.filterwarnings("ignore::ResourceWarning")
     async def test_lock(
         self,
         isolation: BaseEventIsolation,


### PR DESCRIPTION
# Description

Fixed ResourceWarning in tests, modified the pytest's configuration file, `pyproject.toml`, to remove filterwarnings settings. It also makes changes in various test files; the Redis isolation test is now using the provided `redis_storage` fixture instead of setting up its own connection, pytest.mark.filterwarnings is no longer used in `test_isolation.py` and `test_aiohttp_session.py` properly closes off sessions.

Fixes #1320 
