### PR TITLE
Fixed default LinkPreviewOptions JSON serialization

### DIFF
--- a/CHANGES/1418.bugfix.rst
+++ b/CHANGES/1418.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed JSON serialization of the :code:`LinkPreviewOptions` class while it is passed
+as bot-wide default options.

--- a/aiogram/client/session/base.py
+++ b/aiogram/client/session/base.py
@@ -38,7 +38,7 @@ from aiogram.exceptions import (
 
 from ...methods import Response, TelegramMethod
 from ...methods.base import TelegramType
-from ...types import InputFile
+from ...types import InputFile, TelegramObject
 from ..default import Default
 from ..telegram import PRODUCTION, TelegramAPIServer
 from .middlewares.manager import RequestMiddlewareManager
@@ -233,7 +233,13 @@ class BaseSession(abc.ABC):
             return str(round(value.timestamp()))
         if isinstance(value, Enum):
             return self.prepare_value(value.value, bot=bot, files=files)
-
+        if isinstance(value, TelegramObject):
+            return self.prepare_value(
+                value.model_dump(warnings=False),
+                bot=bot,
+                files=files,
+                _dumps_json=_dumps_json,
+            )
         if _dumps_json:
             return self.json_dumps(value)
         return value

--- a/tests/test_api/test_client/test_session/test_base_session.py
+++ b/tests/test_api/test_client/test_session/test_base_session.py
@@ -26,7 +26,7 @@ from aiogram.exceptions import (
     TelegramUnauthorizedError,
 )
 from aiogram.methods import DeleteMessage, GetMe, TelegramMethod
-from aiogram.types import UNSET_PARSE_MODE, User
+from aiogram.types import UNSET_PARSE_MODE, User, LinkPreviewOptions
 from aiogram.types.base import UNSET_DISABLE_WEB_PAGE_PREVIEW, UNSET_PROTECT_CONTENT
 from tests.mocked_bot import MockedBot
 
@@ -110,6 +110,10 @@ class TestBaseSession:
                     year=2017, month=5, day=17, hour=4, minute=11, second=42, tzinfo=utc
                 ),
                 "1494994302",
+            ],
+            [
+                {"link_preview": LinkPreviewOptions(is_disabled=True)},
+                '{"link_preview": {"is_disabled": true}}',
             ],
         ],
     )


### PR DESCRIPTION
# Description

Fixed JSON serialization of the `LinkPreviewOptions` class while it is passed
as bot-wide default options.
