### PR TITLE
fix prepare Default

### DIFF
--- a/CHANGES/1418.bugfix.rst
+++ b/CHANGES/1418.bugfix.rst
@@ -1,0 +1,1 @@
+fix TelegramObject from DefaultBotProperties is not JSON serializable

--- a/aiogram/client/session/base.py
+++ b/aiogram/client/session/base.py
@@ -38,7 +38,7 @@ from aiogram.exceptions import (
 
 from ...methods import Response, TelegramMethod
 from ...methods.base import TelegramType
-from ...types import InputFile
+from ...types import InputFile, TelegramObject
 from ..default import Default
 from ..telegram import PRODUCTION, TelegramAPIServer
 from .middlewares.manager import RequestMiddlewareManager
@@ -193,6 +193,8 @@ class BaseSession(abc.ABC):
             return value
         if isinstance(value, Default):
             default_value = bot.default[value.name]
+            if isinstance(default_value, TelegramObject):
+                default_value = default_value.model_dump(warnings=False)
             return self.prepare_value(default_value, bot=bot, files=files, _dumps_json=_dumps_json)
         if isinstance(value, InputFile):
             key = secrets.token_urlsafe(10)


### PR DESCRIPTION
# Description

fix TelegramObject from DefaultBotProperties is not JSON serializable 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
