### PR TITLE
Fixing tests and content types for Telegram Bot API 7.2 update

### DIFF
--- a/CHANGES/1453.bugfix.rst
+++ b/CHANGES/1453.bugfix.rst
@@ -1,0 +1,1 @@
+Fixing tests and content types for Telegram Bot API 7.2 update

--- a/aiogram/enums/content_type.py
+++ b/aiogram/enums/content_type.py
@@ -62,6 +62,7 @@ class ContentType(str, Enum):
     VIDEO_CHAT_PARTICIPANTS_INVITED = "video_chat_participants_invited"
     WEB_APP_DATA = "web_app_data"
     USER_SHARED = "user_shared"
+    SHARED_USER = "shared_user"
     BUSINESS_CONNECTION_ID = "business_connection_id"
     SENDER_BUSINESS_BOT = "sender_business_bot"
     IS_FROM_OFFLINE = "is_from_offline"

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
     from .text_quote import TextQuote
     from .user import User
     from .user_shared import UserShared
+    from .shared_user import SharedUser
     from .users_shared import UsersShared
     from .venue import Venue
     from .video import Video
@@ -238,6 +239,8 @@ class Message(MaybeInaccessibleMessage):
     """*Optional*. Message is an invoice for a `payment <https://core.telegram.org/bots/api#payments>`_, information about the invoice. `More about payments » <https://core.telegram.org/bots/api#payments>`_"""
     successful_payment: Optional[SuccessfulPayment] = None
     """*Optional*. Message is a service message about a successful payment, information about the payment. `More about payments » <https://core.telegram.org/bots/api#payments>`_"""
+    shared_user: Optional[SharedUser] = None
+    """*Optional*. A user that was shared with the bot"""
     users_shared: Optional[UsersShared] = None
     """*Optional*. Service message: users were shared with the bot"""
     chat_shared: Optional[ChatShared] = None
@@ -620,6 +623,8 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.USER_SHARED
         if self.chat_shared:
             return ContentType.CHAT_SHARED
+        if self.shared_user:
+            return ContentType.SHARED_USER
         if self.story:
             return ContentType.STORY
         if self.has_media_spoiler:
@@ -628,6 +633,12 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.WRITE_ACCESS_ALLOWED
         if self.boost_added:
             return ContentType.BOOST_ADDED
+        if self.business_connection_id:
+            return ContentType.BUSINESS_CONNECTION_ID
+        if self.is_from_offline:
+            return ContentType.IS_FROM_OFFLINE
+        if self.sender_business_bot:
+            return ContentType.SENDER_BUSINESS_BOT
 
         return ContentType.UNKNOWN
 

--- a/tests/test_api/test_methods/test_add_sticker_to_set.py
+++ b/tests/test_api/test_methods/test_add_sticker_to_set.py
@@ -1,3 +1,4 @@
+from aiogram.enums import StickerFormat
 from aiogram.methods import AddStickerToSet
 from aiogram.types import InputSticker
 from tests.mocked_bot import MockedBot
@@ -10,7 +11,7 @@ class TestAddStickerToSet:
         response: bool = await bot.add_sticker_to_set(
             user_id=42,
             name="test stickers pack",
-            sticker=InputSticker(sticker="file id", emoji_list=[":)"]),
+            sticker=InputSticker(sticker="file id", format=StickerFormat.STATIC, emoji_list=[":)"]),
         )
         request = bot.get_request()
         assert response == prepare_result.result

--- a/tests/test_api/test_methods/test_create_new_sticker_set.py
+++ b/tests/test_api/test_methods/test_create_new_sticker_set.py
@@ -13,8 +13,8 @@ class TestCreateNewStickerSet:
             name="name",
             title="title",
             stickers=[
-                InputSticker(sticker="file id", emoji_list=[":)"]),
-                InputSticker(sticker=FSInputFile("file.png"), emoji_list=["=("]),
+                InputSticker(sticker="file id", format=StickerFormat.STATIC, emoji_list=[":)"]),
+                InputSticker(sticker=FSInputFile("file.png"), format=StickerFormat.STATIC, emoji_list=["=("]),
             ],
             sticker_format=StickerFormat.STATIC,
         )

--- a/tests/test_api/test_methods/test_set_sticker_set_thumbnail.py
+++ b/tests/test_api/test_methods/test_set_sticker_set_thumbnail.py
@@ -1,3 +1,4 @@
+from aiogram.enums import StickerFormat
 from aiogram.methods import Request, SetStickerSetThumbnail
 from tests.mocked_bot import MockedBot
 
@@ -6,6 +7,6 @@ class TestSetStickerSetThumbnail:
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(SetStickerSetThumbnail, ok=True, result=None)
 
