### PR TITLE
Fixed UUID (and other types) serialization in the CallbackData factory.

### DIFF
--- a/CHANGES/1602.bugfix.rst
+++ b/CHANGES/1602.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed customized serialization in the :class:`aiogram.filters.callback_data.CallbackData` factory.
+
+From now UUID will have 32 bytes length instead of 36 bytes (with no `-` separators) in the callback data representation.

--- a/aiogram/filters/callback_data.py
+++ b/aiogram/filters/callback_data.py
@@ -94,7 +94,7 @@ class CallbackData(BaseModel):
         :return: valid callback data for Telegram Bot API
         """
         result = [self.__prefix__]
-        for key, value in self.model_dump(mode="json").items():
+        for key, value in self.model_dump(mode="python").items():
             encoded = self._encode_value(key, value)
             if self.__separator__ in encoded:
                 raise ValueError(

--- a/tests/test_filters/test_callback_data.py
+++ b/tests/test_filters/test_callback_data.py
@@ -92,6 +92,18 @@ class TestCallbackData:
 
         assert MyCallback(foo="test", bar=42).pack() == "test:test:42"
 
+    def test_pack_uuid(self):
+        class MyCallbackWithUUID(CallbackData, prefix="test"):
+            foo: str
+            bar: UUID
+
+        callback = MyCallbackWithUUID(
+            foo="test",
+            bar=UUID("123e4567-e89b-12d3-a456-426655440000"),
+        )
+
+        assert callback.pack() == "test:test:123e4567e89b12d3a456426655440000"
+
     def test_pack_optional(self):
         class MyCallback1(CallbackData, prefix="test1"):
             foo: str


### PR DESCRIPTION
From now UUID will have 32 bytes length instead of 36 bytes.