### PR TITLE
fix: use default preview options for inline queries

### DIFF
--- a/CHANGES/1544.bugfix.rst
+++ b/CHANGES/1544.bugfix.rst
@@ -1,0 +1,1 @@
+Fix inline query handlers to use bot's default link preview options. Fixes #1543

--- a/aiogram/types/input_text_message_content.py
+++ b/aiogram/types/input_text_message_content.py
@@ -25,10 +25,12 @@ class InputTextMessageContent(InputMessageContent):
     """*Optional*. Mode for parsing entities in the message text. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     entities: Optional[List[MessageEntity]] = None
     """*Optional*. List of special entities that appear in message text, which can be specified instead of *parse_mode*"""
-    link_preview_options: Optional[LinkPreviewOptions] = None
+    link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+        "link_preview"
+    )
     """*Optional*. Link preview generation options for the message"""
     disable_web_page_preview: Optional[Union[bool, Default]] = Field(
-        Default("disable_web_page_preview"), json_schema_extra={"deprecated": True}
+        Default("link_preview_is_disabled"), json_schema_extra={"deprecated": True}
     )
     """*Optional*. Disables link previews for links in the sent message
 
@@ -45,9 +47,11 @@ class InputTextMessageContent(InputMessageContent):
             message_text: str,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             entities: Optional[List[MessageEntity]] = None,
-            link_preview_options: Optional[LinkPreviewOptions] = None,
+            link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+                "link_preview"
+            ),
             disable_web_page_preview: Optional[Union[bool, Default]] = Default(
-                "disable_web_page_preview"
+                "link_preview_is_disabled"
             ),
             **__pydantic_kwargs: Any,
         ) -> None:


### PR DESCRIPTION
Improve `link_preview_options` parameter in `InputTextMessageContent` class:
- Add default value `Default("link_preview")`
- Change default key from `disable_web_page_preview` to `link_preview_is_disabled` to match `DefaultBotProperties` definition

This allows inline query handlers to use bot's default link preview options.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #1543 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

```python
import asyncio

from aiogram import Bot, Dispatcher, types
from aiogram.client.default import DefaultBotProperties

bot = Bot(
    token="token",
    default=DefaultBotProperties(
        link_preview_is_disabled=True,
    ),
)

dp = Dispatcher()


@dp.inline_query()
async def inline_query_handler(inline_query: types.InlineQuery):
    await inline_query.answer(
        results=[
            types.InlineQueryResultArticle(
                id="1",
                title="hello",
                description="aiogram",
                input_message_content=types.InputTextMessageContent(
                    message_text="https://github.com/aiogram/aiogram",
                ),
            )
        ],
        cache_time=0,
    )


asyncio.run(dp.start_polling(bot))

```

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: macOS 14.5
* Python version: 3.11.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
