### PR TITLE
#1579 Fixed `Default` object annotation resolution in `pydantic` models.

### DIFF
--- a/CHANGES/1579.bugfix.rst
+++ b/CHANGES/1579.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `Default` object annotation resolution using `pydantic`

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -162,6 +162,7 @@ from .paid_media import PaidMedia
 from .paid_media_info import PaidMediaInfo
 from .paid_media_photo import PaidMediaPhoto
 from .paid_media_preview import PaidMediaPreview
+from .paid_media_purchased import PaidMediaPurchased
 from .paid_media_video import PaidMediaVideo
 from .passport_data import PassportData
 from .passport_element_error import PassportElementError
@@ -233,7 +234,6 @@ from .web_app_data import WebAppData
 from .web_app_info import WebAppInfo
 from .webhook_info import WebhookInfo
 from .write_access_allowed import WriteAccessAllowed
-from .paid_media_purchased import PaidMediaPurchased
 
 __all__ = (
     "Animation",
@@ -473,6 +473,8 @@ __all__ = (
     "WriteAccessAllowed",
 )
 
+from ..client.default import Default as _Default
+
 # Load typing forward refs for every TelegramObject
 for _entity_name in __all__:
     _entity = globals()[_entity_name]
@@ -484,6 +486,7 @@ for _entity_name in __all__:
             "Optional": Optional,
             "Union": Union,
             "Literal": Literal,
+            "Default": _Default,
             **{k: v for k, v in globals().items() if k in __all__},
         }
     )

--- a/aiogram/types/update.py
+++ b/aiogram/types/update.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, cast
 
-from .base import TelegramObject
 from ..utils.mypy_hacks import lru_cache
+from .base import TelegramObject
 
 if TYPE_CHECKING:
     from .business_connection import BusinessConnection
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
     from .message import Message
     from .message_reaction_count_updated import MessageReactionCountUpdated
     from .message_reaction_updated import MessageReactionUpdated
+    from .paid_media_purchased import PaidMediaPurchased
     from .poll import Poll
     from .poll_answer import PollAnswer
     from .pre_checkout_query import PreCheckoutQuery
     from .shipping_query import ShippingQuery
-    from .paid_media_purchased import PaidMediaPurchased
 
 
 class Update(TelegramObject):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.11",
-    "pydantic>=2.4.1,<2.9; python_version < '3.10'",
-    "pydantic>=2.4.1,<2.10; python_version >= '3.10'",
+    "pydantic>=2.4.1,<2.9; python_version < '3.9'",  # v2.10 breaks compatibility with Python 3.8 without any reason
+    "pydantic>=2.4.1,<2.10; python_version >= '3.9'",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.11",
-    "pydantic>=2.4.1,<2.10",
+    "pydantic>=2.4.1,<2.9; python_version < '3.10'",
+    "pydantic>=2.4.1,<2.10; python_version >= '3.10'",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.11",
-    "pydantic>=2.4.1,<2.9; python_version < '3.9'",  # v2.10 breaks compatibility with Python 3.8 without any reason
+    "pydantic>=2.4.1,<2.9; python_version < '3.9'",  # v2.9 breaks compatibility with Python 3.8 without any reason
     "pydantic>=2.4.1,<2.10; python_version >= '3.9'",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ fast = [
     "aiodns>=3.0.0",
 ]
 redis = [
-    "redis[hiredis]~=5.0.1",
+    "redis[hiredis]>=5.0.1,<5.1.0",
 ]
 mongo = [
-    "motor~=3.3.2",
+    "motor>=3.3.2,<3.7.0",
 ]
 proxy = [
     "aiohttp-socks~=0.8.3",

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -32,6 +32,7 @@ from aiogram.types import (
     Message,
     MessageReactionCountUpdated,
     MessageReactionUpdated,
+    PaidMediaPurchased,
     Poll,
     PollAnswer,
     PollOption,
@@ -42,7 +43,6 @@ from aiogram.types import (
     ShippingQuery,
     Update,
     User,
-    PaidMediaPurchased,
 )
 from aiogram.types.error_event import ErrorEvent
 from tests.mocked_bot import MockedBot


### PR DESCRIPTION
Fixed `Default` object annotation resolution in `pydantic` models.

Reformat code.


Fixes: #1579