### PR TITLE
Add missing closing bold tag in the docs

### DIFF
--- a/CHANGES/1599.doc.rst
+++ b/CHANGES/1599.doc.rst
@@ -1,0 +1,1 @@
+Add missing closing tag for bold.

--- a/docs/utils/formatting.rst
+++ b/docs/utils/formatting.rst
@@ -28,7 +28,7 @@ Is the same as the next example, but without usage markup
 .. code-block:: python
 
     await message.answer(
-        text=f"Hello, <b>{html.quote(message.from_user.full_name)}!",
+        text=f"Hello, <b>{html.quote(message.from_user.full_name)}</b>!",
         parse_mode=ParseMode.HTML
     )
 


### PR DESCRIPTION
# Description

Add missing closing tag for bold

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
