### PR TITLE
Fix link formatting

### DIFF
--- a/docs/locale/uk_UA/LC_MESSAGES/migration_2_to_3.po
+++ b/docs/locale/uk_UA/LC_MESSAGES/migration_2_to_3.po
@@ -230,11 +230,11 @@ msgstr ""
 #: ../../migration_2_to_3.rst:71
 msgid ""
 "All API methods are now classes with validation, implemented via "
-"`pydantic <https://docs.pydantic.dev/>`. These API calls are also "
+"`pydantic <https://docs.pydantic.dev/>`_. These API calls are also "
 "available as methods in the Bot class."
 msgstr ""
 "Всі методи API тепер є класами з валідацією, реалізованими через "
-"`pydantic <https://docs.pydantic.dev/>`. Ці виклики API також доступні як"
+"`pydantic <https://docs.pydantic.dev/>`_. Ці виклики API також доступні як"
 " методи в класі Bot."
 
 #: ../../migration_2_to_3.rst:74

--- a/docs/migration_2_to_3.rst
+++ b/docs/migration_2_to_3.rst
@@ -83,7 +83,7 @@ Bot API
 =======
 
 - All API methods are now classes with validation, implemented via
-  `pydantic <https://docs.pydantic.dev/>`.
+  `pydantic <https://docs.pydantic.dev/>`_.
   These API calls are also available as methods in the Bot class.
 - More pre-defined Enums have been added and moved to the `aiogram.enums` sub-package.
   For example, the chat type enum is now :class:`aiogram.enums.ChatType` instead of :class:`aiogram.types.chat.ChatType`.


### PR DESCRIPTION
# Description

Fix link formatting for pydantic in migration docs (migration_2_to_3.po and migration_2_to_3.rst)

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)