### PR TITLE
chore(docs): fix in `defaults.rst` change Bot parameter name to `default`.

### DIFF
--- a/docs/api/defaults.rst
+++ b/docs/api/defaults.rst
@@ -31,7 +31,7 @@ Here is an example of setting default parse mode for all requests to Telegram Bo
 
     bot = Bot(
         token=...,
-        defaults=DefaultBotProperties(
+        default=DefaultBotProperties(
             parse_mode=ParseMode.HTML,
         )
     )


### PR DESCRIPTION
Fix parameter name `default`.

# Description

The parameter name is `default` in bot.py instead of `defaults`.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
