### PR TITLE
misc(deps): Bump pydantic version to <2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.11",
-    "pydantic>=2.4.1,<2.10",
+    "pydantic>=2.4.1,<2.11",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",


### PR DESCRIPTION
# Description

Added support for pydantic 2.10
Pydantic release notes: https://docs.pydantic.dev/latest/changelog/

Fixes # (issue)

Added support for pydantic 2.10

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I runned `pytest tests` with updated pyproject.toml. Results: `1528 passed, 26 skipped in 17.37s`. Before run tests i reinstalled aiogram from `.` and upgrade pydantic to the latest version. Tests passed


**Test Configuration**:
* Operating System: Windows 11, 23H2
* Python version: 3.13.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
