### PR TITLE
Bump aiofiles version upper bound to <24.2

### DIFF
--- a/CHANGES/1577.feature.rst
+++ b/CHANGES/1577.feature.rst
@@ -1,0 +1,1 @@
+Bump aiofiles version upper bound to <24.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.11",
     "pydantic>=2.4.1,<2.10",
-    "aiofiles~=23.2.1",
+    "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",
 ]


### PR DESCRIPTION
I think the upper bound can be removed altogether, since aiogram only uses aiofiles.open, which is unlikely to ever be changed. Let me know what you think is best.