### PR TITLE
Telegram stars support

### DIFF
--- a/aiogram/bot/bot.py
+++ b/aiogram/bot/bot.py
@@ -3673,9 +3673,9 @@ class Bot(BaseBot, DataMixin, ContextInstanceMixin):
                            title: base.String,
                            description: base.String,
                            payload: base.String,
-                           provider_token: base.String,
                            currency: base.String,
                            prices: typing.List[types.LabeledPrice],
+                           provider_token: base.String = None,
                            max_tip_amount: typing.Optional[base.Integer] = None,
                            suggested_tip_amounts: typing.Optional[
                                typing.List[base.Integer]


### PR DESCRIPTION
# Description

Bot send_invoice method was changed because token_provider can be None when telegram stars are used as payment.
Soon this will be the only available payment method.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
