### PR TITLE
Precalculate StateGroup values

### DIFF
--- a/CHANGES/1507.misc.rst
+++ b/CHANGES/1507.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of StatesGroup

--- a/aiogram/fsm/state.py
+++ b/aiogram/fsm/state.py
@@ -109,7 +109,7 @@ class StatesGroupMeta(type):
             return ".".join((cls.__parent__.__full_group_name__, cls.__name__))
         return cls.__name__
 
-    def __prepare_child(cls, child: Type["StatesGroup"]) -> Type["StatesGroup"]:
+    def _prepare_child(cls, child: Type["StatesGroup"]) -> Type["StatesGroup"]:
         """Prepare child.
 
         While adding `cls` for its children, we also need to recalculate

--- a/aiogram/fsm/state.py
+++ b/aiogram/fsm/state.py
@@ -87,14 +87,16 @@ class StatesGroupMeta(type):
             elif inspect.isclass(arg) and issubclass(arg, StatesGroup):
                 childs.append(arg)
                 arg.__parent__ = cls
-                arg.__update_all_values__()
+                arg.__all_states_names__ = arg.__get_all_states_names__()
 
         cls.__parent__ = None
         cls.__childs__ = tuple(childs)
         cls.__states__ = tuple(states)
         cls.__state_names__ = tuple(state.state for state in states)
 
-        cls.__update_all_values__()
+        cls.__all_childs__ = cls.__get_all_childs__()
+        cls.__all_states__ = cls.__get_all_states__()
+        cls.__all_states_names__ = cls.__get_all_states_names__()
         return cls
 
     @property
@@ -102,11 +104,6 @@ class StatesGroupMeta(type):
         if cls.__parent__:
             return ".".join((cls.__parent__.__full_group_name__, cls.__name__))
         return cls.__name__
-
-    def __update_all_values__(cls) -> None:
-        cls.__all_childs__ = cls.__get_all_childs__()
-        cls.__all_states__ = cls.__get_all_states__()
-        cls.__all_states_names__ = cls.__get_all_states_names__()
 
     def __get_all_childs__(cls) -> Tuple[Type["StatesGroup"], ...]:
         result = cls.__childs__


### PR DESCRIPTION
# Description

To prevent runtime calculating we should pre-calculate StateGroup values

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* Operating System: macOS
* Python version: 3.11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
