### PR TITLE
Added support of "startapp" deep links

### DIFF
--- a/CHANGES/1648.feature.rst
+++ b/CHANGES/1648.feature.rst
@@ -1,0 +1,2 @@
+Added new method to utils/deep_linking.py module to creating "startapp" deep links, see also 
+https://core.telegram.org/api/links#main-mini-app-links

--- a/aiogram/utils/deep_linking.py
+++ b/aiogram/utils/deep_linking.py
@@ -24,6 +24,7 @@ BAD_PATTERN = re.compile(r"[^a-zA-Z0-9-_]")
 async def create_start_link(
     bot: Bot,
     payload: str,
+    link_type: Literal["start", "startgroup", "startapp"],
     encode: bool = False,
     encoder: Optional[Callable[[bytes], bytes]] = None,
 ) -> str:
@@ -35,6 +36,7 @@ async def create_start_link(
 
     :param bot: bot instance
     :param payload: args passed with /start
+    :param link_type: name of query arg
     :param encode: encode payload with base64url or custom encoder
     :param encoder: custom encoder callable
     :return: link
@@ -42,7 +44,7 @@ async def create_start_link(
     username = (await bot.me()).username
     return create_deep_link(
         username=cast(str, username),
-        link_type="start",
+        link_type=link_type,
         payload=payload,
         encode=encode,
         encoder=encoder,
@@ -79,7 +81,7 @@ async def create_startgroup_link(
 
 def create_deep_link(
     username: str,
-    link_type: Literal["start", "startgroup"],
+    link_type: Literal["start", "startgroup", "startapp"],
     payload: str,
     encode: bool = False,
     encoder: Optional[Callable[[bytes], bytes]] = None,

--- a/aiogram/utils/deep_linking.py
+++ b/aiogram/utils/deep_linking.py
@@ -85,17 +85,17 @@ async def create_startapp_link(
     encoder: Optional[Callable[[bytes], bytes]] = None,
 ) -> str:
     """
-        Create 'startapp' deep link with your payload.
+    Create 'startapp' deep link with your payload.
 
-        If you need to encode payload or pass special characters -
-            set encode as True
+    If you need to encode payload or pass special characters -
+        set encode as True
 
-        :param bot: bot instance
-        :param payload: args passed with /start
-        :param encode: encode payload with base64url or custom encoder
-        :param encoder: custom encoder callable
-        :return: link
-        """
+    :param bot: bot instance
+    :param payload: args passed with /start
+    :param encode: encode payload with base64url or custom encoder
+    :param encoder: custom encoder callable
+    :return: link
+    """
     username = (await bot.me()).username
     return create_deep_link(
         username=cast(str, username),

--- a/aiogram/utils/deep_linking.py
+++ b/aiogram/utils/deep_linking.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = [
     "create_start_link",
     "create_startgroup_link",
+    "create_startapp_link",
     "create_deep_link",
     "create_telegram_link",
     "encode_payload",
@@ -24,7 +25,6 @@ BAD_PATTERN = re.compile(r"[^a-zA-Z0-9-_]")
 async def create_start_link(
     bot: Bot,
     payload: str,
-    link_type: Literal["start", "startgroup", "startapp"],
     encode: bool = False,
     encoder: Optional[Callable[[bytes], bytes]] = None,
 ) -> str:
@@ -36,7 +36,6 @@ async def create_start_link(
 
     :param bot: bot instance
     :param payload: args passed with /start
-    :param link_type: name of query arg
     :param encode: encode payload with base64url or custom encoder
     :param encoder: custom encoder callable
     :return: link
@@ -44,7 +43,7 @@ async def create_start_link(
     username = (await bot.me()).username
     return create_deep_link(
         username=cast(str, username),
-        link_type=link_type,
+        link_type="start",
         payload=payload,
         encode=encode,
         encoder=encoder,
@@ -73,6 +72,34 @@ async def create_startgroup_link(
     return create_deep_link(
         username=cast(str, username),
         link_type="startgroup",
+        payload=payload,
+        encode=encode,
+        encoder=encoder,
+    )
+
+
+async def create_startapp_link(
+    bot: Bot,
+    payload: str,
+    encode: bool = False,
+    encoder: Optional[Callable[[bytes], bytes]] = None,
+) -> str:
+    """
+        Create 'startapp' deep link with your payload.
+
+        If you need to encode payload or pass special characters -
+            set encode as True
+
+        :param bot: bot instance
+        :param payload: args passed with /start
+        :param encode: encode payload with base64url or custom encoder
+        :param encoder: custom encoder callable
+        :return: link
+        """
+    username = (await bot.me()).username
+    return create_deep_link(
+        username=cast(str, username),
+        link_type="startapp",
         payload=payload,
         encode=encode,
         encoder=encoder,

--- a/tests/test_utils/test_deep_linking.py
+++ b/tests/test_utils/test_deep_linking.py
@@ -1,6 +1,7 @@
 import pytest
 
-from aiogram.utils.deep_linking import create_start_link, create_startgroup_link
+from aiogram.utils.deep_linking import create_start_link, create_startgroup_link, \
+    create_startapp_link
 from aiogram.utils.payload import decode_payload, encode_payload
 from tests.mocked_bot import MockedBot
 
@@ -44,6 +45,10 @@ class TestDeepLinking:
         link = await create_startgroup_link(bot, payload)
         assert link == f"https://t.me/tbot?startgroup={payload}"
 
+    async def test_get_startapp_link(self, bot: MockedBot, payload: str):
+        link = await create_startapp_link(bot, payload)
+        assert link == f"https://t.me/tbot?startapp={payload}"
+
     async def test_filter_encode_and_decode(self, payload: str):
         encoded = encode_payload(payload)
         decoded = decode_payload(encoded)
@@ -84,6 +89,15 @@ class TestDeepLinking:
         encoded_payload = encode_payload(wrong_payload)
 
         assert link == f"https://t.me/tbot?start={encoded_payload}"
+
+    async def test_get_startapp_link_with_encoding(self, bot: MockedBot, wrong_payload: str):
+        # define link
+        link = await create_startapp_link(bot, wrong_payload, encode=True)
+
+        # define reference link
+        encoded_payload = encode_payload(wrong_payload)
+
+        assert link == f"https://t.me/tbot?startapp={encoded_payload}"
 
     async def test_64_len_payload(self, bot: MockedBot):
         payload = "p" * 64

--- a/tests/test_utils/test_deep_linking.py
+++ b/tests/test_utils/test_deep_linking.py
@@ -1,7 +1,10 @@
 import pytest
 
-from aiogram.utils.deep_linking import create_start_link, create_startgroup_link, \
-    create_startapp_link
+from aiogram.utils.deep_linking import (
+    create_start_link,
+    create_startapp_link,
+    create_startgroup_link,
+)
 from aiogram.utils.payload import decode_payload, encode_payload
 from tests.mocked_bot import MockedBot
 


### PR DESCRIPTION
# Description

Added support [deep links to open Mini Apps](https://core.telegram.org/api/links#main-mini-app-links) 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```python
from aiogram.utils.deep_linking import create_startapp_link

link = await create_startapp_link(bot, 'foo')
# result: 'https://t.me/MyBot?startapp=foo'
```

**Test Configuration**:
* Operating System: Mac OS Sequoia 15.3.1
* Python version: 3.11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
