### PR TITLE
Handle loop is closed

### DIFF
--- a/CHANGES/1492.misc.rst
+++ b/CHANGES/1492.misc.rst
@@ -1,0 +1,1 @@
+Handle loop is closed in asgiref.sync.async_to_sync

--- a/aiogram/client/session/aiohttp.py
+++ b/aiogram/client/session/aiohttp.py
@@ -123,7 +123,7 @@ class AiohttpSession(BaseSession):
         if self._should_reset_connector:
             await self.close()
 
-        if self._session is None or self._session.closed:
+        if self._session is None or self._session.closed or self._session.loop.is_closed():
             self._session = ClientSession(
                 connector=self._connector_type(**self._connector_init),
                 headers={


### PR DESCRIPTION
# Description

Working with asgiref.sync.async_to_sync leads to telegram bot clients' closed event loop

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test Configuration:

Operating System: macOS
Python version: 3.12

Locally:
```
from asgiref.sync import async_to_sync
from aiogram import Bot



async_to_sync(Bot(TOKEN)).send_message(...). # ok
async_to_sync(Bot(TOKEN)).send_message(...). # error: Event loop is closed
```

**Test Configuration**:
* Operating System: Ventura 13.4.1
* Python version: 3.11

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
