### PR TITLE
Fix missing error logging

### DIFF
--- a/CHANGES/1458.bugfix.rst
+++ b/CHANGES/1458.bugfix.rst
@@ -1,0 +1,2 @@
+Added missing error handling to :code:`_background_feed_update` (when in :code:`handle_in_background=True` webhook mode)
+

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -186,7 +186,7 @@ class Dispatcher(Router):
         :param kwargs:
         """
         parsed_update = Update.model_validate(update, context={"bot": bot})
-        return await self.feed_update(bot=bot, update=parsed_update, **kwargs)
+        return await self._feed_webhook_update(bot=bot, update=parsed_update, **kwargs)
 
     @classmethod
     async def _listen_updates(


### PR DESCRIPTION
No error logging when handle_in_background=True

# Description

There were no error logging when in handle_in_background=True mode. I changed the call to the one used in synchronous handling mode

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
