### PR TITLE
Update message.send_copy: add missing reply_parameters param

### DIFF
--- a/CHANGES/1403.bugfix.rst
+++ b/CHANGES/1403.bugfix.rst
@@ -1,0 +1,1 @@
+Add new :code:`reply_parameters` param to :code:`message.send_copy` because it hasn't been added there

--- a/CHANGES/1403.bugfix.rst
+++ b/CHANGES/1403.bugfix.rst
@@ -1,1 +1,1 @@
-Add new :code:`reply_parameters` param to :code:`message.send_copy` because it hasn't been added there
+Added new :code:`reply_parameters` param to :code:`message.send_copy` because it hasn't been added there

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -3013,6 +3013,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id: Union[str, int],
         disable_notification: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
+        reply_parameters: Optional[ReplyParameters] = None,
         reply_markup: Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, None] = None,
         allow_sending_without_reply: Optional[bool] = None,
         message_thread_id: Optional[int] = None,
@@ -3048,6 +3049,7 @@ class Message(MaybeInaccessibleMessage):
         :param chat_id:
         :param disable_notification:
         :param reply_to_message_id:
+        :param reply_parameters:
         :param reply_markup:
         :param allow_sending_without_reply:
         :param message_thread_id:
@@ -3077,6 +3079,7 @@ class Message(MaybeInaccessibleMessage):
             "reply_markup": reply_markup or self.reply_markup,
             "disable_notification": disable_notification,
             "reply_to_message_id": reply_to_message_id,
+            "reply_parameters": reply_parameters,
             "message_thread_id": message_thread_id,
             "allow_sending_without_reply": allow_sending_without_reply,
             # when sending a copy, we don't need any parse mode


### PR DESCRIPTION
# Description

with the 7.0 changes `reply_parameters` has been added everywhere except for `messages.send_copy`, this PR aims to fix that


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