-        response: bool = await bot.set_sticker_set_thumbnail(name="test", user_id=42)
+        response: bool = await bot.set_sticker_set_thumbnail(name="test", format=StickerFormat.STATIC, user_id=42)
         request = bot.get_request()
         assert response == prepare_result.result

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -71,6 +71,7 @@ from aiogram.types import (
     PollOption,
     ProximityAlertTriggered,
     ReactionTypeCustomEmoji,
+    SharedUser,
     Sticker,
     Story,
     SuccessfulPayment,
@@ -462,6 +463,13 @@ TEST_MESSAGE_USER_SHARED = Message(
     from_user=User(id=42, is_bot=False, first_name="Test"),
     user_shared=UserShared(request_id=42, user_id=42),
 )
+TEST_MESSAGE_SHARED_USER = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=False, first_name="User"),
+    shared_user=SharedUser(request_id=42, user_id=1),
+)
 TEST_MESSAGE_USERS_SHARED = Message(
     message_id=42,
     date=datetime.datetime.now(),
@@ -469,7 +477,7 @@ TEST_MESSAGE_USERS_SHARED = Message(
     from_user=None,
     users_shared=UsersShared(
         request_id=0,
-        user_ids=[1, 2],
+        users=[SharedUser(user_id=1), SharedUser(user_id=2)],
     ),
 )
 TEST_CHAT_SHARED = Message(
@@ -562,6 +570,27 @@ TEST_MESSAGE_BOOST_ADDED = Message(
     from_user=User(id=42, is_bot=False, first_name="User"),
     boost_added=ChatBoostAdded(boost_count=1),
 )
+TEST_MESSAGE_BUSINESS_CONNECTION_ID = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=False, first_name="User"),
+    business_connection_id="idk"
+)
+TEST_MESSAGE_IS_FROM_OFFLINE = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=False, first_name="User"),
+    is_from_offline=True
+)
+TEST_MESSAGE_SENDER_BUSINESS_BOT = Message(
+    message_id=42,
+    date=datetime.datetime.now(),
+    chat=Chat(id=42, type="private"),
+    from_user=User(id=42, is_bot=True, first_name="Bot"),
+    sender_business_bot=User(id=42, is_bot=True, first_name="Bot")
+)
 TEST_MESSAGE_UNKNOWN = Message(
     message_id=42,
     date=datetime.datetime.now(),
@@ -620,6 +649,7 @@ MESSAGES_AND_CONTENT_TYPES = [
     [TEST_MESSAGE_USER_SHARED, ContentType.USER_SHARED],
     [TEST_MESSAGE_USERS_SHARED, ContentType.USERS_SHARED],
     [TEST_CHAT_SHARED, ContentType.CHAT_SHARED],
+    [TEST_MESSAGE_SHARED_USER, ContentType.SHARED_USER],
     [TEST_MESSAGE_STORY, ContentType.STORY],
     [TEST_MESSAGE_GIVEAWAY, ContentType.GIVEAWAY],
     [TEST_MESSAGE_GIVEAWAY_CREATED, ContentType.GIVEAWAY_CREATED],
@@ -630,6 +660,9 @@ MESSAGES_AND_CONTENT_TYPES = [
     [TEST_MESSAGE_GENERAL_FORUM_TOPIC_UNHIDDEN, ContentType.GENERAL_FORUM_TOPIC_UNHIDDEN],
     [TEST_MESSAGE_WRITE_ACCESS_ALLOWED, ContentType.WRITE_ACCESS_ALLOWED],
     [TEST_MESSAGE_BOOST_ADDED, ContentType.BOOST_ADDED],
+    [TEST_MESSAGE_BUSINESS_CONNECTION_ID, ContentType.BUSINESS_CONNECTION_ID],
+    [TEST_MESSAGE_IS_FROM_OFFLINE, ContentType.IS_FROM_OFFLINE],
+    [TEST_MESSAGE_SENDER_BUSINESS_BOT, ContentType.SENDER_BUSINESS_BOT],
     [TEST_MESSAGE_UNKNOWN, ContentType.UNKNOWN],
 ]
 
@@ -673,6 +706,7 @@ MESSAGES_AND_COPY_METHODS = [
     [TEST_MESSAGE_DICE, SendDice],
     [TEST_MESSAGE_USER_SHARED, None],
     [TEST_CHAT_SHARED, None],
+    [TEST_MESSAGE_SHARED_USER, None],
     [TEST_MESSAGE_GIVEAWAY_COMPLETED, None],
     [TEST_MESSAGE_HAS_MEDIA_SPOILER, None],
     [TEST_MESSAGE_WEB_APP_DATA, None],
@@ -689,6 +723,9 @@ MESSAGES_AND_COPY_METHODS = [
     [TEST_MESSAGE_GIVEAWAY, None],
     [TEST_MESSAGE_GIVEAWAY_WINNERS, None],
     [TEST_MESSAGE_BOOST_ADDED, None],
+    [TEST_MESSAGE_BUSINESS_CONNECTION_ID, None],
+    [TEST_MESSAGE_IS_FROM_OFFLINE, None],
+    [TEST_MESSAGE_SENDER_BUSINESS_BOT, None],
     [TEST_MESSAGE_UNKNOWN, None],
 ]
 


### PR DESCRIPTION
# Description

* Adding `SHARED_USER` in `ContentType` enum
* Adding tests for SharedUser, business_connection_id, is_from_offline, sender_business_bot

Fixes # (issue)
#1446

## Type of change

- [x] Bug fix (non-breaking* change which fixes an issue)
- [x] This change requires a documentation update

\* InputSticker now requires format as in [Telegram Bot API](https://core.telegram.org/bots/api#inputsticker)

# How Has This Been Tested?

- [x] Tested with [sticker-bot](https://github.com/RoLO0u/sticker-bot) project. It has instruction on how to start bot. Additionally, change aiogram from pip installed one to experimental.

**Test Configuration**:
* Operating System: Arch Linux x86_64
* Python version: 3.11.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
