### PR TITLE
Increased aiohttp version

### DIFF
--- a/CHANGES/1615.misc.rst
+++ b/CHANGES/1615.misc.rst
@@ -1,1 +1,1 @@
-Increased aiohttp upper limit
+Increased max :code:`aiohttp` version support from “<3.11” to “<3.12”

--- a/CHANGES/1615.misc.rst
+++ b/CHANGES/1615.misc.rst
@@ -1,0 +1,1 @@
+Increased aiohttp upper limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
-    "aiohttp>=3.9.0,<3.11",
+    "aiohttp>=3.9.0,<3.12",
     "pydantic>=2.4.1,<2.11",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",


### PR DESCRIPTION
# Description

The aiohttp version in the project is outdated and has a number of vulnerabilities.
When installing additional libraries into a project, conflicts arise that cannot be resolved while the aiohttp version is limited to <3.11

Fixes #1614

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`pytest test`

**Test Configuration**:
* Operating System: MacOs
* Python version: 3.12.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
