### PR TITLE
Fix readable BufferedInputFile and add support BufferedIOBase

### DIFF
--- a/CHANGES/1564.misc.rst
+++ b/CHANGES/1564.misc.rst
@@ -1,0 +1,5 @@
+Fixed unsafe file reading in BufferedInputFile.from_file and 
+added support for initializing BufferedInputFile from BytesIO and 
+other bytes buffers. 
+This change improves safety and extends flexibility in handling 
+different byte sources when working with buffered input files.


### PR DESCRIPTION
# Description

- Fixed not safe read file of method BufferedInputFile.from_file.
- Added support initialization BufferedInputFile from BytesIO or other bytes buffer's.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test by unit tests

**Test Configuration**:
* Operating System: Win-11 x64
* Python version: 3.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
