### PR TITLE
[misc] fix tg-emoji closing tag: use constant

### DIFF
--- a/CHANGES/1608.misc.rst
+++ b/CHANGES/1608.misc.rst
@@ -1,0 +1,1 @@
+fix closing tag for tg-emoji: use the same constant as for tag opening

--- a/CHANGES/1608.misc.rst
+++ b/CHANGES/1608.misc.rst
@@ -1,1 +1,1 @@
-fix closing tag for tg-emoji: use the same constant as for tag opening
+Fixed closing tag for :code:`tg-emoji` in the :class:`aiogram.utils.text_decoration.HtmlDecoration`: use the same constant as for tag opening

--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -218,7 +218,7 @@ class HtmlDecoration(TextDecoration):
         return html.escape(value, quote=False)
 
     def custom_emoji(self, value: str, custom_emoji_id: str) -> str:
-        return f'<{self.EMOJI_TAG} emoji-id="{custom_emoji_id}">{value}</tg-emoji>'
+        return f'<{self.EMOJI_TAG} emoji-id="{custom_emoji_id}">{value}</{self.EMOJI_TAG}>'
 
     def blockquote(self, value: str) -> str:
         return f"<{self.BLOCKQUOTE_TAG}>{value}</{self.BLOCKQUOTE_TAG}>"


### PR DESCRIPTION
# Description

Reuse constant for the `tg-emoji` closing tag