### PR TITLE
Fix web_app example

### DIFF
--- a/CHANGES/1538.misc.rst
+++ b/CHANGES/1538.misc.rst
@@ -1,3 +1,0 @@
-Added method :func:`aiogram.types.message.Message.as_reply_parameters`.
-Replaced usage of the argument :code:`reply_to_message_id` with :code:`reply_parameters`
-in all Message reply methods.

--- a/CHANGES/1538.misc.rst
+++ b/CHANGES/1538.misc.rst
@@ -1,0 +1,3 @@
+Added method :func:`aiogram.types.message.Message.as_reply_parameters`.
+Replaced usage of the argument :code:`reply_to_message_id` with :code:`reply_parameters`
+in all Message reply methods.

--- a/CHANGES/1546.bugfix.rst
+++ b/CHANGES/1546.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed URL path in the "Open" button at the "demo/sendMessage" endpoint in the web_app example.

--- a/examples/web_app/routes.py
+++ b/examples/web_app/routes.py
@@ -43,7 +43,7 @@ async def send_message_handler(request: Request):
                 [
                     InlineKeyboardButton(
                         text="Open",
-                        web_app=WebAppInfo(url=str(request.url.with_scheme("https"))),
+                        web_app=WebAppInfo(url=str(request.url.with_scheme("https").with_path("demo"))),
                     )
                 ]
             ]


### PR DESCRIPTION
# Description

Fixed URL path in the "Open" button at the "demo/sendMessage" endpoint in the web_app example. 
The button should open the web application, but at the moment it sends a GET request to the current endpoint (which only accepts POST requests).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
