### PR TITLE
Add KeyboardButtonPollTypeType enum

### DIFF
--- a/.butcher/enums/KeyboardButtonPollTypeType.yml
+++ b/.butcher/enums/KeyboardButtonPollTypeType.yml
@@ -1,0 +1,8 @@
+name: KeyboardButtonPollTypeType
+description: |
+  This object represents type of a poll, which is allowed to be created and sent when the corresponding button is pressed.
+
+  Source: https://core.telegram.org/bots/api#keyboardbuttonpolltype
+static:
+  QUIZ: "quiz"
+  REGULAR: "regular"

--- a/CHANGES/1398.feature.rst
+++ b/CHANGES/1398.feature.rst
@@ -1,0 +1,1 @@
+A new enum :code:`KeyboardButtonPollTypeType` for :code:`KeyboardButtonPollTypeType.type` field has bed added.

--- a/aiogram/enums/__init__.py
+++ b/aiogram/enums/__init__.py
@@ -9,6 +9,7 @@ from .dice_emoji import DiceEmoji
 from .encrypted_passport_element import EncryptedPassportElement
 from .inline_query_result_type import InlineQueryResultType
 from .input_media_type import InputMediaType
+from .keyboard_button_poll_type_type import KeyboardButtonPollTypeType
 from .mask_position_point import MaskPositionPoint
 from .menu_button_type import MenuButtonType
 from .message_entity_type import MessageEntityType
@@ -34,6 +35,7 @@ __all__ = (
     "EncryptedPassportElement",
     "InlineQueryResultType",
     "InputMediaType",
+    "KeyboardButtonPollTypeType",
     "MaskPositionPoint",
     "MenuButtonType",
     "MessageEntityType",

--- a/aiogram/enums/keyboard_button_poll_type_type.py
+++ b/aiogram/enums/keyboard_button_poll_type_type.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class KeyboardButtonPollTypeType(str, Enum):
+    """
+    This object represents type of a poll, which is allowed to be created and sent when the corresponding button is pressed.
+
+    Source: https://core.telegram.org/bots/api#keyboardbuttonpolltype
+    """
+
+    QUIZ = "quiz"
+    REGULAR = "regular"

--- a/docs/api/enums/index.rst
+++ b/docs/api/enums/index.rst
@@ -21,6 +21,7 @@ Here is list of all available enums:
     encrypted_passport_element
     inline_query_result_type
     input_media_type
+    keyboard_button_poll_type_type
     mask_position_point
     menu_button_type
     message_entity_type

--- a/docs/api/enums/keyboard_button_poll_type_type.rst
+++ b/docs/api/enums/keyboard_button_poll_type_type.rst
@@ -1,0 +1,9 @@
+##########################
+KeyboardButtonPollTypeType
+##########################
+
+
+.. automodule:: aiogram.enums.keyboard_button_poll_type_type
+    :members:
+    :member-order: bysource
+    :undoc-members: True


### PR DESCRIPTION
A new enum `KeyboardButtonPollTypeType` for `KeyboardButtonPollTypeType.type` field has bed added.
