### PR TITLE
Fixed link preview options to use global defaults in some types and methods

### DIFF
--- a/.butcher/types/ExternalReplyInfo/default.yml
+++ b/.butcher/types/ExternalReplyInfo/default.yml
@@ -1,3 +1,2 @@
 disable_web_page_preview: link_preview_is_disabled
-link_preview_options: link_preview
 parse_mode: parse_mode

--- a/.butcher/types/InputTextMessageContent/default.yml
+++ b/.butcher/types/InputTextMessageContent/default.yml
@@ -1,2 +1,2 @@
-disable_web_page_preview: disable_web_page_preview
+link_preview_options: link_preview
 parse_mode: parse_mode

--- a/CHANGES/1543.bugfix.rst
+++ b/CHANGES/1543.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed link preview options to use global defaults in various types and methods
+to use global defaults for `link_preview_options`.
+This change ensures consistency and enhances flexibility in handling link preview options
+across different components.

--- a/aiogram/client/bot.py
+++ b/aiogram/client/bot.py
@@ -1526,7 +1526,9 @@ class Bot:
         inline_message_id: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         entities: Optional[List[MessageEntity]] = None,
-        link_preview_options: Optional[LinkPreviewOptions] = None,
+        link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+            "link_preview"
+        ),
         reply_markup: Optional[InlineKeyboardMarkup] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"

--- a/aiogram/methods/edit_message_text.py
+++ b/aiogram/methods/edit_message_text.py
@@ -39,7 +39,7 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
     """Mode for parsing entities in the message text. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     entities: Optional[List[MessageEntity]] = None
     """A JSON-serialized list of special entities that appear in message text, which can be specified instead of *parse_mode*"""
-    link_preview_options: Optional[LinkPreviewOptions] = None
+    link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default("link_preview")
     """Link preview generation options for the message"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_."""
@@ -65,7 +65,9 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
             inline_message_id: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             entities: Optional[List[MessageEntity]] = None,
-            link_preview_options: Optional[LinkPreviewOptions] = None,
+            link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+                "link_preview"
+            ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
             disable_web_page_preview: Optional[Union[bool, Default]] = Default(
                 "link_preview_is_disabled"

--- a/aiogram/types/input_text_message_content.py
+++ b/aiogram/types/input_text_message_content.py
@@ -25,11 +25,9 @@ class InputTextMessageContent(InputMessageContent):
     """*Optional*. Mode for parsing entities in the message text. See `formatting options <https://core.telegram.org/bots/api#formatting-options>`_ for more details."""
     entities: Optional[List[MessageEntity]] = None
     """*Optional*. List of special entities that appear in message text, which can be specified instead of *parse_mode*"""
-    link_preview_options: Optional[LinkPreviewOptions] = None
+    link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default("link_preview")
     """*Optional*. Link preview generation options for the message"""
-    disable_web_page_preview: Optional[Union[bool, Default]] = Field(
-        Default("disable_web_page_preview"), json_schema_extra={"deprecated": True}
-    )
+    disable_web_page_preview: Optional[bool] = Field(None, json_schema_extra={"deprecated": True})
     """*Optional*. Disables link previews for links in the sent message
 
 .. deprecated:: API:7.0
@@ -45,10 +43,10 @@ class InputTextMessageContent(InputMessageContent):
             message_text: str,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             entities: Optional[List[MessageEntity]] = None,
-            link_preview_options: Optional[LinkPreviewOptions] = None,
-            disable_web_page_preview: Optional[Union[bool, Default]] = Default(
-                "disable_web_page_preview"
+            link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+                "link_preview"
             ),
+            disable_web_page_preview: Optional[bool] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -3524,7 +3524,9 @@ class Message(MaybeInaccessibleMessage):
         inline_message_id: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         entities: Optional[List[MessageEntity]] = None,
-        link_preview_options: Optional[LinkPreviewOptions] = None,
+        link_preview_options: Optional[Union[LinkPreviewOptions, Default]] = Default(
+            "link_preview"
+        ),
         reply_markup: Optional[InlineKeyboardMarkup] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"


### PR DESCRIPTION
Fixed link preview options to use global defaults in various types and methods to use global defaults for `link_preview_options`.
This change ensures consistency and enhances flexibility in handling link preview options across different components.

Fixes #1543 