### PR TITLE
Remove duped PyPI section in install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,13 +2,6 @@
 Installation
 ############
 
-From Arch Linux Repository
---------------------------
-
-.. code-block:: bash
-
-    pacman -S python-aiogram
-
 Development build (3.x)
 =======================
 
@@ -25,3 +18,14 @@ From GitHub
 .. code-block:: bash
 
     pip install https://github.com/aiogram/aiogram/archive/refs/heads/dev-3.x.zip
+
+Stable build (2.x)
+=======================
+
+From Arch Linux Repository
+--------------------------
+
+.. code-block:: bash
+
+    pacman -S python-aiogram
+

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,13 +2,6 @@
 Installation
 ############
 
-From PyPI
----------
-
-.. code-block:: bash
-
-    pip install -U aiogram
-
 From Arch Linux Repository
 --------------------------
 


### PR DESCRIPTION
It's there twice.

https://docs.aiogram.dev/en/dev-3.x/install.html#id1