### PR TITLE
Fix `BAD_PATTERN` regex in deeplinking process.

### DIFF
--- a/CHANGES/1630.bugfix.rst
+++ b/CHANGES/1630.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the regex pattern that finds the "bad characters" for deeplink payload.

--- a/aiogram/utils/deep_linking.py
+++ b/aiogram/utils/deep_linking.py
@@ -18,7 +18,7 @@ from aiogram.utils.payload import decode_payload, encode_payload
 if TYPE_CHECKING:
     from aiogram import Bot
 
-BAD_PATTERN = re.compile(r"[^A-z0-9-]")
+BAD_PATTERN = re.compile(r"[^a-zA-Z0-9-_]")
 
 
 async def create_start_link(

--- a/tests/test_utils/test_deep_linking.py
+++ b/tests/test_utils/test_deep_linking.py
@@ -10,12 +10,14 @@ PAYLOADS = [
     "aaBBccDDeeFF5544332211",
     -12345678901234567890,
     12345678901234567890,
+    "underscore_and-dash",
 ]
 WRONG_PAYLOADS = [
     "@BotFather",
     "Some:special$characters#=",
     "spaces spaces spaces",
     1234567890123456789.0,
+    "has`backtick",
 ]
 
 


### PR DESCRIPTION
# Description

The regex pattern which identifies the "bad characters" for [deeplink payload](https://core.telegram.org/bots/features#deep-linking) is not correct:

```python
import re

print(f"{ord('A')=}")
print(f"{ord('Z')=}")
print(f"{ord('a')=}")
print(f"{ord('z')=}")
print("-----------------------------------")
for i in range(91, 97):
    print(f"{i}: {chr(i)}")
print("-----------------------------------")
print(re.search(r"[^A-z0-9-]", "hi`bye"))      # None
print(re.search(r"[^A-Za-z0-9-_]", "hi`bye"))  # <re.Match object; span=(2, 3), match='`'>
```
There is a gap between `Z` and `a`. We should explicitly include the ranges `A-Z` and `a-z` to avoid accepting characters like backtick.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I modified the `WRONG_PAYLOADS` list in `tests/test_utils/test_deep_linking.py` to demonstrate the bug.

**Test Configuration**:
* Operating System: MacOS
* Python version: 3.12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
