### PR TITLE
Fixed webhook Bot initialization to use default properties in updated…

### DIFF
--- a/aiogram/webhook/aiohttp_server.py
+++ b/aiogram/webhook/aiohttp_server.py
@@ -14,6 +14,7 @@ from aiogram.methods import TelegramMethod
 from aiogram.methods.base import TelegramType
 from aiogram.types import InputFile
 from aiogram.webhook.security import IPFilter
+from aiogram.client.default import DefaultBotProperties
 
 
 def setup_application(app: Application, dispatcher: Dispatcher, /, **kwargs: Any) -> None:
@@ -240,7 +241,7 @@ class TokenBasedRequestHandler(BaseRequestHandler):
         self,
         dispatcher: Dispatcher,
         handle_in_background: bool = True,
-        bot_settings: Optional[Dict[str, Any]] = None,
+        bot_settings: Optional[DefaultBotProperties] = None,
         **data: Any,
     ) -> None:
         """
@@ -291,5 +292,11 @@ class TokenBasedRequestHandler(BaseRequestHandler):
         """
         token = request.match_info["bot_token"]
         if token not in self.bots:
-            self.bots[token] = Bot(token=token, **self.bot_settings)
+            if not isinstance(self.bot_settings, DefaultBotProperties):
+                raise TypeError(
+                    "Passing `parse_mode`, `disable_web_page_preview` or `protect_content` "
+                    "to Bot initializer is not supported anymore. These arguments have been removed "
+                    f"in 3.7.0 version. Use `default=DefaultBotProperties(parse_mode=...)` argument instead."
+                )
+            self.bots[token] = Bot(token=token, default=self.bot_settings)
         return self.bots[token]


### PR DESCRIPTION
# Description

This PR updates the Bot initialization to comply with the changes introduced in aiogram version 3.7.0. The `parse_mode`, `disable_web_page_preview`, and `protect_content` arguments have been removed from the Bot initializer. Instead, the `default=DefaultBotProperties(parse_mode=<ParseMode.HTML: 'HTML'>)` argument is now used to set default properties.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual 
- [x] Verified that the bot initializes correctly with the new `DefaultBotProperties` argument.
- [x] Tested webhook handling to ensure it functions as expected with the updated aiogram version.

**Test Configuration**:
* Operating System: Ubuntu 22.04
* Python version: 3.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code