### PR TITLE
Fixed display of regular expressions in documentation

### DIFF
--- a/docs/dispatcher/filters/command.rst
+++ b/docs/dispatcher/filters/command.rst
@@ -6,8 +6,8 @@ Usage
 =====
 
 1. Filter single variant of commands: :code:`Command("start")`
-2. Handle command by regexp pattern: :code:`Command(re.compile(r"item_(\d+)"))`
-3. Match command by multiple variants: :code:`Command("item", re.compile(r"item_(\d+)"))`
+2. Handle command by regexp pattern: :code:`Command(re.compile(r"item_(\\d+)"))`
+3. Match command by multiple variants: :code:`Command("item", re.compile(r"item_(\\d+)"))`
 4. Handle commands in public chats intended for other bots: :code:`Command("command", ignore_mention=True)`
 5. Use :class:`aiogram.types.bot_command.BotCommand` object as command reference :code:`Command(BotCommand(command="command", description="My awesome command")`
 


### PR DESCRIPTION
Fix rendition of the backslash in regular expressions

# Description

Regexp expressions were rendered incorrectly in docs.

## Type of change

Please delete options that are not relevant.

- [X] Documentation (typos, code examples or any documentation update)
