### PR TITLE
Don't use KeyboardBuilder directly

### DIFF
--- a/aiogram/utils/keyboard.py
+++ b/aiogram/utils/keyboard.py
@@ -152,7 +152,7 @@ class KeyboardBuilder(Generic[ButtonType], ABC):
 
         .. code-block:: python
 
-            >>> builder = KeyboardBuilder(button_type=InlineKeyboardButton)
+            >>> builder = InlineKeyboardBuilder(button_type=InlineKeyboardButton)
             >>> ... # Add buttons to builder
             >>> markup = InlineKeyboardMarkup(inline_keyboard=builder.export())
 


### PR DESCRIPTION
As discussed in issue #1595 KeyboardBuilder should not be used directly. Instead InlineKeyboardBuilder or ReplyKeyboardBuilder should be used. This fix makes sure that the documentation rendered does not include a "wrong example".

# Description

Make the example a developer best practise.
 
Fixes #1595 

## Type of change

Please delete options that are not relevant.

- [X] Documentation (typos, code examples or any documentation update)
- [X] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
