### PR TITLE
Add blockquotes to text decorations

### DIFF
--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -138,6 +138,10 @@ class TextDecoration(ABC):
         pass
 
     @abstractmethod
+    def underline(self, value: str) -> str:  # pragma: no cover
+        pass
+
+    @abstractmethod
     def strikethrough(self, value: str) -> str:  # pragma: no cover
         pass
 
@@ -145,6 +149,10 @@ class TextDecoration(ABC):
     def quote(self, value: str) -> str:  # pragma: no cover
         pass
 
+    @abstractmethod
+    def blockquote(self, value: str) -> str: #pragma: no cover
+        return f"<blockquote>{value}</blockquote>"
+    
     @abstractmethod
     def custom_emoji(self, value: str, custom_emoji_id: str) -> str:  # pragma: no cover
         pass
@@ -177,6 +185,9 @@ class HtmlDecoration(TextDecoration):
 
     def strikethrough(self, value: str) -> str:
         return f"<s>{value}</s>"
+
+    def blockquote(self, value: str) -> str:
+        return f"<blockquote>{value}</blockquote>"
 
     def quote(self, value: str) -> str:
         return html.escape(value, quote=False)
@@ -215,6 +226,9 @@ class MarkdownDecoration(TextDecoration):
     def strikethrough(self, value: str) -> str:
         return f"~{value}~"
 
+    def blockquote(self, value: str) -> str:
+        return f">{value}"
+    
     def quote(self, value: str) -> str:
         return re.sub(pattern=self.MARKDOWN_QUOTE_PATTERN, repl=r"\\\1", string=value)
 

--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -150,8 +150,8 @@ class TextDecoration(ABC):
         pass
 
     @abstractmethod
-    def blockquote(self, value: str) -> str: #pragma: no cover
-        return f"<blockquote>{value}</blockquote>"
+    def blockquote(self, value: str) -> str: # pragma: no cover
+        pass
     
     @abstractmethod
     def custom_emoji(self, value: str, custom_emoji_id: str) -> str:  # pragma: no cover


### PR DESCRIPTION
# Description

I just added the blockquotes to text decorations, it will be useful for the legacy users, that want to use this feature (e.g, while editing).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
