### PR TITLE
Fix pytest-asyncio deprecation warning in test

### DIFF
--- a/CHANGES/1584.bugfix.rst
+++ b/CHANGES/1584.bugfix.rst
@@ -1,0 +1,1 @@
+Fix PytestDeprecationWarning thrown by pytest-asyncio when running the tests

--- a/tests/test_utils/test_chat_action.py
+++ b/tests/test_utils/test_chat_action.py
@@ -13,9 +13,10 @@ from tests.mocked_bot import MockedBot
 
 
 class TestChatActionSender:
-    async def test_wait(self, bot: Bot, event_loop: asyncio.BaseEventLoop):
+    async def test_wait(self, bot: Bot):
         sender = ChatActionSender.typing(bot=bot, chat_id=42)
-        event_loop.call_soon(sender._close_event.set)
+        loop = asyncio.get_running_loop()
+        loop.call_soon(sender._close_event.set)
         start = time.monotonic()
         await sender._wait(1)
         assert time.monotonic() - start < 1


### PR DESCRIPTION
Hey :wave: Arch Linux maintainer here.

This fixes a `PytestDeprecationWarning` thrown when running the tests. This warning was introduced in pytest-asyncio in https://github.com/pytest-dev/pytest-asyncio/pull/648.
