### PR TITLE
Refactor: Introduce Union types for streamlined type handling

### DIFF
--- a/CHANGES/1592.misc.rst
+++ b/CHANGES/1592.misc.rst
@@ -1,0 +1,5 @@
+Introduce Union types for streamlined type handling.
+
+Implemented Union types across various modules to consolidate and simplify type annotations.
+This change replaces repetitive union declarations with reusable Union aliases,
+improving code readability and maintainability.

--- a/aiogram/client/bot.py
+++ b/aiogram/client/bot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import io
 import pathlib
 from contextlib import asynccontextmanager
@@ -168,6 +167,7 @@ from ..types import (
     BusinessConnection,
     ChatAdministratorRights,
     ChatFullInfo,
+    ChatIdUnion,
     ChatInviteLink,
     ChatMemberAdministrator,
     ChatMemberBanned,
@@ -176,9 +176,9 @@ from ..types import (
     ChatMemberOwner,
     ChatMemberRestricted,
     ChatPermissions,
+    DateTimeUnion,
     Downloadable,
     File,
-    ForceReply,
     ForumTopic,
     GameHighScore,
     Gifts,
@@ -186,17 +186,15 @@ from ..types import (
     InlineQueryResultsButton,
     InlineQueryResultUnion,
     InputFile,
-    InputMediaAudio,
-    InputMediaDocument,
-    InputMediaPhoto,
+    InputFileUnion,
     InputMediaUnion,
-    InputMediaVideo,
     InputPaidMediaUnion,
-    InputPollOption,
+    InputPollOptionUnion,
     InputSticker,
     LabeledPrice,
     LinkPreviewOptions,
     MaskPosition,
+    MediaUnion,
     MenuButtonCommands,
     MenuButtonDefault,
     MenuButtonUnion,
@@ -208,8 +206,7 @@ from ..types import (
     Poll,
     PreparedInlineMessage,
     ReactionTypeUnion,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
     SentWebAppMessage,
     ShippingOption,
@@ -664,7 +661,7 @@ class Bot:
 
     async def approve_chat_join_request(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -687,9 +684,9 @@ class Bot:
 
     async def ban_chat_member(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
-        until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        until_date: Optional[DateTimeUnion] = None,
         revoke_messages: Optional[bool] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -716,7 +713,7 @@ class Bot:
 
     async def ban_chat_sender_chat(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         sender_chat_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -755,7 +752,7 @@ class Bot:
 
     async def close_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -778,11 +775,11 @@ class Bot:
 
     async def copy_message(
         self,
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
+        from_chat_id: ChatIdUnion,
         message_id: int,
         message_thread_id: Optional[int] = None,
-        video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        video_start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -793,9 +790,7 @@ class Bot:
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -847,9 +842,9 @@ class Bot:
 
     async def create_chat_invite_link(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         name: Optional[str] = None,
-        expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        expire_date: Optional[DateTimeUnion] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None,
         request_timeout: Optional[int] = None,
@@ -879,7 +874,7 @@ class Bot:
 
     async def create_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         name: str,
         icon_color: Optional[int] = None,
         icon_custom_emoji_id: Optional[str] = None,
@@ -1029,7 +1024,7 @@ class Bot:
 
     async def decline_chat_join_request(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -1052,7 +1047,7 @@ class Bot:
 
     async def delete_chat_photo(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -1072,7 +1067,7 @@ class Bot:
 
     async def delete_chat_sticker_set(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -1092,7 +1087,7 @@ class Bot:
 
     async def delete_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -1115,7 +1110,7 @@ class Bot:
 
     async def delete_message(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -1219,10 +1214,10 @@ class Bot:
 
     async def edit_chat_invite_link(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         invite_link: str,
         name: Optional[str] = None,
-        expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        expire_date: Optional[DateTimeUnion] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None,
         request_timeout: Optional[int] = None,
@@ -1254,7 +1249,7 @@ class Bot:
 
     async def edit_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: int,
         name: Optional[str] = None,
         icon_custom_emoji_id: Optional[str] = None,
@@ -1284,7 +1279,7 @@ class Bot:
     async def edit_message_caption(
         self,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         caption: Optional[str] = None,
@@ -1332,7 +1327,7 @@ class Bot:
         latitude: float,
         longitude: float,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         live_period: Optional[int] = None,
@@ -1381,7 +1376,7 @@ class Bot:
         self,
         media: InputMediaUnion,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
@@ -1415,7 +1410,7 @@ class Bot:
     async def edit_message_reply_markup(
         self,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
@@ -1448,7 +1443,7 @@ class Bot:
         self,
         text: str,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1497,7 +1492,7 @@ class Bot:
 
     async def export_chat_invite_link(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> str:
         """
@@ -1519,11 +1514,11 @@ class Bot:
 
     async def forward_message(
         self,
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
+        from_chat_id: ChatIdUnion,
         message_id: int,
         message_thread_id: Optional[int] = None,
-        video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        video_start_timestamp: Optional[DateTimeUnion] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         request_timeout: Optional[int] = None,
@@ -1557,7 +1552,7 @@ class Bot:
 
     async def get_chat(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> ChatFullInfo:
         """
@@ -1577,7 +1572,7 @@ class Bot:
 
     async def get_chat_administrators(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> list[
         Union[
@@ -1606,7 +1601,7 @@ class Bot:
 
     async def get_chat_member(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         request_timeout: Optional[int] = None,
     ) -> Union[
@@ -1636,7 +1631,7 @@ class Bot:
 
     async def get_chat_member_count(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> int:
         """
@@ -1920,7 +1915,7 @@ class Bot:
 
     async def leave_chat(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -1956,7 +1951,7 @@ class Bot:
 
     async def pin_chat_message(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_id: int,
         business_connection_id: Optional[str] = None,
         disable_notification: Optional[bool] = None,
@@ -1985,7 +1980,7 @@ class Bot:
 
     async def promote_chat_member(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         is_anonymous: Optional[bool] = None,
         can_manage_chat: Optional[bool] = None,
@@ -2053,7 +2048,7 @@ class Bot:
 
     async def reopen_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -2076,11 +2071,11 @@ class Bot:
 
     async def restrict_chat_member(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         permissions: ChatPermissions,
         use_independent_chat_permissions: Optional[bool] = None,
-        until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        until_date: Optional[DateTimeUnion] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -2108,7 +2103,7 @@ class Bot:
 
     async def revoke_chat_invite_link(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         invite_link: str,
         request_timeout: Optional[int] = None,
     ) -> ChatInviteLink:
@@ -2131,8 +2126,8 @@ class Bot:
 
     async def send_animation(
         self,
-        chat_id: Union[int, str],
-        animation: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -2151,9 +2146,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2215,8 +2208,8 @@ class Bot:
 
     async def send_audio(
         self,
-        chat_id: Union[int, str],
-        audio: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2231,9 +2224,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2292,7 +2283,7 @@ class Bot:
 
     async def send_chat_action(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         action: str,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
@@ -2325,7 +2316,7 @@ class Bot:
 
     async def send_contact(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         phone_number: str,
         first_name: str,
         business_connection_id: Optional[str] = None,
@@ -2337,9 +2328,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2389,7 +2378,7 @@ class Bot:
 
     async def send_dice(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -2398,9 +2387,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2444,8 +2431,8 @@ class Bot:
 
     async def send_document(
         self,
-        chat_id: Union[int, str],
-        document: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -2458,9 +2445,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2567,7 +2552,7 @@ class Bot:
 
     async def send_invoice(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         title: str,
         description: str,
         payload: str,
@@ -2677,7 +2662,7 @@ class Bot:
 
     async def send_location(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         latitude: float,
         longitude: float,
         business_connection_id: Optional[str] = None,
@@ -2691,9 +2676,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2747,8 +2730,8 @@ class Bot:
 
     async def send_media_group(
         self,
-        chat_id: Union[int, str],
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        chat_id: ChatIdUnion,
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -2797,7 +2780,7 @@ class Bot:
 
     async def send_message(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         text: str,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
@@ -2811,9 +2794,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -2868,8 +2849,8 @@ class Bot:
 
     async def send_photo(
         self,
-        chat_id: Union[int, str],
-        photo: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2884,9 +2865,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -2940,9 +2919,9 @@ class Bot:
 
     async def send_poll(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -2955,16 +2934,14 @@ class Bot:
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3034,8 +3011,8 @@ class Bot:
 
     async def send_sticker(
         self,
-        chat_id: Union[int, str],
-        sticker: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -3044,9 +3021,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3092,7 +3067,7 @@ class Bot:
 
     async def send_venue(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         latitude: float,
         longitude: float,
         title: str,
@@ -3108,9 +3083,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3168,16 +3141,16 @@ class Bot:
 
     async def send_video(
         self,
-        chat_id: Union[int, str],
-        video: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -3191,9 +3164,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3261,8 +3232,8 @@ class Bot:
 
     async def send_video_note(
         self,
-        chat_id: Union[int, str],
-        video_note: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -3273,9 +3244,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3325,8 +3294,8 @@ class Bot:
 
     async def send_voice(
         self,
-        chat_id: Union[int, str],
-        voice: Union[InputFile, str],
+        chat_id: ChatIdUnion,
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -3338,9 +3307,7 @@ class Bot:
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3392,7 +3359,7 @@ class Bot:
 
     async def set_chat_administrator_custom_title(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         custom_title: str,
         request_timeout: Optional[int] = None,
@@ -3418,7 +3385,7 @@ class Bot:
 
     async def set_chat_description(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         description: Optional[str] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3464,7 +3431,7 @@ class Bot:
 
     async def set_chat_permissions(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         permissions: ChatPermissions,
         use_independent_chat_permissions: Optional[bool] = None,
         request_timeout: Optional[int] = None,
@@ -3490,7 +3457,7 @@ class Bot:
 
     async def set_chat_photo(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         photo: InputFile,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3513,7 +3480,7 @@ class Bot:
 
     async def set_chat_sticker_set(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         sticker_set_name: str,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3536,7 +3503,7 @@ class Bot:
 
     async def set_chat_title(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         title: str,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3742,7 +3709,7 @@ class Bot:
     async def stop_message_live_location(
         self,
         business_connection_id: Optional[str] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         message_id: Optional[int] = None,
         inline_message_id: Optional[str] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
@@ -3773,7 +3740,7 @@ class Bot:
 
     async def stop_poll(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_id: int,
         business_connection_id: Optional[str] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
@@ -3802,7 +3769,7 @@ class Bot:
 
     async def unban_chat_member(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         only_if_banned: Optional[bool] = None,
         request_timeout: Optional[int] = None,
@@ -3828,7 +3795,7 @@ class Bot:
 
     async def unban_chat_sender_chat(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         sender_chat_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3851,7 +3818,7 @@ class Bot:
 
     async def unpin_all_chat_messages(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -3871,7 +3838,7 @@ class Bot:
 
     async def unpin_all_forum_topic_messages(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: int,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3894,7 +3861,7 @@ class Bot:
 
     async def unpin_chat_message(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         business_connection_id: Optional[str] = None,
         message_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
@@ -3946,7 +3913,7 @@ class Bot:
 
     async def close_general_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -3966,7 +3933,7 @@ class Bot:
 
     async def edit_general_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         name: str,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3989,7 +3956,7 @@ class Bot:
 
     async def hide_general_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4009,7 +3976,7 @@ class Bot:
 
     async def reopen_general_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4029,7 +3996,7 @@ class Bot:
 
     async def unhide_general_forum_topic(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4250,7 +4217,7 @@ class Bot:
         name: str,
         user_id: int,
         format: str,
-        thumbnail: Optional[Union[InputFile, str]] = None,
+        thumbnail: Optional[InputFileUnion] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4342,7 +4309,7 @@ class Bot:
 
     async def unpin_all_general_forum_topic_messages(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4362,8 +4329,8 @@ class Bot:
 
     async def copy_messages(
         self,
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
+        from_chat_id: ChatIdUnion,
         message_ids: list[int],
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -4400,7 +4367,7 @@ class Bot:
 
     async def delete_messages(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_ids: list[int],
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -4423,8 +4390,8 @@ class Bot:
 
     async def forward_messages(
         self,
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
+        from_chat_id: ChatIdUnion,
         message_ids: list[int],
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -4458,7 +4425,7 @@ class Bot:
 
     async def get_user_chat_boosts(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         user_id: int,
         request_timeout: Optional[int] = None,
     ) -> UserChatBoosts:
@@ -4481,7 +4448,7 @@ class Bot:
 
     async def set_message_reaction(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_id: int,
         reaction: Optional[list[ReactionTypeUnion]] = None,
         is_big: Optional[bool] = None,
@@ -4605,7 +4572,7 @@ class Bot:
 
     async def send_paid_media(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         star_count: int,
         media: list[InputPaidMediaUnion],
         business_connection_id: Optional[str] = None,
@@ -4618,9 +4585,7 @@ class Bot:
         protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         request_timeout: Optional[int] = None,
     ) -> Message:
         """
@@ -4666,8 +4631,8 @@ class Bot:
 
     async def create_chat_subscription_invite_link(
         self,
-        chat_id: Union[int, str],
-        subscription_period: Union[datetime.datetime, datetime.timedelta, int],
+        chat_id: ChatIdUnion,
+        subscription_period: DateTimeUnion,
         subscription_price: int,
         name: Optional[str] = None,
         request_timeout: Optional[int] = None,
@@ -4695,7 +4660,7 @@ class Bot:
 
     async def edit_chat_subscription_invite_link(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         invite_link: str,
         name: Optional[str] = None,
         request_timeout: Optional[int] = None,
@@ -4800,7 +4765,7 @@ class Bot:
         self,
         gift_id: str,
         user_id: Optional[int] = None,
-        chat_id: Optional[Union[int, str]] = None,
+        chat_id: Optional[ChatIdUnion] = None,
         pay_for_upgrade: Optional[bool] = None,
         text: Optional[str] = None,
         text_parse_mode: Optional[str] = None,
@@ -4838,9 +4803,7 @@ class Bot:
         self,
         user_id: int,
         emoji_status_custom_emoji_id: Optional[str] = None,
-        emoji_status_expiration_date: Optional[
-            Union[datetime.datetime, datetime.timedelta, int]
-        ] = None,
+        emoji_status_expiration_date: Optional[DateTimeUnion] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4864,7 +4827,7 @@ class Bot:
 
     async def remove_chat_verification(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4904,7 +4867,7 @@ class Bot:
 
     async def verify_chat(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         custom_description: Optional[str] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:

--- a/aiogram/client/bot.py
+++ b/aiogram/client/bot.py
@@ -161,13 +161,7 @@ from ..methods import (
 )
 from ..types import (
     BotCommand,
-    BotCommandScopeAllChatAdministrators,
-    BotCommandScopeAllGroupChats,
-    BotCommandScopeAllPrivateChats,
-    BotCommandScopeChat,
-    BotCommandScopeChatAdministrators,
-    BotCommandScopeChatMember,
-    BotCommandScopeDefault,
+    BotCommandScopeUnion,
     BotDescription,
     BotName,
     BotShortDescription,
@@ -189,35 +183,15 @@ from ..types import (
     GameHighScore,
     Gifts,
     InlineKeyboardMarkup,
-    InlineQueryResultArticle,
-    InlineQueryResultAudio,
-    InlineQueryResultCachedAudio,
-    InlineQueryResultCachedDocument,
-    InlineQueryResultCachedGif,
-    InlineQueryResultCachedMpeg4Gif,
-    InlineQueryResultCachedPhoto,
-    InlineQueryResultCachedSticker,
-    InlineQueryResultCachedVideo,
-    InlineQueryResultCachedVoice,
-    InlineQueryResultContact,
-    InlineQueryResultDocument,
-    InlineQueryResultGame,
-    InlineQueryResultGif,
-    InlineQueryResultLocation,
-    InlineQueryResultMpeg4Gif,
-    InlineQueryResultPhoto,
     InlineQueryResultsButton,
-    InlineQueryResultVenue,
-    InlineQueryResultVideo,
-    InlineQueryResultVoice,
+    InlineQueryResultUnion,
     InputFile,
-    InputMediaAnimation,
     InputMediaAudio,
     InputMediaDocument,
     InputMediaPhoto,
+    InputMediaUnion,
     InputMediaVideo,
-    InputPaidMediaPhoto,
-    InputPaidMediaVideo,
+    InputPaidMediaUnion,
     InputPollOption,
     InputSticker,
     LabeledPrice,
@@ -225,24 +199,15 @@ from ..types import (
     MaskPosition,
     MenuButtonCommands,
     MenuButtonDefault,
+    MenuButtonUnion,
     MenuButtonWebApp,
     Message,
     MessageEntity,
     MessageId,
-    PassportElementErrorDataField,
-    PassportElementErrorFile,
-    PassportElementErrorFiles,
-    PassportElementErrorFrontSide,
-    PassportElementErrorReverseSide,
-    PassportElementErrorSelfie,
-    PassportElementErrorTranslationFile,
-    PassportElementErrorTranslationFiles,
-    PassportElementErrorUnspecified,
+    PassportElementErrorUnion,
     Poll,
     PreparedInlineMessage,
-    ReactionTypeCustomEmoji,
-    ReactionTypeEmoji,
-    ReactionTypePaid,
+    ReactionTypeUnion,
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
     ReplyParameters,
@@ -579,30 +544,7 @@ class Bot:
     async def answer_inline_query(
         self,
         inline_query_id: str,
-        results: list[
-            Union[
-                InlineQueryResultCachedAudio,
-                InlineQueryResultCachedDocument,
-                InlineQueryResultCachedGif,
-                InlineQueryResultCachedMpeg4Gif,
-                InlineQueryResultCachedPhoto,
-                InlineQueryResultCachedSticker,
-                InlineQueryResultCachedVideo,
-                InlineQueryResultCachedVoice,
-                InlineQueryResultArticle,
-                InlineQueryResultAudio,
-                InlineQueryResultContact,
-                InlineQueryResultGame,
-                InlineQueryResultDocument,
-                InlineQueryResultGif,
-                InlineQueryResultLocation,
-                InlineQueryResultMpeg4Gif,
-                InlineQueryResultPhoto,
-                InlineQueryResultVenue,
-                InlineQueryResultVideo,
-                InlineQueryResultVoice,
-            ]
-        ],
+        results: list[InlineQueryResultUnion],
         cache_time: Optional[int] = None,
         is_personal: Optional[bool] = None,
         next_offset: Optional[str] = None,
@@ -700,28 +642,7 @@ class Bot:
     async def answer_web_app_query(
         self,
         web_app_query_id: str,
-        result: Union[
-            InlineQueryResultCachedAudio,
-            InlineQueryResultCachedDocument,
-            InlineQueryResultCachedGif,
-            InlineQueryResultCachedMpeg4Gif,
-            InlineQueryResultCachedPhoto,
-            InlineQueryResultCachedSticker,
-            InlineQueryResultCachedVideo,
-            InlineQueryResultCachedVoice,
-            InlineQueryResultArticle,
-            InlineQueryResultAudio,
-            InlineQueryResultContact,
-            InlineQueryResultGame,
-            InlineQueryResultDocument,
-            InlineQueryResultGif,
-            InlineQueryResultLocation,
-            InlineQueryResultMpeg4Gif,
-            InlineQueryResultPhoto,
-            InlineQueryResultVenue,
-            InlineQueryResultVideo,
-            InlineQueryResultVoice,
-        ],
+        result: InlineQueryResultUnion,
         request_timeout: Optional[int] = None,
     ) -> SentWebAppMessage:
         """
@@ -1235,17 +1156,7 @@ class Bot:
 
     async def delete_my_commands(
         self,
-        scope: Optional[
-            Union[
-                BotCommandScopeDefault,
-                BotCommandScopeAllPrivateChats,
-                BotCommandScopeAllGroupChats,
-                BotCommandScopeAllChatAdministrators,
-                BotCommandScopeChat,
-                BotCommandScopeChatAdministrators,
-                BotCommandScopeChatMember,
-            ]
-        ] = None,
+        scope: Optional[BotCommandScopeUnion] = None,
         language_code: Optional[str] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -1468,13 +1379,7 @@ class Bot:
 
     async def edit_message_media(
         self,
-        media: Union[
-            InputMediaAnimation,
-            InputMediaDocument,
-            InputMediaAudio,
-            InputMediaPhoto,
-            InputMediaVideo,
-        ],
+        media: InputMediaUnion,
         business_connection_id: Optional[str] = None,
         chat_id: Optional[Union[int, str]] = None,
         message_id: Optional[int] = None,
@@ -1875,17 +1780,7 @@ class Bot:
 
     async def get_my_commands(
         self,
-        scope: Optional[
-            Union[
-                BotCommandScopeDefault,
-                BotCommandScopeAllPrivateChats,
-                BotCommandScopeAllGroupChats,
-                BotCommandScopeAllChatAdministrators,
-                BotCommandScopeChat,
-                BotCommandScopeChatAdministrators,
-                BotCommandScopeChatMember,
-            ]
-        ] = None,
+        scope: Optional[BotCommandScopeUnion] = None,
         language_code: Optional[str] = None,
         request_timeout: Optional[int] = None,
     ) -> list[BotCommand]:
@@ -3547,9 +3442,7 @@ class Bot:
     async def set_chat_menu_button(
         self,
         chat_id: Optional[int] = None,
-        menu_button: Optional[
-            Union[MenuButtonCommands, MenuButtonWebApp, MenuButtonDefault]
-        ] = None,
+        menu_button: Optional[MenuButtonUnion] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -3705,17 +3598,7 @@ class Bot:
     async def set_my_commands(
         self,
         commands: list[BotCommand],
-        scope: Optional[
-            Union[
-                BotCommandScopeDefault,
-                BotCommandScopeAllPrivateChats,
-                BotCommandScopeAllGroupChats,
-                BotCommandScopeAllChatAdministrators,
-                BotCommandScopeChat,
-                BotCommandScopeChatAdministrators,
-                BotCommandScopeChatMember,
-            ]
-        ] = None,
+        scope: Optional[BotCommandScopeUnion] = None,
         language_code: Optional[str] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -3764,19 +3647,7 @@ class Bot:
     async def set_passport_data_errors(
         self,
         user_id: int,
-        errors: list[
-            Union[
-                PassportElementErrorDataField,
-                PassportElementErrorFrontSide,
-                PassportElementErrorReverseSide,
-                PassportElementErrorSelfie,
-                PassportElementErrorFile,
-                PassportElementErrorFiles,
-                PassportElementErrorTranslationFile,
-                PassportElementErrorTranslationFiles,
-                PassportElementErrorUnspecified,
-            ]
-        ],
+        errors: list[PassportElementErrorUnion],
         request_timeout: Optional[int] = None,
     ) -> bool:
         """
@@ -4612,9 +4483,7 @@ class Bot:
         self,
         chat_id: Union[int, str],
         message_id: int,
-        reaction: Optional[
-            list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-        ] = None,
+        reaction: Optional[list[ReactionTypeUnion]] = None,
         is_big: Optional[bool] = None,
         request_timeout: Optional[int] = None,
     ) -> bool:
@@ -4738,7 +4607,7 @@ class Bot:
         self,
         chat_id: Union[int, str],
         star_count: int,
-        media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+        media: list[InputPaidMediaUnion],
         business_connection_id: Optional[str] = None,
         payload: Optional[str] = None,
         caption: Optional[str] = None,
@@ -4895,28 +4764,7 @@ class Bot:
     async def save_prepared_inline_message(
         self,
         user_id: int,
-        result: Union[
-            InlineQueryResultCachedAudio,
-            InlineQueryResultCachedDocument,
-            InlineQueryResultCachedGif,
-            InlineQueryResultCachedMpeg4Gif,
-            InlineQueryResultCachedPhoto,
-            InlineQueryResultCachedSticker,
-            InlineQueryResultCachedVideo,
-            InlineQueryResultCachedVoice,
-            InlineQueryResultArticle,
-            InlineQueryResultAudio,
-            InlineQueryResultContact,
-            InlineQueryResultGame,
-            InlineQueryResultDocument,
-            InlineQueryResultGif,
-            InlineQueryResultLocation,
-            InlineQueryResultMpeg4Gif,
-            InlineQueryResultPhoto,
-            InlineQueryResultVenue,
-            InlineQueryResultVideo,
-            InlineQueryResultVoice,
-        ],
+        result: InlineQueryResultUnion,
         allow_user_chats: Optional[bool] = None,
         allow_bot_chats: Optional[bool] = None,
         allow_group_chats: Optional[bool] = None,

--- a/aiogram/client/bot.py
+++ b/aiogram/client/bot.py
@@ -169,12 +169,6 @@ from ..types import (
     ChatFullInfo,
     ChatIdUnion,
     ChatInviteLink,
-    ChatMemberAdministrator,
-    ChatMemberBanned,
-    ChatMemberLeft,
-    ChatMemberMember,
-    ChatMemberOwner,
-    ChatMemberRestricted,
     ChatPermissions,
     DateTimeUnion,
     Downloadable,
@@ -195,10 +189,7 @@ from ..types import (
     LinkPreviewOptions,
     MaskPosition,
     MediaUnion,
-    MenuButtonCommands,
-    MenuButtonDefault,
     MenuButtonUnion,
-    MenuButtonWebApp,
     Message,
     MessageEntity,
     MessageId,
@@ -208,6 +199,8 @@ from ..types import (
     ReactionTypeUnion,
     ReplyMarkupUnion,
     ReplyParameters,
+    ResultChatMemberUnion,
+    ResultMenuButtonUnion,
     SentWebAppMessage,
     ShippingOption,
     StarTransactions,
@@ -1574,16 +1567,7 @@ class Bot:
         self,
         chat_id: ChatIdUnion,
         request_timeout: Optional[int] = None,
-    ) -> list[
-        Union[
-            ChatMemberOwner,
-            ChatMemberAdministrator,
-            ChatMemberMember,
-            ChatMemberRestricted,
-            ChatMemberLeft,
-            ChatMemberBanned,
-        ]
-    ]:
+    ) -> list[ResultChatMemberUnion]:
         """
         Use this method to get a list of administrators in a chat, which aren't bots. Returns an Array of :class:`aiogram.types.chat_member.ChatMember` objects.
 
@@ -1604,14 +1588,7 @@ class Bot:
         chat_id: ChatIdUnion,
         user_id: int,
         request_timeout: Optional[int] = None,
-    ) -> Union[
-        ChatMemberOwner,
-        ChatMemberAdministrator,
-        ChatMemberMember,
-        ChatMemberRestricted,
-        ChatMemberLeft,
-        ChatMemberBanned,
-    ]:
+    ) -> ResultChatMemberUnion:
         """
         Use this method to get information about a member of a chat. The method is only guaranteed to work for other users if the bot is an administrator in the chat. Returns a :class:`aiogram.types.chat_member.ChatMember` object on success.
 
@@ -1653,7 +1630,7 @@ class Bot:
         self,
         chat_id: Optional[int] = None,
         request_timeout: Optional[int] = None,
-    ) -> Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands]:
+    ) -> ResultMenuButtonUnion:
         """
         Use this method to get the current value of the bot's menu button in a private chat, or the default menu button. Returns :class:`aiogram.types.menu_button.MenuButton` on success.
 

--- a/aiogram/methods/answer_inline_query.py
+++ b/aiogram/methods/answer_inline_query.py
@@ -1,32 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
-from ..types import (
-    InlineQueryResultArticle,
-    InlineQueryResultAudio,
-    InlineQueryResultCachedAudio,
-    InlineQueryResultCachedDocument,
-    InlineQueryResultCachedGif,
-    InlineQueryResultCachedMpeg4Gif,
-    InlineQueryResultCachedPhoto,
-    InlineQueryResultCachedSticker,
-    InlineQueryResultCachedVideo,
-    InlineQueryResultCachedVoice,
-    InlineQueryResultContact,
-    InlineQueryResultDocument,
-    InlineQueryResultGame,
-    InlineQueryResultGif,
-    InlineQueryResultLocation,
-    InlineQueryResultMpeg4Gif,
-    InlineQueryResultPhoto,
-    InlineQueryResultsButton,
-    InlineQueryResultVenue,
-    InlineQueryResultVideo,
-    InlineQueryResultVoice,
-)
+from ..types import InlineQueryResultsButton, InlineQueryResultUnion
 from .base import TelegramMethod
 
 
@@ -44,30 +22,7 @@ class AnswerInlineQuery(TelegramMethod[bool]):
 
     inline_query_id: str
     """Unique identifier for the answered query"""
-    results: list[
-        Union[
-            InlineQueryResultCachedAudio,
-            InlineQueryResultCachedDocument,
-            InlineQueryResultCachedGif,
-            InlineQueryResultCachedMpeg4Gif,
-            InlineQueryResultCachedPhoto,
-            InlineQueryResultCachedSticker,
-            InlineQueryResultCachedVideo,
-            InlineQueryResultCachedVoice,
-            InlineQueryResultArticle,
-            InlineQueryResultAudio,
-            InlineQueryResultContact,
-            InlineQueryResultGame,
-            InlineQueryResultDocument,
-            InlineQueryResultGif,
-            InlineQueryResultLocation,
-            InlineQueryResultMpeg4Gif,
-            InlineQueryResultPhoto,
-            InlineQueryResultVenue,
-            InlineQueryResultVideo,
-            InlineQueryResultVoice,
-        ]
-    ]
+    results: list[InlineQueryResultUnion]
     """A JSON-serialized array of results for the inline query"""
     cache_time: Optional[int] = None
     """The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300."""
@@ -96,30 +51,7 @@ class AnswerInlineQuery(TelegramMethod[bool]):
             __pydantic__self__,
             *,
             inline_query_id: str,
-            results: list[
-                Union[
-                    InlineQueryResultCachedAudio,
-                    InlineQueryResultCachedDocument,
-                    InlineQueryResultCachedGif,
-                    InlineQueryResultCachedMpeg4Gif,
-                    InlineQueryResultCachedPhoto,
-                    InlineQueryResultCachedSticker,
-                    InlineQueryResultCachedVideo,
-                    InlineQueryResultCachedVoice,
-                    InlineQueryResultArticle,
-                    InlineQueryResultAudio,
-                    InlineQueryResultContact,
-                    InlineQueryResultGame,
-                    InlineQueryResultDocument,
-                    InlineQueryResultGif,
-                    InlineQueryResultLocation,
-                    InlineQueryResultMpeg4Gif,
-                    InlineQueryResultPhoto,
-                    InlineQueryResultVenue,
-                    InlineQueryResultVideo,
-                    InlineQueryResultVoice,
-                ]
-            ],
+            results: list[InlineQueryResultUnion],
             cache_time: Optional[int] = None,
             is_personal: Optional[bool] = None,
             next_offset: Optional[str] = None,

--- a/aiogram/methods/answer_web_app_query.py
+++ b/aiogram/methods/answer_web_app_query.py
@@ -1,30 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import (
-    InlineQueryResultArticle,
-    InlineQueryResultAudio,
-    InlineQueryResultCachedAudio,
-    InlineQueryResultCachedDocument,
-    InlineQueryResultCachedGif,
-    InlineQueryResultCachedMpeg4Gif,
-    InlineQueryResultCachedPhoto,
-    InlineQueryResultCachedSticker,
-    InlineQueryResultCachedVideo,
-    InlineQueryResultCachedVoice,
-    InlineQueryResultContact,
-    InlineQueryResultDocument,
-    InlineQueryResultGame,
-    InlineQueryResultGif,
-    InlineQueryResultLocation,
-    InlineQueryResultMpeg4Gif,
-    InlineQueryResultPhoto,
-    InlineQueryResultVenue,
-    InlineQueryResultVideo,
-    InlineQueryResultVoice,
-    SentWebAppMessage,
-)
+from ..types import InlineQueryResultUnion, SentWebAppMessage
 from .base import TelegramMethod
 
 
@@ -40,28 +18,7 @@ class AnswerWebAppQuery(TelegramMethod[SentWebAppMessage]):
 
     web_app_query_id: str
     """Unique identifier for the query to be answered"""
-    result: Union[
-        InlineQueryResultCachedAudio,
-        InlineQueryResultCachedDocument,
-        InlineQueryResultCachedGif,
-        InlineQueryResultCachedMpeg4Gif,
-        InlineQueryResultCachedPhoto,
-        InlineQueryResultCachedSticker,
-        InlineQueryResultCachedVideo,
-        InlineQueryResultCachedVoice,
-        InlineQueryResultArticle,
-        InlineQueryResultAudio,
-        InlineQueryResultContact,
-        InlineQueryResultGame,
-        InlineQueryResultDocument,
-        InlineQueryResultGif,
-        InlineQueryResultLocation,
-        InlineQueryResultMpeg4Gif,
-        InlineQueryResultPhoto,
-        InlineQueryResultVenue,
-        InlineQueryResultVideo,
-        InlineQueryResultVoice,
-    ]
+    result: InlineQueryResultUnion
     """A JSON-serialized object describing the message to be sent"""
 
     if TYPE_CHECKING:
@@ -72,28 +29,7 @@ class AnswerWebAppQuery(TelegramMethod[SentWebAppMessage]):
             __pydantic__self__,
             *,
             web_app_query_id: str,
-            result: Union[
-                InlineQueryResultCachedAudio,
-                InlineQueryResultCachedDocument,
-                InlineQueryResultCachedGif,
-                InlineQueryResultCachedMpeg4Gif,
-                InlineQueryResultCachedPhoto,
-                InlineQueryResultCachedSticker,
-                InlineQueryResultCachedVideo,
-                InlineQueryResultCachedVoice,
-                InlineQueryResultArticle,
-                InlineQueryResultAudio,
-                InlineQueryResultContact,
-                InlineQueryResultGame,
-                InlineQueryResultDocument,
-                InlineQueryResultGif,
-                InlineQueryResultLocation,
-                InlineQueryResultMpeg4Gif,
-                InlineQueryResultPhoto,
-                InlineQueryResultVenue,
-                InlineQueryResultVideo,
-                InlineQueryResultVoice,
-            ],
+            result: InlineQueryResultUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/approve_chat_join_request.py
+++ b/aiogram/methods/approve_chat_join_request.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class ApproveChatJoinRequest(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "approveChatJoinRequest"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -25,7 +26,7 @@ class ApproveChatJoinRequest(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], user_id: int, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, user_id: int, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/ban_chat_member.py
+++ b/aiogram/methods/ban_chat_member.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion, DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -16,11 +16,11 @@ class BanChatMember(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "banChatMember"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target group or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
-    until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    until_date: Optional[DateTimeUnion] = None
     """Date when the user will be unbanned; Unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only."""
     revoke_messages: Optional[bool] = None
     """Pass :code:`True` to delete all messages from the chat for the user that is being removed. If :code:`False`, the user will be able to see messages in the group that were sent before the user was removed. Always :code:`True` for supergroups and channels."""
@@ -32,9 +32,9 @@ class BanChatMember(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
-            until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            until_date: Optional[DateTimeUnion] = None,
             revoke_messages: Optional[bool] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/ban_chat_sender_chat.py
+++ b/aiogram/methods/ban_chat_sender_chat.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class BanChatSenderChat(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "banChatSenderChat"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     sender_chat_id: int
     """Unique identifier of the target sender chat"""
@@ -27,7 +28,7 @@ class BanChatSenderChat(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             sender_chat_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/base.py
+++ b/aiogram/methods/base.py
@@ -66,7 +66,7 @@ class TelegramMethod(BotContextController, BaseModel, Generic[TelegramType], ABC
         return {k: v for k, v in values.items() if not isinstance(v, UNSET_TYPE)}
 
     if TYPE_CHECKING:
-        __returning__: ClassVar[type]
+        __returning__: ClassVar[Any]
         __api_method__: ClassVar[str]
     else:
 

--- a/aiogram/methods/close_forum_topic.py
+++ b/aiogram/methods/close_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class CloseForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "closeForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     message_thread_id: int
     """Unique identifier for the target message thread of the forum topic"""
@@ -27,7 +28,7 @@ class CloseForumTopic(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_thread_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/close_general_forum_topic.py
+++ b/aiogram/methods/close_general_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class CloseGeneralForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "closeGeneralForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class CloseGeneralForumTopic(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/copy_message.py
+++ b/aiogram/methods/copy_message.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
+    DateTimeUnion,
     MessageEntity,
     MessageId,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,15 +26,15 @@ class CopyMessage(TelegramMethod[MessageId]):
     __returning__ = MessageId
     __api_method__ = "copyMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    from_chat_id: Union[int, str]
+    from_chat_id: ChatIdUnion
     """Unique identifier for the chat where the original message was sent (or channel username in the format :code:`@channelusername`)"""
     message_id: int
     """Message identifier in the chat specified in *from_chat_id*"""
     message_thread_id: Optional[int] = None
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
-    video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    video_start_timestamp: Optional[DateTimeUnion] = None
     """New start timestamp for the copied video in the message"""
     caption: Optional[str] = None
     """New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept"""
@@ -54,9 +52,7 @@ class CopyMessage(TelegramMethod[MessageId]):
     """Pass :code:`True` to allow up to 1000 messages per second, ignoring `broadcasting limits <https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once>`_ for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -78,13 +74,11 @@ class CopyMessage(TelegramMethod[MessageId]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            from_chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
+            from_chat_id: ChatIdUnion,
             message_id: int,
             message_thread_id: Optional[int] = None,
-            video_start_timestamp: Optional[
-                Union[datetime.datetime, datetime.timedelta, int]
-            ] = None,
+            video_start_timestamp: Optional[DateTimeUnion] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,
@@ -95,9 +89,7 @@ class CopyMessage(TelegramMethod[MessageId]):
             protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
             allow_paid_broadcast: Optional[bool] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/copy_messages.py
+++ b/aiogram/methods/copy_messages.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import MessageId
+from ..types import ChatIdUnion, MessageId
 from .base import TelegramMethod
 
 
@@ -14,9 +14,9 @@ class CopyMessages(TelegramMethod[list[MessageId]]):
     __returning__ = list[MessageId]
     __api_method__ = "copyMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    from_chat_id: Union[int, str]
+    from_chat_id: ChatIdUnion
     """Unique identifier for the chat where the original messages were sent (or channel username in the format :code:`@channelusername`)"""
     message_ids: list[int]
     """A JSON-serialized list of 1-100 identifiers of messages in the chat *from_chat_id* to copy. The identifiers must be specified in a strictly increasing order."""
@@ -36,8 +36,8 @@ class CopyMessages(TelegramMethod[list[MessageId]]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            from_chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
+            from_chat_id: ChatIdUnion,
             message_ids: list[int],
             message_thread_id: Optional[int] = None,
             disable_notification: Optional[bool] = None,

--- a/aiogram/methods/create_chat_invite_link.py
+++ b/aiogram/methods/create_chat_invite_link.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatInviteLink
+from ..types import ChatIdUnion, ChatInviteLink, DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -17,11 +16,11 @@ class CreateChatInviteLink(TelegramMethod[ChatInviteLink]):
     __returning__ = ChatInviteLink
     __api_method__ = "createChatInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     name: Optional[str] = None
     """Invite link name; 0-32 characters"""
-    expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    expire_date: Optional[DateTimeUnion] = None
     """Point in time (Unix timestamp) when the link will expire"""
     member_limit: Optional[int] = None
     """The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999"""
@@ -35,9 +34,9 @@ class CreateChatInviteLink(TelegramMethod[ChatInviteLink]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             name: Optional[str] = None,
-            expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            expire_date: Optional[DateTimeUnion] = None,
             member_limit: Optional[int] = None,
             creates_join_request: Optional[bool] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/create_chat_subscription_invite_link.py
+++ b/aiogram/methods/create_chat_subscription_invite_link.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatInviteLink
+from ..types import ChatIdUnion, ChatInviteLink, DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -17,9 +16,9 @@ class CreateChatSubscriptionInviteLink(TelegramMethod[ChatInviteLink]):
     __returning__ = ChatInviteLink
     __api_method__ = "createChatSubscriptionInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target channel chat or username of the target channel (in the format :code:`@channelusername`)"""
-    subscription_period: Union[datetime.datetime, datetime.timedelta, int]
+    subscription_period: DateTimeUnion
     """The number of seconds the subscription will be active for before the next payment. Currently, it must always be 2592000 (30 days)."""
     subscription_price: int
     """The amount of Telegram Stars a user must pay initially and after each subsequent subscription period to be a member of the chat; 1-2500"""
@@ -33,8 +32,8 @@ class CreateChatSubscriptionInviteLink(TelegramMethod[ChatInviteLink]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            subscription_period: Union[datetime.datetime, datetime.timedelta, int],
+            chat_id: ChatIdUnion,
+            subscription_period: DateTimeUnion,
             subscription_price: int,
             name: Optional[str] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/create_forum_topic.py
+++ b/aiogram/methods/create_forum_topic.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ForumTopic
+from ..types import ChatIdUnion, ForumTopic
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class CreateForumTopic(TelegramMethod[ForumTopic]):
     __returning__ = ForumTopic
     __api_method__ = "createForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     name: str
     """Topic name, 1-128 characters"""
@@ -32,7 +32,7 @@ class CreateForumTopic(TelegramMethod[ForumTopic]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             name: str,
             icon_color: Optional[int] = None,
             icon_custom_emoji_id: Optional[str] = None,

--- a/aiogram/methods/decline_chat_join_request.py
+++ b/aiogram/methods/decline_chat_join_request.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class DeclineChatJoinRequest(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "declineChatJoinRequest"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -25,7 +26,7 @@ class DeclineChatJoinRequest(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], user_id: int, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, user_id: int, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/delete_chat_photo.py
+++ b/aiogram/methods/delete_chat_photo.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class DeleteChatPhoto(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteChatPhoto"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class DeleteChatPhoto(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/delete_chat_sticker_set.py
+++ b/aiogram/methods/delete_chat_sticker_set.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class DeleteChatStickerSet(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteChatStickerSet"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class DeleteChatStickerSet(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/delete_forum_topic.py
+++ b/aiogram/methods/delete_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class DeleteForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     message_thread_id: int
     """Unique identifier for the target message thread of the forum topic"""
@@ -27,7 +28,7 @@ class DeleteForumTopic(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_thread_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/delete_message.py
+++ b/aiogram/methods/delete_message.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -33,7 +34,7 @@ class DeleteMessage(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: int
     """Identifier of the message to delete"""
@@ -43,11 +44,7 @@ class DeleteMessage(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__,
-            *,
-            chat_id: Union[int, str],
-            message_id: int,
-            **__pydantic_kwargs: Any,
+            __pydantic__self__, *, chat_id: ChatIdUnion, message_id: int, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/delete_messages.py
+++ b/aiogram/methods/delete_messages.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -13,7 +14,7 @@ class DeleteMessages(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_ids: list[int]
     """A JSON-serialized list of 1-100 identifiers of messages to delete. See :class:`aiogram.methods.delete_message.DeleteMessage` for limitations on which messages can be deleted"""
@@ -25,7 +26,7 @@ class DeleteMessages(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_ids: list[int],
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/delete_my_commands.py
+++ b/aiogram/methods/delete_my_commands.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import (
-    BotCommandScopeAllChatAdministrators,
-    BotCommandScopeAllGroupChats,
-    BotCommandScopeAllPrivateChats,
-    BotCommandScopeChat,
-    BotCommandScopeChatAdministrators,
-    BotCommandScopeChatMember,
-    BotCommandScopeDefault,
-)
+from ..types import BotCommandScopeUnion
 from .base import TelegramMethod
 
 
@@ -24,17 +16,7 @@ class DeleteMyCommands(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "deleteMyCommands"
 
-    scope: Optional[
-        Union[
-            BotCommandScopeDefault,
-            BotCommandScopeAllPrivateChats,
-            BotCommandScopeAllGroupChats,
-            BotCommandScopeAllChatAdministrators,
-            BotCommandScopeChat,
-            BotCommandScopeChatAdministrators,
-            BotCommandScopeChatMember,
-        ]
-    ] = None
+    scope: Optional[BotCommandScopeUnion] = None
     """A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to :class:`aiogram.types.bot_command_scope_default.BotCommandScopeDefault`."""
     language_code: Optional[str] = None
     """A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands"""
@@ -46,17 +28,7 @@ class DeleteMyCommands(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            scope: Optional[
-                Union[
-                    BotCommandScopeDefault,
-                    BotCommandScopeAllPrivateChats,
-                    BotCommandScopeAllGroupChats,
-                    BotCommandScopeAllChatAdministrators,
-                    BotCommandScopeChat,
-                    BotCommandScopeChatAdministrators,
-                    BotCommandScopeChatMember,
-                ]
-            ] = None,
+            scope: Optional[BotCommandScopeUnion] = None,
             language_code: Optional[str] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/edit_chat_invite_link.py
+++ b/aiogram/methods/edit_chat_invite_link.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatInviteLink
+from ..types import ChatIdUnion, ChatInviteLink, DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -17,13 +16,13 @@ class EditChatInviteLink(TelegramMethod[ChatInviteLink]):
     __returning__ = ChatInviteLink
     __api_method__ = "editChatInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     invite_link: str
     """The invite link to edit"""
     name: Optional[str] = None
     """Invite link name; 0-32 characters"""
-    expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    expire_date: Optional[DateTimeUnion] = None
     """Point in time (Unix timestamp) when the link will expire"""
     member_limit: Optional[int] = None
     """The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999"""
@@ -37,10 +36,10 @@ class EditChatInviteLink(TelegramMethod[ChatInviteLink]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             invite_link: str,
             name: Optional[str] = None,
-            expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            expire_date: Optional[DateTimeUnion] = None,
             member_limit: Optional[int] = None,
             creates_join_request: Optional[bool] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/edit_chat_subscription_invite_link.py
+++ b/aiogram/methods/edit_chat_subscription_invite_link.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatInviteLink
+from ..types import ChatIdUnion, ChatInviteLink
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class EditChatSubscriptionInviteLink(TelegramMethod[ChatInviteLink]):
     __returning__ = ChatInviteLink
     __api_method__ = "editChatSubscriptionInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     invite_link: str
     """The invite link to edit"""
@@ -30,7 +30,7 @@ class EditChatSubscriptionInviteLink(TelegramMethod[ChatInviteLink]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             invite_link: str,
             name: Optional[str] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/edit_forum_topic.py
+++ b/aiogram/methods/edit_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class EditForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "editForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     message_thread_id: int
     """Unique identifier for the target message thread of the forum topic"""
@@ -31,7 +32,7 @@ class EditForumTopic(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_thread_id: int,
             name: Optional[str] = None,
             icon_custom_emoji_id: Optional[str] = None,

--- a/aiogram/methods/edit_general_forum_topic.py
+++ b/aiogram/methods/edit_general_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class EditGeneralForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "editGeneralForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     name: str
     """New topic name, 1-128 characters"""
@@ -25,7 +26,7 @@ class EditGeneralForumTopic(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], name: str, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, name: str, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/edit_message_caption.py
+++ b/aiogram/methods/edit_message_caption.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..client.default import Default
-from ..types import InlineKeyboardMarkup, Message, MessageEntity
+from ..types import ChatIdUnion, InlineKeyboardMarkup, Message, MessageEntity
 from .base import TelegramMethod
 
 
@@ -19,7 +19,7 @@ class EditMessageCaption(TelegramMethod[Union[Message, bool]]):
 
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
@@ -44,7 +44,7 @@ class EditMessageCaption(TelegramMethod[Union[Message, bool]]):
             __pydantic__self__,
             *,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             caption: Optional[str] = None,

--- a/aiogram/methods/edit_message_live_location.py
+++ b/aiogram/methods/edit_message_live_location.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import InlineKeyboardMarkup, Message
+from ..types import ChatIdUnion, InlineKeyboardMarkup, Message
 from .base import TelegramMethod
 
 
@@ -22,7 +22,7 @@ class EditMessageLiveLocation(TelegramMethod[Union[Message, bool]]):
     """Longitude of new location"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
@@ -49,7 +49,7 @@ class EditMessageLiveLocation(TelegramMethod[Union[Message, bool]]):
             latitude: float,
             longitude: float,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             live_period: Optional[int] = None,

--- a/aiogram/methods/edit_message_media.py
+++ b/aiogram/methods/edit_message_media.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import InlineKeyboardMarkup, InputMediaUnion, Message
+from ..types import ChatIdUnion, InlineKeyboardMarkup, InputMediaUnion, Message
 from .base import TelegramMethod
 
 
@@ -20,7 +20,7 @@ class EditMessageMedia(TelegramMethod[Union[Message, bool]]):
     """A JSON-serialized object for a new media content of the message"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
@@ -38,7 +38,7 @@ class EditMessageMedia(TelegramMethod[Union[Message, bool]]):
             *,
             media: InputMediaUnion,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,

--- a/aiogram/methods/edit_message_media.py
+++ b/aiogram/methods/edit_message_media.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import (
-    InlineKeyboardMarkup,
-    InputMediaAnimation,
-    InputMediaAudio,
-    InputMediaDocument,
-    InputMediaPhoto,
-    InputMediaVideo,
-    Message,
-)
+from ..types import InlineKeyboardMarkup, InputMediaUnion, Message
 from .base import TelegramMethod
 
 
@@ -24,9 +16,7 @@ class EditMessageMedia(TelegramMethod[Union[Message, bool]]):
     __returning__ = Union[Message, bool]
     __api_method__ = "editMessageMedia"
 
-    media: Union[
-        InputMediaAnimation, InputMediaDocument, InputMediaAudio, InputMediaPhoto, InputMediaVideo
-    ]
+    media: InputMediaUnion
     """A JSON-serialized object for a new media content of the message"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
@@ -46,13 +36,7 @@ class EditMessageMedia(TelegramMethod[Union[Message, bool]]):
         def __init__(
             __pydantic__self__,
             *,
-            media: Union[
-                InputMediaAnimation,
-                InputMediaDocument,
-                InputMediaAudio,
-                InputMediaPhoto,
-                InputMediaVideo,
-            ],
+            media: InputMediaUnion,
             business_connection_id: Optional[str] = None,
             chat_id: Optional[Union[int, str]] = None,
             message_id: Optional[int] = None,

--- a/aiogram/methods/edit_message_reply_markup.py
+++ b/aiogram/methods/edit_message_reply_markup.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import InlineKeyboardMarkup, Message
+from ..types import ChatIdUnion, InlineKeyboardMarkup, Message
 from .base import TelegramMethod
 
 
@@ -18,7 +18,7 @@ class EditMessageReplyMarkup(TelegramMethod[Union[Message, bool]]):
 
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
@@ -35,7 +35,7 @@ class EditMessageReplyMarkup(TelegramMethod[Union[Message, bool]]):
             __pydantic__self__,
             *,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,

--- a/aiogram/methods/edit_message_text.py
+++ b/aiogram/methods/edit_message_text.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import InlineKeyboardMarkup, LinkPreviewOptions, Message, MessageEntity
+from ..types import (
+    ChatIdUnion,
+    InlineKeyboardMarkup,
+    LinkPreviewOptions,
+    Message,
+    MessageEntity,
+)
 from .base import TelegramMethod
 
 
@@ -23,7 +29,7 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
     """New text of the message, 1-4096 characters after entities parsing"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message to edit"""
@@ -54,7 +60,7 @@ class EditMessageText(TelegramMethod[Union[Message, bool]]):
             *,
             text: str,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),

--- a/aiogram/methods/export_chat_invite_link.py
+++ b/aiogram/methods/export_chat_invite_link.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -17,7 +18,7 @@ class ExportChatInviteLink(TelegramMethod[str]):
     __returning__ = str
     __api_method__ = "exportChatInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -25,7 +26,7 @@ class ExportChatInviteLink(TelegramMethod[str]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/forward_message.py
+++ b/aiogram/methods/forward_message.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..client.default import Default
-from ..types import Message
+from ..types import ChatIdUnion, DateTimeUnion, Message
 from .base import TelegramMethod
 
 
@@ -18,15 +17,15 @@ class ForwardMessage(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "forwardMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    from_chat_id: Union[int, str]
+    from_chat_id: ChatIdUnion
     """Unique identifier for the chat where the original message was sent (or channel username in the format :code:`@channelusername`)"""
     message_id: int
     """Message identifier in the chat specified in *from_chat_id*"""
     message_thread_id: Optional[int] = None
     """Unique identifier for the target message thread (topic) of the forum; for forum supergroups only"""
-    video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    video_start_timestamp: Optional[DateTimeUnion] = None
     """New start timestamp for the forwarded video in the message"""
     disable_notification: Optional[bool] = None
     """Sends the message `silently <https://telegram.org/blog/channels-2-0#silent-messages>`_. Users will receive a notification with no sound."""
@@ -40,13 +39,11 @@ class ForwardMessage(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            from_chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
+            from_chat_id: ChatIdUnion,
             message_id: int,
             message_thread_id: Optional[int] = None,
-            video_start_timestamp: Optional[
-                Union[datetime.datetime, datetime.timedelta, int]
-            ] = None,
+            video_start_timestamp: Optional[DateTimeUnion] = None,
             disable_notification: Optional[bool] = None,
             protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/forward_messages.py
+++ b/aiogram/methods/forward_messages.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import MessageId
+from ..types import ChatIdUnion, MessageId
 from .base import TelegramMethod
 
 
@@ -14,9 +14,9 @@ class ForwardMessages(TelegramMethod[list[MessageId]]):
     __returning__ = list[MessageId]
     __api_method__ = "forwardMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    from_chat_id: Union[int, str]
+    from_chat_id: ChatIdUnion
     """Unique identifier for the chat where the original messages were sent (or channel username in the format :code:`@channelusername`)"""
     message_ids: list[int]
     """A JSON-serialized list of 1-100 identifiers of messages in the chat *from_chat_id* to forward. The identifiers must be specified in a strictly increasing order."""
@@ -34,8 +34,8 @@ class ForwardMessages(TelegramMethod[list[MessageId]]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            from_chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
+            from_chat_id: ChatIdUnion,
             message_ids: list[int],
             message_thread_id: Optional[int] = None,
             disable_notification: Optional[bool] = None,

--- a/aiogram/methods/get_chat.py
+++ b/aiogram/methods/get_chat.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import ChatFullInfo
+from ..types import ChatFullInfo, ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class GetChat(TelegramMethod[ChatFullInfo]):
     __returning__ = ChatFullInfo
     __api_method__ = "getChat"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -24,7 +24,7 @@ class GetChat(TelegramMethod[ChatFullInfo]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/get_chat_administrators.py
+++ b/aiogram/methods/get_chat_administrators.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Union
 
 from ..types import (
+    ChatIdUnion,
     ChatMemberAdministrator,
     ChatMemberBanned,
     ChatMemberLeft,
@@ -45,7 +46,7 @@ class GetChatAdministrators(
     ]
     __api_method__ = "getChatAdministrators"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -53,7 +54,7 @@ class GetChatAdministrators(
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/get_chat_administrators.py
+++ b/aiogram/methods/get_chat_administrators.py
@@ -1,49 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import (
-    ChatIdUnion,
-    ChatMemberAdministrator,
-    ChatMemberBanned,
-    ChatMemberLeft,
-    ChatMemberMember,
-    ChatMemberOwner,
-    ChatMemberRestricted,
-)
+from ..types import ChatIdUnion, ResultChatMemberUnion
 from .base import TelegramMethod
 
 
-class GetChatAdministrators(
-    TelegramMethod[
-        list[
-            Union[
-                ChatMemberOwner,
-                ChatMemberAdministrator,
-                ChatMemberMember,
-                ChatMemberRestricted,
-                ChatMemberLeft,
-                ChatMemberBanned,
-            ]
-        ]
-    ]
-):
+class GetChatAdministrators(TelegramMethod[list[ResultChatMemberUnion]]):
     """
     Use this method to get a list of administrators in a chat, which aren't bots. Returns an Array of :class:`aiogram.types.chat_member.ChatMember` objects.
 
     Source: https://core.telegram.org/bots/api#getchatadministrators
     """
 
-    __returning__ = list[
-        Union[
-            ChatMemberOwner,
-            ChatMemberAdministrator,
-            ChatMemberMember,
-            ChatMemberRestricted,
-            ChatMemberLeft,
-            ChatMemberBanned,
-        ]
-    ]
+    __returning__ = list[ResultChatMemberUnion]
     __api_method__ = "getChatAdministrators"
 
     chat_id: ChatIdUnion

--- a/aiogram/methods/get_chat_member.py
+++ b/aiogram/methods/get_chat_member.py
@@ -1,45 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import (
-    ChatIdUnion,
-    ChatMemberAdministrator,
-    ChatMemberBanned,
-    ChatMemberLeft,
-    ChatMemberMember,
-    ChatMemberOwner,
-    ChatMemberRestricted,
-)
+from ..types import ChatIdUnion, ResultChatMemberUnion
 from .base import TelegramMethod
 
 
-class GetChatMember(
-    TelegramMethod[
-        Union[
-            ChatMemberOwner,
-            ChatMemberAdministrator,
-            ChatMemberMember,
-            ChatMemberRestricted,
-            ChatMemberLeft,
-            ChatMemberBanned,
-        ]
-    ]
-):
+class GetChatMember(TelegramMethod[ResultChatMemberUnion]):
     """
     Use this method to get information about a member of a chat. The method is only guaranteed to work for other users if the bot is an administrator in the chat. Returns a :class:`aiogram.types.chat_member.ChatMember` object on success.
 
     Source: https://core.telegram.org/bots/api#getchatmember
     """
 
-    __returning__ = Union[
-        ChatMemberOwner,
-        ChatMemberAdministrator,
-        ChatMemberMember,
-        ChatMemberRestricted,
-        ChatMemberLeft,
-        ChatMemberBanned,
-    ]
+    __returning__ = ResultChatMemberUnion
     __api_method__ = "getChatMember"
 
     chat_id: ChatIdUnion

--- a/aiogram/methods/get_chat_member.py
+++ b/aiogram/methods/get_chat_member.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Union
 
 from ..types import (
+    ChatIdUnion,
     ChatMemberAdministrator,
     ChatMemberBanned,
     ChatMemberLeft,
@@ -41,7 +42,7 @@ class GetChatMember(
     ]
     __api_method__ = "getChatMember"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -51,7 +52,7 @@ class GetChatMember(
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], user_id: int, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, user_id: int, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/get_chat_member_count.py
+++ b/aiogram/methods/get_chat_member_count.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class GetChatMemberCount(TelegramMethod[int]):
     __returning__ = int
     __api_method__ = "getChatMemberCount"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class GetChatMemberCount(TelegramMethod[int]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/get_chat_menu_button.py
+++ b/aiogram/methods/get_chat_menu_button.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import MenuButtonCommands, MenuButtonDefault, MenuButtonWebApp
+from ..types import ResultMenuButtonUnion
 from .base import TelegramMethod
 
 
-class GetChatMenuButton(
-    TelegramMethod[Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands]]
-):
+class GetChatMenuButton(TelegramMethod[ResultMenuButtonUnion]):
     """
     Use this method to get the current value of the bot's menu button in a private chat, or the default menu button. Returns :class:`aiogram.types.menu_button.MenuButton` on success.
 
     Source: https://core.telegram.org/bots/api#getchatmenubutton
     """
 
-    __returning__ = Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands]
+    __returning__ = ResultMenuButtonUnion
     __api_method__ = "getChatMenuButton"
 
     chat_id: Optional[int] = None

--- a/aiogram/methods/get_my_commands.py
+++ b/aiogram/methods/get_my_commands.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import (
-    BotCommand,
-    BotCommandScopeAllChatAdministrators,
-    BotCommandScopeAllGroupChats,
-    BotCommandScopeAllPrivateChats,
-    BotCommandScopeChat,
-    BotCommandScopeChatAdministrators,
-    BotCommandScopeChatMember,
-    BotCommandScopeDefault,
-)
+from ..types import BotCommand, BotCommandScopeUnion
 from .base import TelegramMethod
 
 
@@ -25,17 +16,7 @@ class GetMyCommands(TelegramMethod[list[BotCommand]]):
     __returning__ = list[BotCommand]
     __api_method__ = "getMyCommands"
 
-    scope: Optional[
-        Union[
-            BotCommandScopeDefault,
-            BotCommandScopeAllPrivateChats,
-            BotCommandScopeAllGroupChats,
-            BotCommandScopeAllChatAdministrators,
-            BotCommandScopeChat,
-            BotCommandScopeChatAdministrators,
-            BotCommandScopeChatMember,
-        ]
-    ] = None
+    scope: Optional[BotCommandScopeUnion] = None
     """A JSON-serialized object, describing scope of users. Defaults to :class:`aiogram.types.bot_command_scope_default.BotCommandScopeDefault`."""
     language_code: Optional[str] = None
     """A two-letter ISO 639-1 language code or an empty string"""
@@ -47,17 +28,7 @@ class GetMyCommands(TelegramMethod[list[BotCommand]]):
         def __init__(
             __pydantic__self__,
             *,
-            scope: Optional[
-                Union[
-                    BotCommandScopeDefault,
-                    BotCommandScopeAllPrivateChats,
-                    BotCommandScopeAllGroupChats,
-                    BotCommandScopeAllChatAdministrators,
-                    BotCommandScopeChat,
-                    BotCommandScopeChatAdministrators,
-                    BotCommandScopeChatMember,
-                ]
-            ] = None,
+            scope: Optional[BotCommandScopeUnion] = None,
             language_code: Optional[str] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/get_user_chat_boosts.py
+++ b/aiogram/methods/get_user_chat_boosts.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import UserChatBoosts
+from ..types import ChatIdUnion, UserChatBoosts
 from .base import TelegramMethod
 
 
@@ -14,7 +14,7 @@ class GetUserChatBoosts(TelegramMethod[UserChatBoosts]):
     __returning__ = UserChatBoosts
     __api_method__ = "getUserChatBoosts"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the chat or username of the channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -24,7 +24,7 @@ class GetUserChatBoosts(TelegramMethod[UserChatBoosts]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], user_id: int, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, user_id: int, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/hide_general_forum_topic.py
+++ b/aiogram/methods/hide_general_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class HideGeneralForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "hideGeneralForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class HideGeneralForumTopic(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/leave_chat.py
+++ b/aiogram/methods/leave_chat.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class LeaveChat(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "leaveChat"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class LeaveChat(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/pin_chat_message.py
+++ b/aiogram/methods/pin_chat_message.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class PinChatMessage(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "pinChatMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: int
     """Identifier of a message to pin"""
@@ -31,7 +32,7 @@ class PinChatMessage(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_id: int,
             business_connection_id: Optional[str] = None,
             disable_notification: Optional[bool] = None,

--- a/aiogram/methods/promote_chat_member.py
+++ b/aiogram/methods/promote_chat_member.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class PromoteChatMember(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "promoteChatMember"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -57,7 +58,7 @@ class PromoteChatMember(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
             is_anonymous: Optional[bool] = None,
             can_manage_chat: Optional[bool] = None,

--- a/aiogram/methods/remove_chat_verification.py
+++ b/aiogram/methods/remove_chat_verification.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class RemoveChatVerification(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "removeChatVerification"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class RemoveChatVerification(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/reopen_forum_topic.py
+++ b/aiogram/methods/reopen_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class ReopenForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "reopenForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     message_thread_id: int
     """Unique identifier for the target message thread of the forum topic"""
@@ -27,7 +28,7 @@ class ReopenForumTopic(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_thread_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/reopen_general_forum_topic.py
+++ b/aiogram/methods/reopen_general_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class ReopenGeneralForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "reopenGeneralForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class ReopenGeneralForumTopic(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/restrict_chat_member.py
+++ b/aiogram/methods/restrict_chat_member.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatPermissions
+from ..types import ChatIdUnion, ChatPermissions, DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -17,7 +16,7 @@ class RestrictChatMember(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "restrictChatMember"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -25,7 +24,7 @@ class RestrictChatMember(TelegramMethod[bool]):
     """A JSON-serialized object for new user permissions"""
     use_independent_chat_permissions: Optional[bool] = None
     """Pass :code:`True` if chat permissions are set independently. Otherwise, the *can_send_other_messages* and *can_add_web_page_previews* permissions will imply the *can_send_messages*, *can_send_audios*, *can_send_documents*, *can_send_photos*, *can_send_videos*, *can_send_video_notes*, and *can_send_voice_notes* permissions; the *can_send_polls* permission will imply the *can_send_messages* permission."""
-    until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    until_date: Optional[DateTimeUnion] = None
     """Date when restrictions will be lifted for the user; Unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever"""
 
     if TYPE_CHECKING:
@@ -35,11 +34,11 @@ class RestrictChatMember(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
             permissions: ChatPermissions,
             use_independent_chat_permissions: Optional[bool] = None,
-            until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            until_date: Optional[DateTimeUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/revoke_chat_invite_link.py
+++ b/aiogram/methods/revoke_chat_invite_link.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import ChatInviteLink
+from ..types import ChatIdUnion, ChatInviteLink
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class RevokeChatInviteLink(TelegramMethod[ChatInviteLink]):
     __returning__ = ChatInviteLink
     __api_method__ = "revokeChatInviteLink"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier of the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     invite_link: str
     """The invite link to revoke"""
@@ -26,11 +26,7 @@ class RevokeChatInviteLink(TelegramMethod[ChatInviteLink]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__,
-            *,
-            chat_id: Union[int, str],
-            invite_link: str,
-            **__pydantic_kwargs: Any,
+            __pydantic__self__, *, chat_id: ChatIdUnion, invite_link: str, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/save_prepared_inline_message.py
+++ b/aiogram/methods/save_prepared_inline_message.py
@@ -1,28 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types.inline_query_result_article import InlineQueryResultArticle
-from ..types.inline_query_result_audio import InlineQueryResultAudio
-from ..types.inline_query_result_cached_audio import InlineQueryResultCachedAudio
-from ..types.inline_query_result_cached_document import InlineQueryResultCachedDocument
-from ..types.inline_query_result_cached_gif import InlineQueryResultCachedGif
-from ..types.inline_query_result_cached_mpeg4_gif import InlineQueryResultCachedMpeg4Gif
-from ..types.inline_query_result_cached_photo import InlineQueryResultCachedPhoto
-from ..types.inline_query_result_cached_sticker import InlineQueryResultCachedSticker
-from ..types.inline_query_result_cached_video import InlineQueryResultCachedVideo
-from ..types.inline_query_result_cached_voice import InlineQueryResultCachedVoice
-from ..types.inline_query_result_contact import InlineQueryResultContact
-from ..types.inline_query_result_document import InlineQueryResultDocument
-from ..types.inline_query_result_game import InlineQueryResultGame
-from ..types.inline_query_result_gif import InlineQueryResultGif
-from ..types.inline_query_result_location import InlineQueryResultLocation
-from ..types.inline_query_result_mpeg4_gif import InlineQueryResultMpeg4Gif
-from ..types.inline_query_result_photo import InlineQueryResultPhoto
-from ..types.inline_query_result_venue import InlineQueryResultVenue
-from ..types.inline_query_result_video import InlineQueryResultVideo
-from ..types.inline_query_result_voice import InlineQueryResultVoice
-from ..types.prepared_inline_message import PreparedInlineMessage
+from ..types import InlineQueryResultUnion, PreparedInlineMessage
 from .base import TelegramMethod
 
 
@@ -38,28 +18,7 @@ class SavePreparedInlineMessage(TelegramMethod[PreparedInlineMessage]):
 
     user_id: int
     """Unique identifier of the target user that can use the prepared message"""
-    result: Union[
-        InlineQueryResultCachedAudio,
-        InlineQueryResultCachedDocument,
-        InlineQueryResultCachedGif,
-        InlineQueryResultCachedMpeg4Gif,
-        InlineQueryResultCachedPhoto,
-        InlineQueryResultCachedSticker,
-        InlineQueryResultCachedVideo,
-        InlineQueryResultCachedVoice,
-        InlineQueryResultArticle,
-        InlineQueryResultAudio,
-        InlineQueryResultContact,
-        InlineQueryResultGame,
-        InlineQueryResultDocument,
-        InlineQueryResultGif,
-        InlineQueryResultLocation,
-        InlineQueryResultMpeg4Gif,
-        InlineQueryResultPhoto,
-        InlineQueryResultVenue,
-        InlineQueryResultVideo,
-        InlineQueryResultVoice,
-    ]
+    result: InlineQueryResultUnion
     """A JSON-serialized object describing the message to be sent"""
     allow_user_chats: Optional[bool] = None
     """Pass :code:`True` if the message can be sent to private chats with users"""
@@ -78,28 +37,7 @@ class SavePreparedInlineMessage(TelegramMethod[PreparedInlineMessage]):
             __pydantic__self__,
             *,
             user_id: int,
-            result: Union[
-                InlineQueryResultCachedAudio,
-                InlineQueryResultCachedDocument,
-                InlineQueryResultCachedGif,
-                InlineQueryResultCachedMpeg4Gif,
-                InlineQueryResultCachedPhoto,
-                InlineQueryResultCachedSticker,
-                InlineQueryResultCachedVideo,
-                InlineQueryResultCachedVoice,
-                InlineQueryResultArticle,
-                InlineQueryResultAudio,
-                InlineQueryResultContact,
-                InlineQueryResultGame,
-                InlineQueryResultDocument,
-                InlineQueryResultGif,
-                InlineQueryResultLocation,
-                InlineQueryResultMpeg4Gif,
-                InlineQueryResultPhoto,
-                InlineQueryResultVenue,
-                InlineQueryResultVideo,
-                InlineQueryResultVoice,
-            ],
+            result: InlineQueryResultUnion,
             allow_user_chats: Optional[bool] = None,
             allow_bot_chats: Optional[bool] = None,
             allow_group_chats: Optional[bool] = None,

--- a/aiogram/methods/send_animation.py
+++ b/aiogram/methods/send_animation.py
@@ -6,13 +6,12 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     InputFile,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,9 +27,9 @@ class SendAnimation(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendAnimation"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    animation: Union[InputFile, str]
+    animation: InputFileUnion
     """Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -64,9 +63,7 @@ class SendAnimation(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -88,8 +85,8 @@ class SendAnimation(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            animation: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            animation: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             duration: Optional[int] = None,
@@ -108,9 +105,7 @@ class SendAnimation(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_audio.py
+++ b/aiogram/methods/send_audio.py
@@ -6,13 +6,12 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     InputFile,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -29,9 +28,9 @@ class SendAudio(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendAudio"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    audio: Union[InputFile, str]
+    audio: InputFileUnion
     """Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an audio file from the Internet, or upload a new one using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -61,9 +60,7 @@ class SendAudio(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -85,8 +82,8 @@ class SendAudio(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            audio: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            audio: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             caption: Optional[str] = None,
@@ -101,9 +98,7 @@ class SendAudio(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_chat_action.py
+++ b/aiogram/methods/send_chat_action.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -19,7 +20,7 @@ class SendChatAction(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "sendChatAction"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     action: str
     """Type of action to broadcast. Choose one, depending on what the user is about to receive: *typing* for `text messages <https://core.telegram.org/bots/api#sendmessage>`_, *upload_photo* for `photos <https://core.telegram.org/bots/api#sendphoto>`_, *record_video* or *upload_video* for `videos <https://core.telegram.org/bots/api#sendvideo>`_, *record_voice* or *upload_voice* for `voice notes <https://core.telegram.org/bots/api#sendvoice>`_, *upload_document* for `general files <https://core.telegram.org/bots/api#senddocument>`_, *choose_sticker* for `stickers <https://core.telegram.org/bots/api#sendsticker>`_, *find_location* for `location data <https://core.telegram.org/bots/api#sendlocation>`_, *record_video_note* or *upload_video_note* for `video notes <https://core.telegram.org/bots/api#sendvideonote>`_."""
@@ -35,7 +36,7 @@ class SendChatAction(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             action: str,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,

--- a/aiogram/methods/send_contact.py
+++ b/aiogram/methods/send_contact.py
@@ -5,14 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-    ReplyParameters,
-)
+from ..types import ChatIdUnion, Message, ReplyMarkupUnion, ReplyParameters
 from .base import TelegramMethod
 
 
@@ -26,7 +19,7 @@ class SendContact(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendContact"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     phone_number: str
     """Contact's phone number"""
@@ -50,9 +43,7 @@ class SendContact(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -74,7 +65,7 @@ class SendContact(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             phone_number: str,
             first_name: str,
             business_connection_id: Optional[str] = None,
@@ -86,9 +77,7 @@ class SendContact(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_dice.py
+++ b/aiogram/methods/send_dice.py
@@ -5,14 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-    ReplyParameters,
-)
+from ..types import ChatIdUnion, Message, ReplyMarkupUnion, ReplyParameters
 from .base import TelegramMethod
 
 
@@ -26,7 +19,7 @@ class SendDice(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendDice"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -44,9 +37,7 @@ class SendDice(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -68,7 +59,7 @@ class SendDice(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             emoji: Optional[str] = None,
@@ -77,9 +68,7 @@ class SendDice(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_document.py
+++ b/aiogram/methods/send_document.py
@@ -6,13 +6,12 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     InputFile,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,9 +27,9 @@ class SendDocument(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendDocument"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    document: Union[InputFile, str]
+    document: InputFileUnion
     """File to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -56,9 +55,7 @@ class SendDocument(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -80,8 +77,8 @@ class SendDocument(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            document: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            document: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             thumbnail: Optional[InputFile] = None,
@@ -94,9 +91,7 @@ class SendDocument(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_gift.py
+++ b/aiogram/methods/send_gift.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from ..types.message_entity import MessageEntity
 from .base import TelegramMethod
 
@@ -20,7 +21,7 @@ class SendGift(TelegramMethod[bool]):
     """Identifier of the gift"""
     user_id: Optional[int] = None
     """Required if *chat_id* is not specified. Unique identifier of the target user who will receive the gift."""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *user_id* is not specified. Unique identifier for the chat or username of the channel (in the format :code:`@channelusername`) that will receive the gift."""
     pay_for_upgrade: Optional[bool] = None
     """Pass :code:`True` to pay for the gift upgrade from the bot's balance, thereby making the upgrade free for the receiver"""
@@ -40,7 +41,7 @@ class SendGift(TelegramMethod[bool]):
             *,
             gift_id: str,
             user_id: Optional[int] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             pay_for_upgrade: Optional[bool] = None,
             text: Optional[str] = None,
             text_parse_mode: Optional[str] = None,

--- a/aiogram/methods/send_invoice.py
+++ b/aiogram/methods/send_invoice.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import InlineKeyboardMarkup, LabeledPrice, Message, ReplyParameters
+from ..types import (
+    ChatIdUnion,
+    InlineKeyboardMarkup,
+    LabeledPrice,
+    Message,
+    ReplyParameters,
+)
 from .base import TelegramMethod
 
 
@@ -19,7 +25,7 @@ class SendInvoice(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendInvoice"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     title: str
     """Product name, 1-32 characters"""
@@ -97,7 +103,7 @@ class SendInvoice(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             title: str,
             description: str,
             payload: str,

--- a/aiogram/methods/send_location.py
+++ b/aiogram/methods/send_location.py
@@ -5,14 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-    ReplyParameters,
-)
+from ..types import ChatIdUnion, Message, ReplyMarkupUnion, ReplyParameters
 from .base import TelegramMethod
 
 
@@ -26,7 +19,7 @@ class SendLocation(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendLocation"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     latitude: float
     """Latitude of the location"""
@@ -54,9 +47,7 @@ class SendLocation(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -78,7 +69,7 @@ class SendLocation(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             latitude: float,
             longitude: float,
             business_connection_id: Optional[str] = None,
@@ -92,9 +83,7 @@ class SendLocation(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_media_group.py
+++ b/aiogram/methods/send_media_group.py
@@ -5,14 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import (
-    InputMediaAudio,
-    InputMediaDocument,
-    InputMediaPhoto,
-    InputMediaVideo,
-    Message,
-    ReplyParameters,
-)
+from ..types import ChatIdUnion, MediaUnion, Message, ReplyParameters
 from .base import TelegramMethod
 
 
@@ -26,9 +19,9 @@ class SendMediaGroup(TelegramMethod[list[Message]]):
     __returning__ = list[Message]
     __api_method__ = "sendMediaGroup"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]]
+    media: list[MediaUnion]
     """A JSON-serialized array describing messages to be sent, must include 2-10 items"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -64,10 +57,8 @@ class SendMediaGroup(TelegramMethod[list[Message]]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            media: list[
-                Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]
-            ],
+            chat_id: ChatIdUnion,
+            media: list[MediaUnion],
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             disable_notification: Optional[bool] = None,

--- a/aiogram/methods/send_message.py
+++ b/aiogram/methods/send_message.py
@@ -6,13 +6,11 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     LinkPreviewOptions,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,7 +26,7 @@ class SendMessage(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     text: str
     """Text of the message to be sent, 1-4096 characters after entities parsing"""
@@ -52,9 +50,7 @@ class SendMessage(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -83,7 +79,7 @@ class SendMessage(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             text: str,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
@@ -97,9 +93,7 @@ class SendMessage(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             disable_web_page_preview: Optional[Union[bool, Default]] = Default(
                 "link_preview_is_disabled"

--- a/aiogram/methods/send_paid_media.py
+++ b/aiogram/methods/send_paid_media.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     InputPaidMediaUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -25,7 +23,7 @@ class SendPaidMedia(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendPaidMedia"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance."""
     star_count: int
     """The number of Telegram Stars that must be paid to buy access to the media; 1-2500"""
@@ -51,9 +49,7 @@ class SendPaidMedia(TelegramMethod[Message]):
     """Pass :code:`True` to allow up to 1000 messages per second, ignoring `broadcasting limits <https://core.telegram.org/bots/faq#how-can-i-message-all-of-my-bot-39s-subscribers-at-once>`_ for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
 
     if TYPE_CHECKING:
@@ -63,7 +59,7 @@ class SendPaidMedia(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             star_count: int,
             media: list[InputPaidMediaUnion],
             business_connection_id: Optional[str] = None,
@@ -76,9 +72,7 @@ class SendPaidMedia(TelegramMethod[Message]):
             protect_content: Optional[bool] = None,
             allow_paid_broadcast: Optional[bool] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/send_paid_media.py
+++ b/aiogram/methods/send_paid_media.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from ..types import (
     ForceReply,
     InlineKeyboardMarkup,
-    InputPaidMediaPhoto,
-    InputPaidMediaVideo,
+    InputPaidMediaUnion,
     Message,
     MessageEntity,
     ReplyKeyboardMarkup,
@@ -30,7 +29,7 @@ class SendPaidMedia(TelegramMethod[Message]):
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance."""
     star_count: int
     """The number of Telegram Stars that must be paid to buy access to the media; 1-2500"""
-    media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]]
+    media: list[InputPaidMediaUnion]
     """A JSON-serialized array describing the media to be sent; up to 10 items"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -66,7 +65,7 @@ class SendPaidMedia(TelegramMethod[Message]):
             *,
             chat_id: Union[int, str],
             star_count: int,
-            media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+            media: list[InputPaidMediaUnion],
             business_connection_id: Optional[str] = None,
             payload: Optional[str] = None,
             caption: Optional[str] = None,

--- a/aiogram/methods/send_photo.py
+++ b/aiogram/methods/send_photo.py
@@ -6,13 +6,11 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    InputFile,
+    ChatIdUnion,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,9 +26,9 @@ class SendPhoto(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendPhoto"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    photo: Union[InputFile, str]
+    photo: InputFileUnion
     """Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a photo from the Internet, or upload a new photo using multipart/form-data. The photo must be at most 10 MB in size. The photo's width and height must not exceed 10000 in total. Width and height ratio must be at most 20. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -56,9 +54,7 @@ class SendPhoto(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -80,8 +76,8 @@ class SendPhoto(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            photo: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            photo: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             caption: Optional[str] = None,
@@ -96,9 +92,7 @@ class SendPhoto(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_poll.py
+++ b/aiogram/methods/send_poll.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    InputPollOption,
+    ChatIdUnion,
+    DateTimeUnion,
+    InputPollOptionUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -29,11 +27,11 @@ class SendPoll(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendPoll"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     question: str
     """Poll question, 1-300 characters"""
-    options: list[Union[InputPollOption, str]]
+    options: list[InputPollOptionUnion]
     """A JSON-serialized list of 2-10 answer options"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -59,7 +57,7 @@ class SendPoll(TelegramMethod[Message]):
     """A JSON-serialized list of special entities that appear in the poll explanation. It can be specified instead of *explanation_parse_mode*"""
     open_period: Optional[int] = None
     """Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with *close_date*."""
-    close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    close_date: Optional[DateTimeUnion] = None
     """Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with *open_period*."""
     is_closed: Optional[bool] = None
     """Pass :code:`True` if the poll needs to be immediately closed. This can be useful for poll preview."""
@@ -73,9 +71,7 @@ class SendPoll(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -97,9 +93,9 @@ class SendPoll(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             question: str,
-            options: list[Union[InputPollOption, str]],
+            options: list[InputPollOptionUnion],
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -112,16 +108,14 @@ class SendPoll(TelegramMethod[Message]):
             explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             explanation_entities: Optional[list[MessageEntity]] = None,
             open_period: Optional[int] = None,
-            close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            close_date: Optional[DateTimeUnion] = None,
             is_closed: Optional[bool] = None,
             disable_notification: Optional[bool] = None,
             protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_sticker.py
+++ b/aiogram/methods/send_sticker.py
@@ -6,12 +6,10 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    InputFile,
+    ChatIdUnion,
+    InputFileUnion,
     Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -27,9 +25,9 @@ class SendSticker(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendSticker"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    sticker: Union[InputFile, str]
+    sticker: InputFileUnion
     """Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP, .TGS, or .WEBM sticker using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`. Video and animated stickers can't be sent via an HTTP URL."""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -47,9 +45,7 @@ class SendSticker(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -71,8 +67,8 @@ class SendSticker(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            sticker: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            sticker: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             emoji: Optional[str] = None,
@@ -81,9 +77,7 @@ class SendSticker(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_venue.py
+++ b/aiogram/methods/send_venue.py
@@ -5,14 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from pydantic import Field
 
 from ..client.default import Default
-from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-    ReplyParameters,
-)
+from ..types import ChatIdUnion, Message, ReplyMarkupUnion, ReplyParameters
 from .base import TelegramMethod
 
 
@@ -26,7 +19,7 @@ class SendVenue(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendVenue"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     latitude: float
     """Latitude of the venue"""
@@ -58,9 +51,7 @@ class SendVenue(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -82,7 +73,7 @@ class SendVenue(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             latitude: float,
             longitude: float,
             title: str,
@@ -98,9 +89,7 @@ class SendVenue(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_video.py
+++ b/aiogram/methods/send_video.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
+    DateTimeUnion,
     InputFile,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -29,9 +28,9 @@ class SendVideo(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendVideo"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    video: Union[InputFile, str]
+    video: InputFileUnion
     """Video to send. Pass a file_id as String to send a video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -45,9 +44,9 @@ class SendVideo(TelegramMethod[Message]):
     """Video height"""
     thumbnail: Optional[InputFile] = None
     """Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
-    cover: Optional[Union[InputFile, str]] = None
+    cover: Optional[InputFileUnion] = None
     """Cover for the video in the message. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
-    start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    start_timestamp: Optional[DateTimeUnion] = None
     """Start timestamp for the video in the message"""
     caption: Optional[str] = None
     """Video caption (may also be used when resending videos by *file_id*), 0-1024 characters after entities parsing"""
@@ -71,9 +70,7 @@ class SendVideo(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -95,16 +92,16 @@ class SendVideo(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            video: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            video: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             duration: Optional[int] = None,
             width: Optional[int] = None,
             height: Optional[int] = None,
             thumbnail: Optional[InputFile] = None,
-            cover: Optional[Union[InputFile, str]] = None,
-            start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            cover: Optional[InputFileUnion] = None,
+            start_timestamp: Optional[DateTimeUnion] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,
@@ -118,9 +115,7 @@ class SendVideo(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_video_note.py
+++ b/aiogram/methods/send_video_note.py
@@ -6,12 +6,11 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
+    ChatIdUnion,
     InputFile,
+    InputFileUnion,
     Message,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -27,9 +26,9 @@ class SendVideoNote(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendVideoNote"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    video_note: Union[InputFile, str]
+    video_note: InputFileUnion
     """Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`. Sending video notes by a URL is currently unsupported"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -51,9 +50,7 @@ class SendVideoNote(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -75,8 +72,8 @@ class SendVideoNote(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            video_note: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            video_note: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             duration: Optional[int] = None,
@@ -87,9 +84,7 @@ class SendVideoNote(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/send_voice.py
+++ b/aiogram/methods/send_voice.py
@@ -6,13 +6,11 @@ from pydantic import Field
 
 from ..client.default import Default
 from ..types import (
-    ForceReply,
-    InlineKeyboardMarkup,
-    InputFile,
+    ChatIdUnion,
+    InputFileUnion,
     Message,
     MessageEntity,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
+    ReplyMarkupUnion,
     ReplyParameters,
 )
 from .base import TelegramMethod
@@ -28,9 +26,9 @@ class SendVoice(TelegramMethod[Message]):
     __returning__ = Message
     __api_method__ = "sendVoice"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
-    voice: Union[InputFile, str]
+    voice: InputFileUnion
     """Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be sent"""
@@ -54,9 +52,7 @@ class SendVoice(TelegramMethod[Message]):
     """Unique identifier of the message effect to be added to the message; for private chats only"""
     reply_parameters: Optional[ReplyParameters] = None
     """Description of the message to reply to"""
-    reply_markup: Optional[
-        Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-    ] = None
+    reply_markup: Optional[ReplyMarkupUnion] = None
     """Additional interface options. A JSON-serialized object for an `inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_, `custom reply keyboard <https://core.telegram.org/bots/features#keyboards>`_, instructions to remove a reply keyboard or to force a reply from the user"""
     allow_sending_without_reply: Optional[bool] = Field(
         None, json_schema_extra={"deprecated": True}
@@ -78,8 +74,8 @@ class SendVoice(TelegramMethod[Message]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
-            voice: Union[InputFile, str],
+            chat_id: ChatIdUnion,
+            voice: InputFileUnion,
             business_connection_id: Optional[str] = None,
             message_thread_id: Optional[int] = None,
             caption: Optional[str] = None,
@@ -91,9 +87,7 @@ class SendVoice(TelegramMethod[Message]):
             allow_paid_broadcast: Optional[bool] = None,
             message_effect_id: Optional[str] = None,
             reply_parameters: Optional[ReplyParameters] = None,
-            reply_markup: Optional[
-                Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-            ] = None,
+            reply_markup: Optional[ReplyMarkupUnion] = None,
             allow_sending_without_reply: Optional[bool] = None,
             reply_to_message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/set_chat_administrator_custom_title.py
+++ b/aiogram/methods/set_chat_administrator_custom_title.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class SetChatAdministratorCustomTitle(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatAdministratorCustomTitle"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -29,7 +30,7 @@ class SetChatAdministratorCustomTitle(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
             custom_title: str,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/set_chat_description.py
+++ b/aiogram/methods/set_chat_description.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class SetChatDescription(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatDescription"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     description: Optional[str] = None
     """New chat description, 0-255 characters"""
@@ -27,7 +28,7 @@ class SetChatDescription(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             description: Optional[str] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/set_chat_menu_button.py
+++ b/aiogram/methods/set_chat_menu_button.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import MenuButtonCommands, MenuButtonDefault, MenuButtonWebApp
+from ..types import MenuButtonUnion
 from .base import TelegramMethod
 
 
@@ -18,7 +18,7 @@ class SetChatMenuButton(TelegramMethod[bool]):
 
     chat_id: Optional[int] = None
     """Unique identifier for the target private chat. If not specified, default bot's menu button will be changed"""
-    menu_button: Optional[Union[MenuButtonCommands, MenuButtonWebApp, MenuButtonDefault]] = None
+    menu_button: Optional[MenuButtonUnion] = None
     """A JSON-serialized object for the bot's new menu button. Defaults to :class:`aiogram.types.menu_button_default.MenuButtonDefault`"""
 
     if TYPE_CHECKING:
@@ -29,9 +29,7 @@ class SetChatMenuButton(TelegramMethod[bool]):
             __pydantic__self__,
             *,
             chat_id: Optional[int] = None,
-            menu_button: Optional[
-                Union[MenuButtonCommands, MenuButtonWebApp, MenuButtonDefault]
-            ] = None,
+            menu_button: Optional[MenuButtonUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/set_chat_permissions.py
+++ b/aiogram/methods/set_chat_permissions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ChatPermissions
+from ..types import ChatIdUnion, ChatPermissions
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class SetChatPermissions(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatPermissions"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     permissions: ChatPermissions
     """A JSON-serialized object for new default chat permissions"""
@@ -30,7 +30,7 @@ class SetChatPermissions(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             permissions: ChatPermissions,
             use_independent_chat_permissions: Optional[bool] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/set_chat_photo.py
+++ b/aiogram/methods/set_chat_photo.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import InputFile
+from ..types import ChatIdUnion, InputFile
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class SetChatPhoto(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatPhoto"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     photo: InputFile
     """New chat photo, uploaded using multipart/form-data"""
@@ -26,11 +26,7 @@ class SetChatPhoto(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__,
-            *,
-            chat_id: Union[int, str],
-            photo: InputFile,
-            **__pydantic_kwargs: Any,
+            __pydantic__self__, *, chat_id: ChatIdUnion, photo: InputFile, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/set_chat_sticker_set.py
+++ b/aiogram/methods/set_chat_sticker_set.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class SetChatStickerSet(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatStickerSet"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     sticker_set_name: str
     """Name of the sticker set to be set as the group sticker set"""
@@ -27,7 +28,7 @@ class SetChatStickerSet(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             sticker_set_name: str,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/set_chat_title.py
+++ b/aiogram/methods/set_chat_title.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class SetChatTitle(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setChatTitle"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     title: str
     """New chat title, 1-128 characters"""
@@ -25,7 +26,7 @@ class SetChatTitle(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], title: str, **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, title: str, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/set_message_reaction.py
+++ b/aiogram/methods/set_message_reaction.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import ReactionTypeCustomEmoji, ReactionTypeEmoji, ReactionTypePaid
+from ..types import ReactionTypeUnion
 from .base import TelegramMethod
 
 
@@ -18,9 +18,7 @@ class SetMessageReaction(TelegramMethod[bool]):
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: int
     """Identifier of the target message. If the message belongs to a media group, the reaction is set to the first non-deleted message in the group instead."""
-    reaction: Optional[
-        list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-    ] = None
+    reaction: Optional[list[ReactionTypeUnion]] = None
     """A JSON-serialized list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators. Paid reactions can't be used by bots."""
     is_big: Optional[bool] = None
     """Pass :code:`True` to set the reaction with a big animation"""
@@ -34,9 +32,7 @@ class SetMessageReaction(TelegramMethod[bool]):
             *,
             chat_id: Union[int, str],
             message_id: int,
-            reaction: Optional[
-                list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-            ] = None,
+            reaction: Optional[list[ReactionTypeUnion]] = None,
             is_big: Optional[bool] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/set_message_reaction.py
+++ b/aiogram/methods/set_message_reaction.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import ReactionTypeUnion
+from ..types import ChatIdUnion, ReactionTypeUnion
 from .base import TelegramMethod
 
 
@@ -14,7 +14,7 @@ class SetMessageReaction(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "setMessageReaction"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: int
     """Identifier of the target message. If the message belongs to a media group, the reaction is set to the first non-deleted message in the group instead."""
@@ -30,7 +30,7 @@ class SetMessageReaction(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_id: int,
             reaction: Optional[list[ReactionTypeUnion]] = None,
             is_big: Optional[bool] = None,

--- a/aiogram/methods/set_my_commands.py
+++ b/aiogram/methods/set_my_commands.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import (
-    BotCommand,
-    BotCommandScopeAllChatAdministrators,
-    BotCommandScopeAllGroupChats,
-    BotCommandScopeAllPrivateChats,
-    BotCommandScopeChat,
-    BotCommandScopeChatAdministrators,
-    BotCommandScopeChatMember,
-    BotCommandScopeDefault,
-)
+from ..types import BotCommand, BotCommandScopeUnion
 from .base import TelegramMethod
 
 
@@ -27,17 +18,7 @@ class SetMyCommands(TelegramMethod[bool]):
 
     commands: list[BotCommand]
     """A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified."""
-    scope: Optional[
-        Union[
-            BotCommandScopeDefault,
-            BotCommandScopeAllPrivateChats,
-            BotCommandScopeAllGroupChats,
-            BotCommandScopeAllChatAdministrators,
-            BotCommandScopeChat,
-            BotCommandScopeChatAdministrators,
-            BotCommandScopeChatMember,
-        ]
-    ] = None
+    scope: Optional[BotCommandScopeUnion] = None
     """A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to :class:`aiogram.types.bot_command_scope_default.BotCommandScopeDefault`."""
     language_code: Optional[str] = None
     """A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands"""
@@ -50,17 +31,7 @@ class SetMyCommands(TelegramMethod[bool]):
             __pydantic__self__,
             *,
             commands: list[BotCommand],
-            scope: Optional[
-                Union[
-                    BotCommandScopeDefault,
-                    BotCommandScopeAllPrivateChats,
-                    BotCommandScopeAllGroupChats,
-                    BotCommandScopeAllChatAdministrators,
-                    BotCommandScopeChat,
-                    BotCommandScopeChatAdministrators,
-                    BotCommandScopeChatMember,
-                ]
-            ] = None,
+            scope: Optional[BotCommandScopeUnion] = None,
             language_code: Optional[str] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/set_passport_data_errors.py
+++ b/aiogram/methods/set_passport_data_errors.py
@@ -1,18 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
-from ..types import (
-    PassportElementErrorDataField,
-    PassportElementErrorFile,
-    PassportElementErrorFiles,
-    PassportElementErrorFrontSide,
-    PassportElementErrorReverseSide,
-    PassportElementErrorSelfie,
-    PassportElementErrorTranslationFile,
-    PassportElementErrorTranslationFiles,
-    PassportElementErrorUnspecified,
-)
+from ..types import PassportElementErrorUnion
 from .base import TelegramMethod
 
 
@@ -29,19 +19,7 @@ class SetPassportDataErrors(TelegramMethod[bool]):
 
     user_id: int
     """User identifier"""
-    errors: list[
-        Union[
-            PassportElementErrorDataField,
-            PassportElementErrorFrontSide,
-            PassportElementErrorReverseSide,
-            PassportElementErrorSelfie,
-            PassportElementErrorFile,
-            PassportElementErrorFiles,
-            PassportElementErrorTranslationFile,
-            PassportElementErrorTranslationFiles,
-            PassportElementErrorUnspecified,
-        ]
-    ]
+    errors: list[PassportElementErrorUnion]
     """A JSON-serialized array describing the errors"""
 
     if TYPE_CHECKING:
@@ -52,19 +30,7 @@ class SetPassportDataErrors(TelegramMethod[bool]):
             __pydantic__self__,
             *,
             user_id: int,
-            errors: list[
-                Union[
-                    PassportElementErrorDataField,
-                    PassportElementErrorFrontSide,
-                    PassportElementErrorReverseSide,
-                    PassportElementErrorSelfie,
-                    PassportElementErrorFile,
-                    PassportElementErrorFiles,
-                    PassportElementErrorTranslationFile,
-                    PassportElementErrorTranslationFiles,
-                    PassportElementErrorUnspecified,
-                ]
-            ],
+            errors: list[PassportElementErrorUnion],
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/set_sticker_set_thumbnail.py
+++ b/aiogram/methods/set_sticker_set_thumbnail.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import InputFile
+from ..types import InputFileUnion
 from .base import TelegramMethod
 
 
@@ -22,7 +22,7 @@ class SetStickerSetThumbnail(TelegramMethod[bool]):
     """User identifier of the sticker set owner"""
     format: str
     """Format of the thumbnail, must be one of 'static' for a **.WEBP** or **.PNG** image, 'animated' for a **.TGS** animation, or 'video' for a **.WEBM** video"""
-    thumbnail: Optional[Union[InputFile, str]] = None
+    thumbnail: Optional[InputFileUnion] = None
     """A **.WEBP** or **.PNG** image with the thumbnail, must be up to 128 kilobytes in size and have a width and height of exactly 100px, or a **.TGS** animation with a thumbnail up to 32 kilobytes in size (see `https://core.telegram.org/stickers#animation-requirements <https://core.telegram.org/stickers#animation-requirements>`_`https://core.telegram.org/stickers#animation-requirements <https://core.telegram.org/stickers#animation-requirements>`_ for animated sticker technical requirements), or a **.WEBM** video with the thumbnail up to 32 kilobytes in size; see `https://core.telegram.org/stickers#video-requirements <https://core.telegram.org/stickers#video-requirements>`_`https://core.telegram.org/stickers#video-requirements <https://core.telegram.org/stickers#video-requirements>`_ for video sticker technical requirements. Pass a *file_id* as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. :ref:`More information on Sending Files » <sending-files>`. Animated and video sticker set thumbnails can't be uploaded via HTTP URL. If omitted, then the thumbnail is dropped and the first sticker is used as the thumbnail."""
 
     if TYPE_CHECKING:
@@ -35,7 +35,7 @@ class SetStickerSetThumbnail(TelegramMethod[bool]):
             name: str,
             user_id: int,
             format: str,
-            thumbnail: Optional[Union[InputFile, str]] = None,
+            thumbnail: Optional[InputFileUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/set_user_emoji_status.py
+++ b/aiogram/methods/set_user_emoji_status.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import DateTimeUnion
 from .base import TelegramMethod
 
 
@@ -20,9 +20,7 @@ class SetUserEmojiStatus(TelegramMethod[bool]):
     """Unique identifier of the target user"""
     emoji_status_custom_emoji_id: Optional[str] = None
     """Custom emoji identifier of the emoji status to set. Pass an empty string to remove the status."""
-    emoji_status_expiration_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = (
-        None
-    )
+    emoji_status_expiration_date: Optional[DateTimeUnion] = None
     """Expiration date of the emoji status, if any"""
 
     if TYPE_CHECKING:
@@ -34,9 +32,7 @@ class SetUserEmojiStatus(TelegramMethod[bool]):
             *,
             user_id: int,
             emoji_status_custom_emoji_id: Optional[str] = None,
-            emoji_status_expiration_date: Optional[
-                Union[datetime.datetime, datetime.timedelta, int]
-            ] = None,
+            emoji_status_expiration_date: Optional[DateTimeUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/methods/stop_message_live_location.py
+++ b/aiogram/methods/stop_message_live_location.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from ..types import InlineKeyboardMarkup, Message
+from ..types import ChatIdUnion, InlineKeyboardMarkup, Message
 from .base import TelegramMethod
 
 
@@ -18,7 +18,7 @@ class StopMessageLiveLocation(TelegramMethod[Union[Message, bool]]):
 
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message to be edited was sent"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """Required if *inline_message_id* is not specified. Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: Optional[int] = None
     """Required if *inline_message_id* is not specified. Identifier of the message with live location to stop"""
@@ -35,7 +35,7 @@ class StopMessageLiveLocation(TelegramMethod[Union[Message, bool]]):
             __pydantic__self__,
             *,
             business_connection_id: Optional[str] = None,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             message_id: Optional[int] = None,
             inline_message_id: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,

--- a/aiogram/methods/stop_poll.py
+++ b/aiogram/methods/stop_poll.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from ..types import InlineKeyboardMarkup, Poll
+from ..types import ChatIdUnion, InlineKeyboardMarkup, Poll
 from .base import TelegramMethod
 
 
@@ -16,7 +16,7 @@ class StopPoll(TelegramMethod[Poll]):
     __returning__ = Poll
     __api_method__ = "stopPoll"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     message_id: int
     """Identifier of the original message with the poll"""
@@ -32,7 +32,7 @@ class StopPoll(TelegramMethod[Poll]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_id: int,
             business_connection_id: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,

--- a/aiogram/methods/unban_chat_member.py
+++ b/aiogram/methods/unban_chat_member.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnbanChatMember(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unbanChatMember"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target group or username of the target supergroup or channel (in the format :code:`@channelusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -29,7 +30,7 @@ class UnbanChatMember(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
             only_if_banned: Optional[bool] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/unban_chat_sender_chat.py
+++ b/aiogram/methods/unban_chat_sender_chat.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnbanChatSenderChat(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unbanChatSenderChat"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     sender_chat_id: int
     """Unique identifier of the target sender chat"""
@@ -27,7 +28,7 @@ class UnbanChatSenderChat(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             sender_chat_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/unhide_general_forum_topic.py
+++ b/aiogram/methods/unhide_general_forum_topic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnhideGeneralForumTopic(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unhideGeneralForumTopic"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class UnhideGeneralForumTopic(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/unpin_all_chat_messages.py
+++ b/aiogram/methods/unpin_all_chat_messages.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnpinAllChatMessages(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unpinAllChatMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
 
     if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class UnpinAllChatMessages(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/unpin_all_forum_topic_messages.py
+++ b/aiogram/methods/unpin_all_forum_topic_messages.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnpinAllForumTopicMessages(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unpinAllForumTopicMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     message_thread_id: int
     """Unique identifier for the target message thread of the forum topic"""
@@ -27,7 +28,7 @@ class UnpinAllForumTopicMessages(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             message_thread_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/methods/unpin_all_general_forum_topic_messages.py
+++ b/aiogram/methods/unpin_all_general_forum_topic_messages.py
@@ -1,6 +1,8 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from aiogram.methods import TelegramMethod
+
+from ..types import ChatIdUnion
 
 
 class UnpinAllGeneralForumTopicMessages(TelegramMethod[bool]):
@@ -13,7 +15,7 @@ class UnpinAllGeneralForumTopicMessages(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unpinAllGeneralForumTopicMessages"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -21,7 +23,7 @@ class UnpinAllGeneralForumTopicMessages(TelegramMethod[bool]):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__, *, chat_id: Union[int, str], **__pydantic_kwargs: Any
+            __pydantic__self__, *, chat_id: ChatIdUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/methods/unpin_chat_message.py
+++ b/aiogram/methods/unpin_chat_message.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class UnpinChatMessage(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "unpinChatMessage"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     business_connection_id: Optional[str] = None
     """Unique identifier of the business connection on behalf of which the message will be unpinned"""
@@ -29,7 +30,7 @@ class UnpinChatMessage(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             business_connection_id: Optional[str] = None,
             message_id: Optional[int] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/methods/verify_chat.py
+++ b/aiogram/methods/verify_chat.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
+from ..types import ChatIdUnion
 from .base import TelegramMethod
 
 
@@ -15,7 +16,7 @@ class VerifyChat(TelegramMethod[bool]):
     __returning__ = bool
     __api_method__ = "verifyChat"
 
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target channel (in the format :code:`@channelusername`)"""
     custom_description: Optional[str] = None
     """Custom description for the verification; 0-70 characters. Must be empty if the organization isn't allowed to provide a custom verification description."""
@@ -27,7 +28,7 @@ class VerifyChat(TelegramMethod[bool]):
         def __init__(
             __pydantic__self__,
             *,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             custom_description: Optional[str] = None,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -220,6 +220,8 @@ from .reply_keyboard_remove import ReplyKeyboardRemove
 from .reply_markup_union import ReplyMarkupUnion
 from .reply_parameters import ReplyParameters
 from .response_parameters import ResponseParameters
+from .result_chat_member_union import ResultChatMemberUnion
+from .result_menu_button_union import ResultMenuButtonUnion
 from .revenue_withdrawal_state import RevenueWithdrawalState
 from .revenue_withdrawal_state_failed import RevenueWithdrawalStateFailed
 from .revenue_withdrawal_state_pending import RevenueWithdrawalStatePending
@@ -485,6 +487,8 @@ __all__ = (
     "ReplyMarkupUnion",
     "ReplyParameters",
     "ResponseParameters",
+    "ResultChatMemberUnion",
+    "ResultMenuButtonUnion",
     "RevenueWithdrawalState",
     "RevenueWithdrawalStateFailed",
     "RevenueWithdrawalStatePending",

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -7,10 +7,12 @@ from .background_fill import BackgroundFill
 from .background_fill_freeform_gradient import BackgroundFillFreeformGradient
 from .background_fill_gradient import BackgroundFillGradient
 from .background_fill_solid import BackgroundFillSolid
+from .background_fill_union import BackgroundFillUnion
 from .background_type import BackgroundType
 from .background_type_chat_theme import BackgroundTypeChatTheme
 from .background_type_fill import BackgroundTypeFill
 from .background_type_pattern import BackgroundTypePattern
+from .background_type_union import BackgroundTypeUnion
 from .background_type_wallpaper import BackgroundTypeWallpaper
 from .base import UNSET_PARSE_MODE, TelegramObject
 from .birthdate import Birthdate
@@ -25,6 +27,7 @@ from .bot_command_scope_chat import BotCommandScopeChat
 from .bot_command_scope_chat_administrators import BotCommandScopeChatAdministrators
 from .bot_command_scope_chat_member import BotCommandScopeChatMember
 from .bot_command_scope_default import BotCommandScopeDefault
+from .bot_command_scope_union import BotCommandScopeUnion
 from .bot_description import BotDescription
 from .bot_name import BotName
 from .bot_short_description import BotShortDescription
@@ -46,8 +49,10 @@ from .chat_boost_source import ChatBoostSource
 from .chat_boost_source_gift_code import ChatBoostSourceGiftCode
 from .chat_boost_source_giveaway import ChatBoostSourceGiveaway
 from .chat_boost_source_premium import ChatBoostSourcePremium
+from .chat_boost_source_union import ChatBoostSourceUnion
 from .chat_boost_updated import ChatBoostUpdated
 from .chat_full_info import ChatFullInfo
+from .chat_id_union import ChatIdUnion
 from .chat_invite_link import ChatInviteLink
 from .chat_join_request import ChatJoinRequest
 from .chat_location import ChatLocation
@@ -58,6 +63,7 @@ from .chat_member_left import ChatMemberLeft
 from .chat_member_member import ChatMemberMember
 from .chat_member_owner import ChatMemberOwner
 from .chat_member_restricted import ChatMemberRestricted
+from .chat_member_union import ChatMemberUnion
 from .chat_member_updated import ChatMemberUpdated
 from .chat_permissions import ChatPermissions
 from .chat_photo import ChatPhoto
@@ -66,6 +72,7 @@ from .chosen_inline_result import ChosenInlineResult
 from .contact import Contact
 from .copy_text_button import CopyTextButton
 from .custom import DateTime
+from .date_time_union import DateTimeUnion
 from .dice import Dice
 from .document import Document
 from .downloadable import Downloadable
@@ -112,12 +119,14 @@ from .inline_query_result_gif import InlineQueryResultGif
 from .inline_query_result_location import InlineQueryResultLocation
 from .inline_query_result_mpeg4_gif import InlineQueryResultMpeg4Gif
 from .inline_query_result_photo import InlineQueryResultPhoto
+from .inline_query_result_union import InlineQueryResultUnion
 from .inline_query_result_venue import InlineQueryResultVenue
 from .inline_query_result_video import InlineQueryResultVideo
 from .inline_query_result_voice import InlineQueryResultVoice
 from .inline_query_results_button import InlineQueryResultsButton
 from .input_contact_message_content import InputContactMessageContent
 from .input_file import BufferedInputFile, FSInputFile, InputFile, URLInputFile
+from .input_file_union import InputFileUnion
 from .input_invoice_message_content import InputInvoiceMessageContent
 from .input_location_message_content import InputLocationMessageContent
 from .input_media import InputMedia
@@ -125,12 +134,16 @@ from .input_media_animation import InputMediaAnimation
 from .input_media_audio import InputMediaAudio
 from .input_media_document import InputMediaDocument
 from .input_media_photo import InputMediaPhoto
+from .input_media_union import InputMediaUnion
 from .input_media_video import InputMediaVideo
 from .input_message_content import InputMessageContent
+from .input_message_content_union import InputMessageContentUnion
 from .input_paid_media import InputPaidMedia
 from .input_paid_media_photo import InputPaidMediaPhoto
+from .input_paid_media_union import InputPaidMediaUnion
 from .input_paid_media_video import InputPaidMediaVideo
 from .input_poll_option import InputPollOption
+from .input_poll_option_union import InputPollOptionUnion
 from .input_sticker import InputSticker
 from .input_text_message_content import InputTextMessageContent
 from .input_venue_message_content import InputVenueMessageContent
@@ -146,9 +159,11 @@ from .location import Location
 from .login_url import LoginUrl
 from .mask_position import MaskPosition
 from .maybe_inaccessible_message import MaybeInaccessibleMessage
+from .maybe_inaccessible_message_union import MaybeInaccessibleMessageUnion
 from .menu_button import MenuButton
 from .menu_button_commands import MenuButtonCommands
 from .menu_button_default import MenuButtonDefault
+from .menu_button_union import MenuButtonUnion
 from .menu_button_web_app import MenuButtonWebApp
 from .message import ContentType, Message
 from .message_auto_delete_timer_changed import MessageAutoDeleteTimerChanged
@@ -158,6 +173,7 @@ from .message_origin import MessageOrigin
 from .message_origin_channel import MessageOriginChannel
 from .message_origin_chat import MessageOriginChat
 from .message_origin_hidden_user import MessageOriginHiddenUser
+from .message_origin_union import MessageOriginUnion
 from .message_origin_user import MessageOriginUser
 from .message_reaction_count_updated import MessageReactionCountUpdated
 from .message_reaction_updated import MessageReactionUpdated
@@ -167,6 +183,7 @@ from .paid_media_info import PaidMediaInfo
 from .paid_media_photo import PaidMediaPhoto
 from .paid_media_preview import PaidMediaPreview
 from .paid_media_purchased import PaidMediaPurchased
+from .paid_media_union import PaidMediaUnion
 from .paid_media_video import PaidMediaVideo
 from .passport_data import PassportData
 from .passport_element_error import PassportElementError
@@ -180,6 +197,7 @@ from .passport_element_error_translation_file import PassportElementErrorTransla
 from .passport_element_error_translation_files import (
     PassportElementErrorTranslationFiles,
 )
+from .passport_element_error_union import PassportElementErrorUnion
 from .passport_element_error_unspecified import PassportElementErrorUnspecified
 from .passport_file import PassportFile
 from .photo_size import PhotoSize
@@ -194,15 +212,18 @@ from .reaction_type import ReactionType
 from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
 from .reaction_type_emoji import ReactionTypeEmoji
 from .reaction_type_paid import ReactionTypePaid
+from .reaction_type_union import ReactionTypeUnion
 from .refunded_payment import RefundedPayment
 from .reply_keyboard_markup import ReplyKeyboardMarkup
 from .reply_keyboard_remove import ReplyKeyboardRemove
+from .reply_markup_union import ReplyMarkupUnion
 from .reply_parameters import ReplyParameters
 from .response_parameters import ResponseParameters
 from .revenue_withdrawal_state import RevenueWithdrawalState
 from .revenue_withdrawal_state_failed import RevenueWithdrawalStateFailed
 from .revenue_withdrawal_state_pending import RevenueWithdrawalStatePending
 from .revenue_withdrawal_state_succeeded import RevenueWithdrawalStateSucceeded
+from .revenue_withdrawal_state_union import RevenueWithdrawalStateUnion
 from .sent_web_app_message import SentWebAppMessage
 from .shared_user import SharedUser
 from .shipping_address import ShippingAddress
@@ -223,6 +244,7 @@ from .transaction_partner_fragment import TransactionPartnerFragment
 from .transaction_partner_other import TransactionPartnerOther
 from .transaction_partner_telegram_ads import TransactionPartnerTelegramAds
 from .transaction_partner_telegram_api import TransactionPartnerTelegramApi
+from .transaction_partner_union import TransactionPartnerUnion
 from .transaction_partner_user import TransactionPartnerUser
 from .update import Update
 from .user import User
@@ -251,10 +273,12 @@ __all__ = (
     "BackgroundFillFreeformGradient",
     "BackgroundFillGradient",
     "BackgroundFillSolid",
+    "BackgroundFillUnion",
     "BackgroundType",
     "BackgroundTypeChatTheme",
     "BackgroundTypeFill",
     "BackgroundTypePattern",
+    "BackgroundTypeUnion",
     "BackgroundTypeWallpaper",
     "Birthdate",
     "BotCommand",
@@ -266,6 +290,7 @@ __all__ = (
     "BotCommandScopeChatAdministrators",
     "BotCommandScopeChatMember",
     "BotCommandScopeDefault",
+    "BotCommandScopeUnion",
     "BotDescription",
     "BotName",
     "BotShortDescription",
@@ -288,8 +313,10 @@ __all__ = (
     "ChatBoostSourceGiftCode",
     "ChatBoostSourceGiveaway",
     "ChatBoostSourcePremium",
+    "ChatBoostSourceUnion",
     "ChatBoostUpdated",
     "ChatFullInfo",
+    "ChatIdUnion",
     "ChatInviteLink",
     "ChatJoinRequest",
     "ChatLocation",
@@ -300,6 +327,7 @@ __all__ = (
     "ChatMemberMember",
     "ChatMemberOwner",
     "ChatMemberRestricted",
+    "ChatMemberUnion",
     "ChatMemberUpdated",
     "ChatPermissions",
     "ChatPhoto",
@@ -309,6 +337,7 @@ __all__ = (
     "ContentType",
     "CopyTextButton",
     "DateTime",
+    "DateTimeUnion",
     "Dice",
     "Document",
     "Downloadable",
@@ -356,12 +385,14 @@ __all__ = (
     "InlineQueryResultLocation",
     "InlineQueryResultMpeg4Gif",
     "InlineQueryResultPhoto",
+    "InlineQueryResultUnion",
     "InlineQueryResultVenue",
     "InlineQueryResultVideo",
     "InlineQueryResultVoice",
     "InlineQueryResultsButton",
     "InputContactMessageContent",
     "InputFile",
+    "InputFileUnion",
     "InputInvoiceMessageContent",
     "InputLocationMessageContent",
     "InputMedia",
@@ -369,12 +400,16 @@ __all__ = (
     "InputMediaAudio",
     "InputMediaDocument",
     "InputMediaPhoto",
+    "InputMediaUnion",
     "InputMediaVideo",
     "InputMessageContent",
+    "InputMessageContentUnion",
     "InputPaidMedia",
     "InputPaidMediaPhoto",
+    "InputPaidMediaUnion",
     "InputPaidMediaVideo",
     "InputPollOption",
+    "InputPollOptionUnion",
     "InputSticker",
     "InputTextMessageContent",
     "InputVenueMessageContent",
@@ -390,9 +425,11 @@ __all__ = (
     "LoginUrl",
     "MaskPosition",
     "MaybeInaccessibleMessage",
+    "MaybeInaccessibleMessageUnion",
     "MenuButton",
     "MenuButtonCommands",
     "MenuButtonDefault",
+    "MenuButtonUnion",
     "MenuButtonWebApp",
     "Message",
     "MessageAutoDeleteTimerChanged",
@@ -402,6 +439,7 @@ __all__ = (
     "MessageOriginChannel",
     "MessageOriginChat",
     "MessageOriginHiddenUser",
+    "MessageOriginUnion",
     "MessageOriginUser",
     "MessageReactionCountUpdated",
     "MessageReactionUpdated",
@@ -411,6 +449,7 @@ __all__ = (
     "PaidMediaPhoto",
     "PaidMediaPreview",
     "PaidMediaPurchased",
+    "PaidMediaUnion",
     "PaidMediaVideo",
     "PassportData",
     "PassportElementError",
@@ -422,6 +461,7 @@ __all__ = (
     "PassportElementErrorSelfie",
     "PassportElementErrorTranslationFile",
     "PassportElementErrorTranslationFiles",
+    "PassportElementErrorUnion",
     "PassportElementErrorUnspecified",
     "PassportFile",
     "PhotoSize",
@@ -436,15 +476,18 @@ __all__ = (
     "ReactionTypeCustomEmoji",
     "ReactionTypeEmoji",
     "ReactionTypePaid",
+    "ReactionTypeUnion",
     "RefundedPayment",
     "ReplyKeyboardMarkup",
     "ReplyKeyboardRemove",
+    "ReplyMarkupUnion",
     "ReplyParameters",
     "ResponseParameters",
     "RevenueWithdrawalState",
     "RevenueWithdrawalStateFailed",
     "RevenueWithdrawalStatePending",
     "RevenueWithdrawalStateSucceeded",
+    "RevenueWithdrawalStateUnion",
     "SentWebAppMessage",
     "SharedUser",
     "ShippingAddress",
@@ -466,6 +509,7 @@ __all__ = (
     "TransactionPartnerOther",
     "TransactionPartnerTelegramAds",
     "TransactionPartnerTelegramApi",
+    "TransactionPartnerUnion",
     "TransactionPartnerUser",
     "UNSET_PARSE_MODE",
     "URLInputFile",

--- a/aiogram/types/__init__.py
+++ b/aiogram/types/__init__.py
@@ -160,6 +160,7 @@ from .login_url import LoginUrl
 from .mask_position import MaskPosition
 from .maybe_inaccessible_message import MaybeInaccessibleMessage
 from .maybe_inaccessible_message_union import MaybeInaccessibleMessageUnion
+from .media_union import MediaUnion
 from .menu_button import MenuButton
 from .menu_button_commands import MenuButtonCommands
 from .menu_button_default import MenuButtonDefault
@@ -426,6 +427,7 @@ __all__ = (
     "MaskPosition",
     "MaybeInaccessibleMessage",
     "MaybeInaccessibleMessageUnion",
+    "MediaUnion",
     "MenuButton",
     "MenuButtonCommands",
     "MenuButtonDefault",

--- a/aiogram/types/background_fill_union.py
+++ b/aiogram/types/background_fill_union.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .background_fill_freeform_gradient import BackgroundFillFreeformGradient
+from .background_fill_gradient import BackgroundFillGradient
+from .background_fill_solid import BackgroundFillSolid
+
+BackgroundFillUnion = Union[
+    BackgroundFillSolid, BackgroundFillGradient, BackgroundFillFreeformGradient
+]

--- a/aiogram/types/background_type_fill.py
+++ b/aiogram/types/background_type_fill.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from .background_type import BackgroundType
 
 if TYPE_CHECKING:
-    from .background_fill_freeform_gradient import BackgroundFillFreeformGradient
-    from .background_fill_gradient import BackgroundFillGradient
-    from .background_fill_solid import BackgroundFillSolid
+    from .background_fill_union import BackgroundFillUnion
 
 
 class BackgroundTypeFill(BackgroundType):
@@ -19,7 +17,7 @@ class BackgroundTypeFill(BackgroundType):
 
     type: Literal["fill"] = "fill"
     """Type of the background, always 'fill'"""
-    fill: Union[BackgroundFillSolid, BackgroundFillGradient, BackgroundFillFreeformGradient]
+    fill: BackgroundFillUnion
     """The background fill"""
     dark_theme_dimming: int
     """Dimming of the background in dark themes, as a percentage; 0-100"""
@@ -32,9 +30,7 @@ class BackgroundTypeFill(BackgroundType):
             __pydantic__self__,
             *,
             type: Literal["fill"] = "fill",
-            fill: Union[
-                BackgroundFillSolid, BackgroundFillGradient, BackgroundFillFreeformGradient
-            ],
+            fill: BackgroundFillUnion,
             dark_theme_dimming: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/types/background_type_pattern.py
+++ b/aiogram/types/background_type_pattern.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from .background_type import BackgroundType
 
 if TYPE_CHECKING:
-    from .background_fill_freeform_gradient import BackgroundFillFreeformGradient
-    from .background_fill_gradient import BackgroundFillGradient
-    from .background_fill_solid import BackgroundFillSolid
+    from .background_fill_union import BackgroundFillUnion
     from .document import Document
 
 
@@ -22,7 +20,7 @@ class BackgroundTypePattern(BackgroundType):
     """Type of the background, always 'pattern'"""
     document: Document
     """Document with the pattern"""
-    fill: Union[BackgroundFillSolid, BackgroundFillGradient, BackgroundFillFreeformGradient]
+    fill: BackgroundFillUnion
     """The background fill that is combined with the pattern"""
     intensity: int
     """Intensity of the pattern when it is shown above the filled background; 0-100"""
@@ -40,9 +38,7 @@ class BackgroundTypePattern(BackgroundType):
             *,
             type: Literal["pattern"] = "pattern",
             document: Document,
-            fill: Union[
-                BackgroundFillSolid, BackgroundFillGradient, BackgroundFillFreeformGradient
-            ],
+            fill: BackgroundFillUnion,
             intensity: int,
             is_inverted: Optional[bool] = None,
             is_moving: Optional[bool] = None,

--- a/aiogram/types/background_type_union.py
+++ b/aiogram/types/background_type_union.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .background_type_chat_theme import BackgroundTypeChatTheme
+from .background_type_fill import BackgroundTypeFill
+from .background_type_pattern import BackgroundTypePattern
+from .background_type_wallpaper import BackgroundTypeWallpaper
+
+BackgroundTypeUnion = Union[
+    BackgroundTypeFill, BackgroundTypeWallpaper, BackgroundTypePattern, BackgroundTypeChatTheme
+]

--- a/aiogram/types/bot_command_scope_chat.py
+++ b/aiogram/types/bot_command_scope_chat.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
+
+if TYPE_CHECKING:
+    from .chat_id_union import ChatIdUnion
 
 
 class BotCommandScopeChat(BotCommandScope):
@@ -15,7 +18,7 @@ class BotCommandScopeChat(BotCommandScope):
 
     type: Literal[BotCommandScopeType.CHAT] = BotCommandScopeType.CHAT
     """Scope type, must be *chat*"""
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -26,7 +29,7 @@ class BotCommandScopeChat(BotCommandScope):
             __pydantic__self__,
             *,
             type: Literal[BotCommandScopeType.CHAT] = BotCommandScopeType.CHAT,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/bot_command_scope_chat_administrators.py
+++ b/aiogram/types/bot_command_scope_chat_administrators.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
+
+if TYPE_CHECKING:
+    from .chat_id_union import ChatIdUnion
 
 
 class BotCommandScopeChatAdministrators(BotCommandScope):
@@ -17,7 +20,7 @@ class BotCommandScopeChatAdministrators(BotCommandScope):
         BotCommandScopeType.CHAT_ADMINISTRATORS
     )
     """Scope type, must be *chat_administrators*"""
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
 
     if TYPE_CHECKING:
@@ -30,7 +33,7 @@ class BotCommandScopeChatAdministrators(BotCommandScope):
             type: Literal[
                 BotCommandScopeType.CHAT_ADMINISTRATORS
             ] = BotCommandScopeType.CHAT_ADMINISTRATORS,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/bot_command_scope_chat_member.py
+++ b/aiogram/types/bot_command_scope_chat_member.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..enums import BotCommandScopeType
 from .bot_command_scope import BotCommandScope
+
+if TYPE_CHECKING:
+    from .chat_id_union import ChatIdUnion
 
 
 class BotCommandScopeChatMember(BotCommandScope):
@@ -15,7 +18,7 @@ class BotCommandScopeChatMember(BotCommandScope):
 
     type: Literal[BotCommandScopeType.CHAT_MEMBER] = BotCommandScopeType.CHAT_MEMBER
     """Scope type, must be *chat_member*"""
-    chat_id: Union[int, str]
+    chat_id: ChatIdUnion
     """Unique identifier for the target chat or username of the target supergroup (in the format :code:`@supergroupusername`)"""
     user_id: int
     """Unique identifier of the target user"""
@@ -28,7 +31,7 @@ class BotCommandScopeChatMember(BotCommandScope):
             __pydantic__self__,
             *,
             type: Literal[BotCommandScopeType.CHAT_MEMBER] = BotCommandScopeType.CHAT_MEMBER,
-            chat_id: Union[int, str],
+            chat_id: ChatIdUnion,
             user_id: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/types/bot_command_scope_union.py
+++ b/aiogram/types/bot_command_scope_union.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .bot_command_scope_all_chat_administrators import (
+    BotCommandScopeAllChatAdministrators,
+)
+from .bot_command_scope_all_group_chats import BotCommandScopeAllGroupChats
+from .bot_command_scope_all_private_chats import BotCommandScopeAllPrivateChats
+from .bot_command_scope_chat import BotCommandScopeChat
+from .bot_command_scope_chat_administrators import BotCommandScopeChatAdministrators
+from .bot_command_scope_chat_member import BotCommandScopeChatMember
+from .bot_command_scope_default import BotCommandScopeDefault
+
+BotCommandScopeUnion = Union[
+    BotCommandScopeDefault,
+    BotCommandScopeAllPrivateChats,
+    BotCommandScopeAllGroupChats,
+    BotCommandScopeAllChatAdministrators,
+    BotCommandScopeChat,
+    BotCommandScopeChatAdministrators,
+    BotCommandScopeChatMember,
+]

--- a/aiogram/types/callback_query.py
+++ b/aiogram/types/callback_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
@@ -8,8 +8,7 @@ from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerCallbackQuery
-    from .inaccessible_message import InaccessibleMessage
-    from .message import Message
+    from .maybe_inaccessible_message_union import MaybeInaccessibleMessageUnion
     from .user import User
 
 
@@ -28,7 +27,7 @@ class CallbackQuery(TelegramObject):
     """Sender"""
     chat_instance: str
     """Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in :class:`aiogram.methods.games.Games`."""
-    message: Optional[Union[Message, InaccessibleMessage]] = None
+    message: Optional[MaybeInaccessibleMessageUnion] = None
     """*Optional*. Message sent by the bot with the callback button that originated the query"""
     inline_message_id: Optional[str] = None
     """*Optional*. Identifier of the message sent via the bot in inline mode, that originated the query."""
@@ -47,7 +46,7 @@ class CallbackQuery(TelegramObject):
             id: str,
             from_user: User,
             chat_instance: str,
-            message: Optional[Union[Message, InaccessibleMessage]] = None,
+            message: Optional[MaybeInaccessibleMessageUnion] = None,
             inline_message_id: Optional[str] = None,
             data: Optional[str] = None,
             game_short_name: Optional[str] = None,

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -48,9 +48,7 @@ if TYPE_CHECKING:
     from .chat_photo import ChatPhoto
     from .input_file import InputFile
     from .message import Message
-    from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
-    from .reaction_type_emoji import ReactionTypeEmoji
-    from .reaction_type_paid import ReactionTypePaid
+    from .reaction_type_union import ReactionTypeUnion
 
 
 class Chat(TelegramObject):
@@ -84,9 +82,9 @@ class Chat(TelegramObject):
 
 .. deprecated:: API:7.3
    https://core.telegram.org/bots/api-changelog#may-6-2024"""
-    available_reactions: Optional[
-        list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-    ] = Field(None, json_schema_extra={"deprecated": True})
+    available_reactions: Optional[list[ReactionTypeUnion]] = Field(
+        None, json_schema_extra={"deprecated": True}
+    )
     """*Optional*. List of available reactions allowed in the chat. If omitted, then all `emoji reactions <https://core.telegram.org/bots/api#reactiontypeemoji>`_ are allowed. Returned only in :class:`aiogram.methods.get_chat.GetChat`.
 
 .. deprecated:: API:7.3
@@ -284,9 +282,7 @@ class Chat(TelegramObject):
             is_forum: Optional[bool] = None,
             accent_color_id: Optional[int] = None,
             active_usernames: Optional[list[str]] = None,
-            available_reactions: Optional[
-                list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-            ] = None,
+            available_reactions: Optional[list[ReactionTypeUnion]] = None,
             background_custom_emoji_id: Optional[str] = None,
             bio: Optional[str] = None,
             birthdate: Optional[Birthdate] = None,

--- a/aiogram/types/chat.py
+++ b/aiogram/types/chat.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
     from .chat_location import ChatLocation
     from .chat_permissions import ChatPermissions
     from .chat_photo import ChatPhoto
+    from .date_time_union import DateTimeUnion
     from .input_file import InputFile
     from .message import Message
     from .reaction_type_union import ReactionTypeUnion
@@ -562,7 +562,7 @@ class Chat(TelegramObject):
         self,
         invite_link: str,
         name: Optional[str] = None,
-        expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        expire_date: Optional[DateTimeUnion] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None,
         **kwargs: Any,
@@ -602,7 +602,7 @@ class Chat(TelegramObject):
     def create_invite_link(
         self,
         name: Optional[str] = None,
-        expire_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        expire_date: Optional[DateTimeUnion] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None,
         **kwargs: Any,
@@ -1076,7 +1076,7 @@ class Chat(TelegramObject):
         user_id: int,
         permissions: ChatPermissions,
         use_independent_chat_permissions: Optional[bool] = None,
-        until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        until_date: Optional[DateTimeUnion] = None,
         **kwargs: Any,
     ) -> RestrictChatMember:
         """
@@ -1144,7 +1144,7 @@ class Chat(TelegramObject):
     def ban(
         self,
         user_id: int,
-        until_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        until_date: Optional[DateTimeUnion] = None,
         revoke_messages: Optional[bool] = None,
         **kwargs: Any,
     ) -> BanChatMember:

--- a/aiogram/types/chat_background.py
+++ b/aiogram/types/chat_background.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
+
+from .base import TelegramObject
 
 if TYPE_CHECKING:
-    from .background_type_chat_theme import BackgroundTypeChatTheme
-    from .background_type_fill import BackgroundTypeFill
-    from .background_type_pattern import BackgroundTypePattern
-    from .background_type_wallpaper import BackgroundTypeWallpaper
-from .base import TelegramObject
+    from .background_type_union import BackgroundTypeUnion
 
 
 class ChatBackground(TelegramObject):
@@ -17,9 +15,7 @@ class ChatBackground(TelegramObject):
     Source: https://core.telegram.org/bots/api#chatbackground
     """
 
-    type: Union[
-        BackgroundTypeFill, BackgroundTypeWallpaper, BackgroundTypePattern, BackgroundTypeChatTheme
-    ]
+    type: BackgroundTypeUnion
     """Type of the background"""
 
     if TYPE_CHECKING:
@@ -27,15 +23,7 @@ class ChatBackground(TelegramObject):
         # This section was auto-generated via `butcher`
 
         def __init__(
-            __pydantic__self__,
-            *,
-            type: Union[
-                BackgroundTypeFill,
-                BackgroundTypeWallpaper,
-                BackgroundTypePattern,
-                BackgroundTypeChatTheme,
-            ],
-            **__pydantic_kwargs: Any,
+            __pydantic__self__, *, type: BackgroundTypeUnion, **__pydantic_kwargs: Any
         ) -> None:
             # DO NOT EDIT MANUALLY!!!
             # This method was auto-generated via `butcher`

--- a/aiogram/types/chat_boost.py
+++ b/aiogram/types/chat_boost.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .base import TelegramObject
 from .custom import DateTime
 
 if TYPE_CHECKING:
-    from .chat_boost_source_gift_code import ChatBoostSourceGiftCode
-    from .chat_boost_source_giveaway import ChatBoostSourceGiveaway
-    from .chat_boost_source_premium import ChatBoostSourcePremium
+    from .chat_boost_source_union import ChatBoostSourceUnion
 
 
 class ChatBoost(TelegramObject):
@@ -24,7 +22,7 @@ class ChatBoost(TelegramObject):
     """Point in time (Unix timestamp) when the chat was boosted"""
     expiration_date: DateTime
     """Point in time (Unix timestamp) when the boost will automatically expire, unless the booster's Telegram Premium subscription is prolonged"""
-    source: Union[ChatBoostSourcePremium, ChatBoostSourceGiftCode, ChatBoostSourceGiveaway]
+    source: ChatBoostSourceUnion
     """Source of the added boost"""
 
     if TYPE_CHECKING:
@@ -37,9 +35,7 @@ class ChatBoost(TelegramObject):
             boost_id: str,
             add_date: DateTime,
             expiration_date: DateTime,
-            source: Union[
-                ChatBoostSourcePremium, ChatBoostSourceGiftCode, ChatBoostSourceGiveaway
-            ],
+            source: ChatBoostSourceUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/chat_boost_removed.py
+++ b/aiogram/types/chat_boost_removed.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .base import TelegramObject
 from .custom import DateTime
 
 if TYPE_CHECKING:
     from .chat import Chat
-    from .chat_boost_source_gift_code import ChatBoostSourceGiftCode
-    from .chat_boost_source_giveaway import ChatBoostSourceGiveaway
-    from .chat_boost_source_premium import ChatBoostSourcePremium
+    from .chat_boost_source_union import ChatBoostSourceUnion
 
 
 class ChatBoostRemoved(TelegramObject):
@@ -25,7 +23,7 @@ class ChatBoostRemoved(TelegramObject):
     """Unique identifier of the boost"""
     remove_date: DateTime
     """Point in time (Unix timestamp) when the boost was removed"""
-    source: Union[ChatBoostSourcePremium, ChatBoostSourceGiftCode, ChatBoostSourceGiveaway]
+    source: ChatBoostSourceUnion
     """Source of the removed boost"""
 
     if TYPE_CHECKING:
@@ -38,9 +36,7 @@ class ChatBoostRemoved(TelegramObject):
             chat: Chat,
             boost_id: str,
             remove_date: DateTime,
-            source: Union[
-                ChatBoostSourcePremium, ChatBoostSourceGiftCode, ChatBoostSourceGiveaway
-            ],
+            source: ChatBoostSourceUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/chat_boost_source_union.py
+++ b/aiogram/types/chat_boost_source_union.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .chat_boost_source_gift_code import ChatBoostSourceGiftCode
+from .chat_boost_source_giveaway import ChatBoostSourceGiveaway
+from .chat_boost_source_premium import ChatBoostSourcePremium
+
+ChatBoostSourceUnion = Union[
+    ChatBoostSourcePremium, ChatBoostSourceGiftCode, ChatBoostSourceGiveaway
+]

--- a/aiogram/types/chat_full_info.py
+++ b/aiogram/types/chat_full_info.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from .chat import Chat
 from .custom import DateTime
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
     from .chat_permissions import ChatPermissions
     from .chat_photo import ChatPhoto
     from .message import Message
-    from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
-    from .reaction_type_emoji import ReactionTypeEmoji
-    from .reaction_type_paid import ReactionTypePaid
+    from .reaction_type_union import ReactionTypeUnion
 
 
 class ChatFullInfo(Chat):
@@ -58,9 +56,7 @@ class ChatFullInfo(Chat):
     """*Optional*. For private chats with business accounts, the opening hours of the business"""
     personal_chat: Optional[Chat] = None
     """*Optional*. For private chats, the personal channel of the user"""
-    available_reactions: Optional[
-        list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-    ] = None
+    available_reactions: Optional[list[ReactionTypeUnion]] = None
     """*Optional*. List of available reactions allowed in the chat. If omitted, then all `emoji reactions <https://core.telegram.org/bots/api#reactiontypeemoji>`_ are allowed."""
     background_custom_emoji_id: Optional[str] = None
     """*Optional*. Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background"""
@@ -142,9 +138,7 @@ class ChatFullInfo(Chat):
             business_location: Optional[BusinessLocation] = None,
             business_opening_hours: Optional[BusinessOpeningHours] = None,
             personal_chat: Optional[Chat] = None,
-            available_reactions: Optional[
-                list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-            ] = None,
+            available_reactions: Optional[list[ReactionTypeUnion]] = None,
             background_custom_emoji_id: Optional[str] = None,
             profile_accent_color_id: Optional[int] = None,
             profile_background_custom_emoji_id: Optional[str] = None,

--- a/aiogram/types/chat_id_union.py
+++ b/aiogram/types/chat_id_union.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from typing import Union
+
+ChatIdUnion = Union[int, str]

--- a/aiogram/types/chat_join_request.py
+++ b/aiogram/types/chat_join_request.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
@@ -33,19 +32,16 @@ if TYPE_CHECKING:
     )
     from .chat import Chat
     from .chat_invite_link import ChatInviteLink
-    from .force_reply import ForceReply
+    from .date_time_union import DateTimeUnion
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
-    from .input_media_audio import InputMediaAudio
-    from .input_media_document import InputMediaDocument
-    from .input_media_photo import InputMediaPhoto
-    from .input_media_video import InputMediaVideo
-    from .input_poll_option import InputPollOption
+    from .input_file_union import InputFileUnion
+    from .input_poll_option_union import InputPollOptionUnion
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
+    from .media_union import MediaUnion
     from .message_entity import MessageEntity
-    from .reply_keyboard_markup import ReplyKeyboardMarkup
-    from .reply_keyboard_remove import ReplyKeyboardRemove
+    from .reply_markup_union import ReplyMarkupUnion
     from .reply_parameters import ReplyParameters
     from .user import User
 
@@ -170,9 +166,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -247,9 +241,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -311,7 +303,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -330,9 +322,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -401,7 +391,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_animation_pm(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -420,9 +410,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -491,7 +479,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -506,9 +494,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -574,7 +560,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_audio_pm(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -589,9 +575,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -668,9 +652,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -738,9 +720,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -797,7 +777,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -810,9 +790,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -873,7 +851,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_document_pm(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -886,9 +864,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1312,9 +1288,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1388,9 +1362,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1451,7 +1423,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -1507,7 +1479,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_media_group_pm(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -1563,7 +1535,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -1578,9 +1550,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1641,7 +1611,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_photo_pm(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -1656,9 +1626,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1720,7 +1688,7 @@ class ChatJoinRequest(TelegramObject):
     def answer_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1733,16 +1701,14 @@ class ChatJoinRequest(TelegramObject):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1820,7 +1786,7 @@ class ChatJoinRequest(TelegramObject):
     def answer_poll_pm(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1833,16 +1799,14 @@ class ChatJoinRequest(TelegramObject):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1927,9 +1891,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1988,9 +1950,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2041,7 +2001,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -2050,9 +2010,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2105,7 +2063,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_sticker_pm(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -2114,9 +2072,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2184,9 +2140,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2266,9 +2220,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2333,15 +2285,15 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2355,9 +2307,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2432,15 +2382,15 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_video_pm(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2454,9 +2404,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2531,7 +2479,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -2542,9 +2490,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2601,7 +2547,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_video_note_pm(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -2612,9 +2558,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2671,7 +2615,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2683,9 +2627,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2744,7 +2686,7 @@ class ChatJoinRequest(TelegramObject):
 
     def answer_voice_pm(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2756,9 +2698,7 @@ class ChatJoinRequest(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,

--- a/aiogram/types/chat_member_union.py
+++ b/aiogram/types/chat_member_union.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .chat_member_administrator import ChatMemberAdministrator
+from .chat_member_banned import ChatMemberBanned
+from .chat_member_left import ChatMemberLeft
+from .chat_member_member import ChatMemberMember
+from .chat_member_owner import ChatMemberOwner
+from .chat_member_restricted import ChatMemberRestricted
+
+ChatMemberUnion = Union[
+    ChatMemberOwner,
+    ChatMemberAdministrator,
+    ChatMemberMember,
+    ChatMemberRestricted,
+    ChatMemberLeft,
+    ChatMemberBanned,
+]

--- a/aiogram/types/chat_member_updated.py
+++ b/aiogram/types/chat_member_updated.py
@@ -31,12 +31,7 @@ if TYPE_CHECKING:
     )
     from .chat import Chat
     from .chat_invite_link import ChatInviteLink
-    from .chat_member_administrator import ChatMemberAdministrator
-    from .chat_member_banned import ChatMemberBanned
-    from .chat_member_left import ChatMemberLeft
-    from .chat_member_member import ChatMemberMember
-    from .chat_member_owner import ChatMemberOwner
-    from .chat_member_restricted import ChatMemberRestricted
+    from .chat_member_union import ChatMemberUnion
     from .force_reply import ForceReply
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
@@ -67,23 +62,9 @@ class ChatMemberUpdated(TelegramObject):
     """Performer of the action, which resulted in the change"""
     date: DateTime
     """Date the change was done in Unix time"""
-    old_chat_member: Union[
-        ChatMemberOwner,
-        ChatMemberAdministrator,
-        ChatMemberMember,
-        ChatMemberRestricted,
-        ChatMemberLeft,
-        ChatMemberBanned,
-    ]
+    old_chat_member: ChatMemberUnion
     """Previous information about the chat member"""
-    new_chat_member: Union[
-        ChatMemberOwner,
-        ChatMemberAdministrator,
-        ChatMemberMember,
-        ChatMemberRestricted,
-        ChatMemberLeft,
-        ChatMemberBanned,
-    ]
+    new_chat_member: ChatMemberUnion
     """New information about the chat member"""
     invite_link: Optional[ChatInviteLink] = None
     """*Optional*. Chat invite link, which was used by the user to join the chat; for joining by invite link events only."""
@@ -102,22 +83,8 @@ class ChatMemberUpdated(TelegramObject):
             chat: Chat,
             from_user: User,
             date: DateTime,
-            old_chat_member: Union[
-                ChatMemberOwner,
-                ChatMemberAdministrator,
-                ChatMemberMember,
-                ChatMemberRestricted,
-                ChatMemberLeft,
-                ChatMemberBanned,
-            ],
-            new_chat_member: Union[
-                ChatMemberOwner,
-                ChatMemberAdministrator,
-                ChatMemberMember,
-                ChatMemberRestricted,
-                ChatMemberLeft,
-                ChatMemberBanned,
-            ],
+            old_chat_member: ChatMemberUnion,
+            new_chat_member: ChatMemberUnion,
             invite_link: Optional[ChatInviteLink] = None,
             via_join_request: Optional[bool] = None,
             via_chat_folder_invite_link: Optional[bool] = None,

--- a/aiogram/types/chat_member_updated.py
+++ b/aiogram/types/chat_member_updated.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
@@ -32,19 +31,16 @@ if TYPE_CHECKING:
     from .chat import Chat
     from .chat_invite_link import ChatInviteLink
     from .chat_member_union import ChatMemberUnion
-    from .force_reply import ForceReply
+    from .date_time_union import DateTimeUnion
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
-    from .input_media_audio import InputMediaAudio
-    from .input_media_document import InputMediaDocument
-    from .input_media_photo import InputMediaPhoto
-    from .input_media_video import InputMediaVideo
-    from .input_poll_option import InputPollOption
+    from .input_file_union import InputFileUnion
+    from .input_poll_option_union import InputPollOptionUnion
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
+    from .media_union import MediaUnion
     from .message_entity import MessageEntity
-    from .reply_keyboard_markup import ReplyKeyboardMarkup
-    from .reply_keyboard_remove import ReplyKeyboardRemove
+    from .reply_markup_union import ReplyMarkupUnion
     from .reply_parameters import ReplyParameters
     from .user import User
 
@@ -121,9 +117,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -185,7 +179,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -204,9 +198,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -275,7 +267,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -290,9 +282,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -369,9 +359,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -428,7 +416,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -441,9 +429,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -692,9 +678,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -755,7 +739,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -811,7 +795,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -826,9 +810,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -890,7 +872,7 @@ class ChatMemberUpdated(TelegramObject):
     def answer_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -903,16 +885,14 @@ class ChatMemberUpdated(TelegramObject):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -997,9 +977,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1050,7 +1028,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -1059,9 +1037,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1129,9 +1105,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1196,15 +1170,15 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -1218,9 +1192,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1295,7 +1267,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -1306,9 +1278,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1365,7 +1335,7 @@ class ChatMemberUpdated(TelegramObject):
 
     def answer_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -1377,9 +1347,7 @@ class ChatMemberUpdated(TelegramObject):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,

--- a/aiogram/types/date_time_union.py
+++ b/aiogram/types/date_time_union.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import datetime
+from typing import Union
+
+DateTimeUnion = Union[datetime.datetime, datetime.timedelta, int]

--- a/aiogram/types/external_reply_info.py
+++ b/aiogram/types/external_reply_info.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from .base import TelegramObject
 
@@ -17,10 +17,7 @@ if TYPE_CHECKING:
     from .invoice import Invoice
     from .link_preview_options import LinkPreviewOptions
     from .location import Location
-    from .message_origin_channel import MessageOriginChannel
-    from .message_origin_chat import MessageOriginChat
-    from .message_origin_hidden_user import MessageOriginHiddenUser
-    from .message_origin_user import MessageOriginUser
+    from .message_origin_union import MessageOriginUnion
     from .paid_media_info import PaidMediaInfo
     from .photo_size import PhotoSize
     from .poll import Poll
@@ -39,9 +36,7 @@ class ExternalReplyInfo(TelegramObject):
     Source: https://core.telegram.org/bots/api#externalreplyinfo
     """
 
-    origin: Union[
-        MessageOriginUser, MessageOriginHiddenUser, MessageOriginChat, MessageOriginChannel
-    ]
+    origin: MessageOriginUnion
     """Origin of the message replied to by the given message"""
     chat: Optional[Chat] = None
     """*Optional*. Chat the original message belongs to. Available only if the chat is a supergroup or a channel."""
@@ -97,9 +92,7 @@ class ExternalReplyInfo(TelegramObject):
         def __init__(
             __pydantic__self__,
             *,
-            origin: Union[
-                MessageOriginUser, MessageOriginHiddenUser, MessageOriginChat, MessageOriginChannel
-            ],
+            origin: MessageOriginUnion,
             chat: Optional[Chat] = None,
             message_id: Optional[int] = None,
             link_preview_options: Optional[LinkPreviewOptions] = None,

--- a/aiogram/types/inaccessible_message.py
+++ b/aiogram/types/inaccessible_message.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 from aiogram.types.chat import Chat
@@ -30,20 +29,17 @@ if TYPE_CHECKING:
         SendVideoNote,
         SendVoice,
     )
-    from .force_reply import ForceReply
+    from .date_time_union import DateTimeUnion
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
-    from .input_media_audio import InputMediaAudio
-    from .input_media_document import InputMediaDocument
-    from .input_media_photo import InputMediaPhoto
-    from .input_media_video import InputMediaVideo
+    from .input_file_union import InputFileUnion
     from .input_paid_media_union import InputPaidMediaUnion
-    from .input_poll_option import InputPollOption
+    from .input_poll_option_union import InputPollOptionUnion
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
+    from .media_union import MediaUnion
     from .message_entity import MessageEntity
-    from .reply_keyboard_markup import ReplyKeyboardMarkup
-    from .reply_keyboard_remove import ReplyKeyboardRemove
+    from .reply_markup_union import ReplyMarkupUnion
 
 
 class InaccessibleMessage(MaybeInaccessibleMessage):
@@ -93,9 +89,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -173,9 +167,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -238,7 +230,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -257,9 +249,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -332,7 +322,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -350,9 +340,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendAnimation:
@@ -422,7 +410,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -437,9 +425,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -509,7 +495,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -523,9 +509,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendAudio:
@@ -603,9 +587,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -676,9 +658,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendContact:
@@ -736,7 +716,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -749,9 +729,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -816,7 +794,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -828,9 +806,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendDocument:
@@ -1263,9 +1239,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1342,9 +1316,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendLocation:
@@ -1406,7 +1378,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -1466,7 +1438,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         disable_notification: Optional[bool] = None,
@@ -1522,7 +1494,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -1537,9 +1509,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1604,7 +1574,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -1618,9 +1588,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendPhoto:
@@ -1683,7 +1651,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
     def answer_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1696,16 +1664,14 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1787,7 +1753,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
     def reply_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1800,15 +1766,13 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendPoll:
@@ -1894,9 +1858,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1958,9 +1920,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendDice:
@@ -2012,7 +1972,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -2021,9 +1981,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2080,7 +2038,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         emoji: Optional[str] = None,
@@ -2088,9 +2046,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendSticker:
@@ -2159,9 +2115,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2244,9 +2198,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVenue:
@@ -2312,15 +2264,15 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2334,9 +2286,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2415,15 +2365,15 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2436,9 +2386,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVideo:
@@ -2514,7 +2462,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -2525,9 +2473,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2588,7 +2534,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         duration: Optional[int] = None,
@@ -2598,9 +2544,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVideoNote:
@@ -2658,7 +2602,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def answer_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2670,9 +2614,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2735,7 +2677,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
 
     def reply_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         business_connection_id: Optional[str] = None,
         message_thread_id: Optional[int] = None,
         caption: Optional[str] = None,
@@ -2746,9 +2688,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVoice:
@@ -2820,9 +2760,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         **kwargs: Any,
     ) -> SendPaidMedia:
         """
@@ -2890,9 +2828,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
         disable_notification: Optional[bool] = None,
         protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         **kwargs: Any,
     ) -> SendPaidMedia:
         """

--- a/aiogram/types/inaccessible_message.py
+++ b/aiogram/types/inaccessible_message.py
@@ -37,8 +37,7 @@ if TYPE_CHECKING:
     from .input_media_document import InputMediaDocument
     from .input_media_photo import InputMediaPhoto
     from .input_media_video import InputMediaVideo
-    from .input_paid_media_photo import InputPaidMediaPhoto
-    from .input_paid_media_video import InputPaidMediaVideo
+    from .input_paid_media_union import InputPaidMediaUnion
     from .input_poll_option import InputPollOption
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
@@ -2810,7 +2809,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
     def answer_paid_media(
         self,
         star_count: int,
-        media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+        media: list[InputPaidMediaUnion],
         business_connection_id: Optional[str] = None,
         payload: Optional[str] = None,
         caption: Optional[str] = None,
@@ -2881,7 +2880,7 @@ class InaccessibleMessage(MaybeInaccessibleMessage):
     def reply_paid_media(
         self,
         star_count: int,
-        media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+        media: list[InputPaidMediaUnion],
         business_connection_id: Optional[str] = None,
         payload: Optional[str] = None,
         caption: Optional[str] = None,

--- a/aiogram/types/inline_query.py
+++ b/aiogram/types/inline_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
@@ -8,26 +8,7 @@ from .base import TelegramObject
 
 if TYPE_CHECKING:
     from ..methods import AnswerInlineQuery
-    from .inline_query_result_article import InlineQueryResultArticle
-    from .inline_query_result_audio import InlineQueryResultAudio
-    from .inline_query_result_cached_audio import InlineQueryResultCachedAudio
-    from .inline_query_result_cached_document import InlineQueryResultCachedDocument
-    from .inline_query_result_cached_gif import InlineQueryResultCachedGif
-    from .inline_query_result_cached_mpeg4_gif import InlineQueryResultCachedMpeg4Gif
-    from .inline_query_result_cached_photo import InlineQueryResultCachedPhoto
-    from .inline_query_result_cached_sticker import InlineQueryResultCachedSticker
-    from .inline_query_result_cached_video import InlineQueryResultCachedVideo
-    from .inline_query_result_cached_voice import InlineQueryResultCachedVoice
-    from .inline_query_result_contact import InlineQueryResultContact
-    from .inline_query_result_document import InlineQueryResultDocument
-    from .inline_query_result_game import InlineQueryResultGame
-    from .inline_query_result_gif import InlineQueryResultGif
-    from .inline_query_result_location import InlineQueryResultLocation
-    from .inline_query_result_mpeg4_gif import InlineQueryResultMpeg4Gif
-    from .inline_query_result_photo import InlineQueryResultPhoto
-    from .inline_query_result_venue import InlineQueryResultVenue
-    from .inline_query_result_video import InlineQueryResultVideo
-    from .inline_query_result_voice import InlineQueryResultVoice
+    from .inline_query_result_union import InlineQueryResultUnion
     from .inline_query_results_button import InlineQueryResultsButton
     from .location import Location
     from .user import User
@@ -84,30 +65,7 @@ class InlineQuery(TelegramObject):
 
     def answer(
         self,
-        results: list[
-            Union[
-                InlineQueryResultCachedAudio,
-                InlineQueryResultCachedDocument,
-                InlineQueryResultCachedGif,
-                InlineQueryResultCachedMpeg4Gif,
-                InlineQueryResultCachedPhoto,
-                InlineQueryResultCachedSticker,
-                InlineQueryResultCachedVideo,
-                InlineQueryResultCachedVoice,
-                InlineQueryResultArticle,
-                InlineQueryResultAudio,
-                InlineQueryResultContact,
-                InlineQueryResultGame,
-                InlineQueryResultDocument,
-                InlineQueryResultGif,
-                InlineQueryResultLocation,
-                InlineQueryResultMpeg4Gif,
-                InlineQueryResultPhoto,
-                InlineQueryResultVenue,
-                InlineQueryResultVideo,
-                InlineQueryResultVoice,
-            ]
-        ],
+        results: list[InlineQueryResultUnion],
         cache_time: Optional[int] = None,
         is_personal: Optional[bool] = None,
         next_offset: Optional[str] = None,

--- a/aiogram/types/inline_query_result_article.py
+++ b/aiogram/types/inline_query_result_article.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from pydantic import Field
 
@@ -9,11 +9,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
 
 
 class InlineQueryResultArticle(InlineQueryResult):
@@ -29,13 +25,7 @@ class InlineQueryResultArticle(InlineQueryResult):
     """Unique identifier for this result, 1-64 Bytes"""
     title: str
     """Title of the result"""
-    input_message_content: Union[
-        InputTextMessageContent,
-        InputLocationMessageContent,
-        InputVenueMessageContent,
-        InputContactMessageContent,
-        InputInvoiceMessageContent,
-    ]
+    input_message_content: InputMessageContentUnion
     """Content of the message to be sent"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
@@ -65,13 +55,7 @@ class InlineQueryResultArticle(InlineQueryResult):
             type: Literal[InlineQueryResultType.ARTICLE] = InlineQueryResultType.ARTICLE,
             id: str,
             title: str,
-            input_message_content: Union[
-                InputTextMessageContent,
-                InputLocationMessageContent,
-                InputVenueMessageContent,
-                InputContactMessageContent,
-                InputInvoiceMessageContent,
-            ],
+            input_message_content: InputMessageContentUnion,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
             url: Optional[str] = None,
             description: Optional[str] = None,

--- a/aiogram/types/inline_query_result_audio.py
+++ b/aiogram/types/inline_query_result_audio.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -43,15 +39,7 @@ class InlineQueryResultAudio(InlineQueryResult):
     """*Optional*. Audio duration in seconds"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the audio"""
 
     if TYPE_CHECKING:
@@ -71,15 +59,7 @@ class InlineQueryResultAudio(InlineQueryResult):
             performer: Optional[str] = None,
             audio_duration: Optional[int] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_audio.py
+++ b/aiogram/types/inline_query_result_cached_audio.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -37,15 +33,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
     """*Optional*. List of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the audio"""
 
     if TYPE_CHECKING:
@@ -62,15 +50,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_document.py
+++ b/aiogram/types/inline_query_result_cached_document.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -41,15 +37,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
     """*Optional*. List of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the file"""
 
     if TYPE_CHECKING:
@@ -68,15 +56,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_gif.py
+++ b/aiogram/types/inline_query_result_cached_gif.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -41,15 +37,7 @@ class InlineQueryResultCachedGif(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the GIF animation"""
 
     if TYPE_CHECKING:
@@ -70,15 +58,7 @@ class InlineQueryResultCachedGif(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_cached_mpeg4_gif.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -41,15 +37,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the video animation"""
 
     if TYPE_CHECKING:
@@ -70,15 +58,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_photo.py
+++ b/aiogram/types/inline_query_result_cached_photo.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -43,15 +39,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the photo"""
 
     if TYPE_CHECKING:
@@ -73,15 +61,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_sticker.py
+++ b/aiogram/types/inline_query_result_cached_sticker.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
 
 
 class InlineQueryResultCachedSticker(InlineQueryResult):
@@ -29,15 +25,7 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
     """A valid file identifier of the sticker"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the sticker"""
 
     if TYPE_CHECKING:
@@ -51,15 +39,7 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
             id: str,
             sticker_file_id: str,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_video.py
+++ b/aiogram/types/inline_query_result_cached_video.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -43,15 +39,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the video"""
 
     if TYPE_CHECKING:
@@ -73,15 +61,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_cached_voice.py
+++ b/aiogram/types/inline_query_result_cached_voice.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -39,15 +35,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
     """*Optional*. List of special entities that appear in the caption, which can be specified instead of *parse_mode*"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the voice message"""
 
     if TYPE_CHECKING:
@@ -65,15 +53,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_contact.py
+++ b/aiogram/types/inline_query_result_contact.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
 
 
 class InlineQueryResultContact(InlineQueryResult):
@@ -35,15 +31,7 @@ class InlineQueryResultContact(InlineQueryResult):
     """*Optional*. Additional data about the contact in the form of a `vCard <https://en.wikipedia.org/wiki/VCard>`_, 0-2048 bytes"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the contact"""
     thumbnail_url: Optional[str] = None
     """*Optional*. Url of the thumbnail for the result"""
@@ -66,15 +54,7 @@ class InlineQueryResultContact(InlineQueryResult):
             last_name: Optional[str] = None,
             vcard: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             thumbnail_url: Optional[str] = None,
             thumbnail_width: Optional[int] = None,
             thumbnail_height: Optional[int] = None,

--- a/aiogram/types/inline_query_result_document.py
+++ b/aiogram/types/inline_query_result_document.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -43,15 +39,7 @@ class InlineQueryResultDocument(InlineQueryResult):
     """*Optional*. Short description of the result"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. Inline keyboard attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the file"""
     thumbnail_url: Optional[str] = None
     """*Optional*. URL of the thumbnail (JPEG only) for the file"""
@@ -77,15 +65,7 @@ class InlineQueryResultDocument(InlineQueryResult):
             caption_entities: Optional[list[MessageEntity]] = None,
             description: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             thumbnail_url: Optional[str] = None,
             thumbnail_width: Optional[int] = None,
             thumbnail_height: Optional[int] = None,

--- a/aiogram/types/inline_query_result_gif.py
+++ b/aiogram/types/inline_query_result_gif.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -51,15 +47,7 @@ class InlineQueryResultGif(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the GIF animation"""
 
     if TYPE_CHECKING:
@@ -85,15 +73,7 @@ class InlineQueryResultGif(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_location.py
+++ b/aiogram/types/inline_query_result_location.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
 
 
 class InlineQueryResultLocation(InlineQueryResult):
@@ -41,15 +37,7 @@ class InlineQueryResultLocation(InlineQueryResult):
     """*Optional*. For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified."""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the location"""
     thumbnail_url: Optional[str] = None
     """*Optional*. Url of the thumbnail for the result"""
@@ -75,15 +63,7 @@ class InlineQueryResultLocation(InlineQueryResult):
             heading: Optional[int] = None,
             proximity_alert_radius: Optional[int] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             thumbnail_url: Optional[str] = None,
             thumbnail_width: Optional[int] = None,
             thumbnail_height: Optional[int] = None,

--- a/aiogram/types/inline_query_result_mpeg4_gif.py
+++ b/aiogram/types/inline_query_result_mpeg4_gif.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -51,15 +47,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the video animation"""
 
     if TYPE_CHECKING:
@@ -85,15 +73,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_photo.py
+++ b/aiogram/types/inline_query_result_photo.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -49,15 +45,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
     """*Optional*. Pass :code:`True`, if the caption must be shown above the message media"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the photo"""
 
     if TYPE_CHECKING:
@@ -82,15 +70,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
                 "show_caption_above_media"
             ),
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_union.py
+++ b/aiogram/types/inline_query_result_union.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .inline_query_result_article import InlineQueryResultArticle
+from .inline_query_result_audio import InlineQueryResultAudio
+from .inline_query_result_cached_audio import InlineQueryResultCachedAudio
+from .inline_query_result_cached_document import InlineQueryResultCachedDocument
+from .inline_query_result_cached_gif import InlineQueryResultCachedGif
+from .inline_query_result_cached_mpeg4_gif import InlineQueryResultCachedMpeg4Gif
+from .inline_query_result_cached_photo import InlineQueryResultCachedPhoto
+from .inline_query_result_cached_sticker import InlineQueryResultCachedSticker
+from .inline_query_result_cached_video import InlineQueryResultCachedVideo
+from .inline_query_result_cached_voice import InlineQueryResultCachedVoice
+from .inline_query_result_contact import InlineQueryResultContact
+from .inline_query_result_document import InlineQueryResultDocument
+from .inline_query_result_game import InlineQueryResultGame
+from .inline_query_result_gif import InlineQueryResultGif
+from .inline_query_result_location import InlineQueryResultLocation
+from .inline_query_result_mpeg4_gif import InlineQueryResultMpeg4Gif
+from .inline_query_result_photo import InlineQueryResultPhoto
+from .inline_query_result_venue import InlineQueryResultVenue
+from .inline_query_result_video import InlineQueryResultVideo
+from .inline_query_result_voice import InlineQueryResultVoice
+
+InlineQueryResultUnion = Union[
+    InlineQueryResultCachedAudio,
+    InlineQueryResultCachedDocument,
+    InlineQueryResultCachedGif,
+    InlineQueryResultCachedMpeg4Gif,
+    InlineQueryResultCachedPhoto,
+    InlineQueryResultCachedSticker,
+    InlineQueryResultCachedVideo,
+    InlineQueryResultCachedVoice,
+    InlineQueryResultArticle,
+    InlineQueryResultAudio,
+    InlineQueryResultContact,
+    InlineQueryResultGame,
+    InlineQueryResultDocument,
+    InlineQueryResultGif,
+    InlineQueryResultLocation,
+    InlineQueryResultMpeg4Gif,
+    InlineQueryResultPhoto,
+    InlineQueryResultVenue,
+    InlineQueryResultVideo,
+    InlineQueryResultVoice,
+]

--- a/aiogram/types/inline_query_result_venue.py
+++ b/aiogram/types/inline_query_result_venue.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import InlineQueryResultType
 from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
 
 
 class InlineQueryResultVenue(InlineQueryResult):
@@ -43,15 +39,7 @@ class InlineQueryResultVenue(InlineQueryResult):
     """*Optional*. Google Places type of the venue. (See `supported types <https://developers.google.com/places/web-service/supported_types>`_.)"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the venue"""
     thumbnail_url: Optional[str] = None
     """*Optional*. Url of the thumbnail for the result"""
@@ -78,15 +66,7 @@ class InlineQueryResultVenue(InlineQueryResult):
             google_place_id: Optional[str] = None,
             google_place_type: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             thumbnail_url: Optional[str] = None,
             thumbnail_width: Optional[int] = None,
             thumbnail_height: Optional[int] = None,

--- a/aiogram/types/inline_query_result_video.py
+++ b/aiogram/types/inline_query_result_video.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -55,15 +51,7 @@ class InlineQueryResultVideo(InlineQueryResult):
     """*Optional*. Short description of the result"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the video. This field is **required** if InlineQueryResultVideo is used to send an HTML-page as a result (e.g., a YouTube video)."""
 
     if TYPE_CHECKING:
@@ -90,15 +78,7 @@ class InlineQueryResultVideo(InlineQueryResult):
             video_duration: Optional[int] = None,
             description: Optional[str] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/inline_query_result_voice.py
+++ b/aiogram/types/inline_query_result_voice.py
@@ -8,11 +8,7 @@ from .inline_query_result import InlineQueryResult
 
 if TYPE_CHECKING:
     from .inline_keyboard_markup import InlineKeyboardMarkup
-    from .input_contact_message_content import InputContactMessageContent
-    from .input_invoice_message_content import InputInvoiceMessageContent
-    from .input_location_message_content import InputLocationMessageContent
-    from .input_text_message_content import InputTextMessageContent
-    from .input_venue_message_content import InputVenueMessageContent
+    from .input_message_content_union import InputMessageContentUnion
     from .message_entity import MessageEntity
 
 
@@ -41,15 +37,7 @@ class InlineQueryResultVoice(InlineQueryResult):
     """*Optional*. Recording duration in seconds"""
     reply_markup: Optional[InlineKeyboardMarkup] = None
     """*Optional*. `Inline keyboard <https://core.telegram.org/bots/features#inline-keyboards>`_ attached to the message"""
-    input_message_content: Optional[
-        Union[
-            InputTextMessageContent,
-            InputLocationMessageContent,
-            InputVenueMessageContent,
-            InputContactMessageContent,
-            InputInvoiceMessageContent,
-        ]
-    ] = None
+    input_message_content: Optional[InputMessageContentUnion] = None
     """*Optional*. Content of the message to be sent instead of the voice recording"""
 
     if TYPE_CHECKING:
@@ -68,15 +56,7 @@ class InlineQueryResultVoice(InlineQueryResult):
             caption_entities: Optional[list[MessageEntity]] = None,
             voice_duration: Optional[int] = None,
             reply_markup: Optional[InlineKeyboardMarkup] = None,
-            input_message_content: Optional[
-                Union[
-                    InputTextMessageContent,
-                    InputLocationMessageContent,
-                    InputVenueMessageContent,
-                    InputContactMessageContent,
-                    InputInvoiceMessageContent,
-                ]
-            ] = None,
+            input_message_content: Optional[InputMessageContentUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/input_file_union.py
+++ b/aiogram/types/input_file_union.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .input_file import InputFile
+
+InputFileUnion = Union[str, InputFile]

--- a/aiogram/types/input_media_animation.py
+++ b/aiogram/types/input_media_animation.py
@@ -8,6 +8,7 @@ from .input_media import InputMedia
 
 if TYPE_CHECKING:
     from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .message_entity import MessageEntity
 
 
@@ -20,7 +21,7 @@ class InputMediaAnimation(InputMedia):
 
     type: Literal[InputMediaType.ANIMATION] = InputMediaType.ANIMATION
     """Type of the result, must be *animation*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     thumbnail: Optional[InputFile] = None
     """*Optional*. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
@@ -49,7 +50,7 @@ class InputMediaAnimation(InputMedia):
             __pydantic__self__,
             *,
             type: Literal[InputMediaType.ANIMATION] = InputMediaType.ANIMATION,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             thumbnail: Optional[InputFile] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),

--- a/aiogram/types/input_media_audio.py
+++ b/aiogram/types/input_media_audio.py
@@ -8,6 +8,7 @@ from .input_media import InputMedia
 
 if TYPE_CHECKING:
     from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .message_entity import MessageEntity
 
 
@@ -20,7 +21,7 @@ class InputMediaAudio(InputMedia):
 
     type: Literal[InputMediaType.AUDIO] = InputMediaType.AUDIO
     """Type of the result, must be *audio*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     thumbnail: Optional[InputFile] = None
     """*Optional*. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
@@ -45,7 +46,7 @@ class InputMediaAudio(InputMedia):
             __pydantic__self__,
             *,
             type: Literal[InputMediaType.AUDIO] = InputMediaType.AUDIO,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             thumbnail: Optional[InputFile] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),

--- a/aiogram/types/input_media_document.py
+++ b/aiogram/types/input_media_document.py
@@ -8,6 +8,7 @@ from .input_media import InputMedia
 
 if TYPE_CHECKING:
     from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .message_entity import MessageEntity
 
 
@@ -20,7 +21,7 @@ class InputMediaDocument(InputMedia):
 
     type: Literal[InputMediaType.DOCUMENT] = InputMediaType.DOCUMENT
     """Type of the result, must be *document*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     thumbnail: Optional[InputFile] = None
     """*Optional*. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
@@ -41,7 +42,7 @@ class InputMediaDocument(InputMedia):
             __pydantic__self__,
             *,
             type: Literal[InputMediaType.DOCUMENT] = InputMediaType.DOCUMENT,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             thumbnail: Optional[InputFile] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),

--- a/aiogram/types/input_media_photo.py
+++ b/aiogram/types/input_media_photo.py
@@ -7,7 +7,7 @@ from ..enums import InputMediaType
 from .input_media import InputMedia
 
 if TYPE_CHECKING:
-    from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .message_entity import MessageEntity
 
 
@@ -20,7 +20,7 @@ class InputMediaPhoto(InputMedia):
 
     type: Literal[InputMediaType.PHOTO] = InputMediaType.PHOTO
     """Type of the result, must be *photo*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     caption: Optional[str] = None
     """*Optional*. Caption of the photo to be sent, 0-1024 characters after entities parsing"""
@@ -41,7 +41,7 @@ class InputMediaPhoto(InputMedia):
             __pydantic__self__,
             *,
             type: Literal[InputMediaType.PHOTO] = InputMediaType.PHOTO,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,

--- a/aiogram/types/input_media_union.py
+++ b/aiogram/types/input_media_union.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .input_media_animation import InputMediaAnimation
+from .input_media_audio import InputMediaAudio
+from .input_media_document import InputMediaDocument
+from .input_media_photo import InputMediaPhoto
+from .input_media_video import InputMediaVideo
+
+InputMediaUnion = Union[
+    InputMediaAnimation, InputMediaDocument, InputMediaAudio, InputMediaPhoto, InputMediaVideo
+]

--- a/aiogram/types/input_media_video.py
+++ b/aiogram/types/input_media_video.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from ..client.default import Default
@@ -8,7 +7,9 @@ from ..enums import InputMediaType
 from .input_media import InputMedia
 
 if TYPE_CHECKING:
+    from .date_time_union import DateTimeUnion
     from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .message_entity import MessageEntity
 
 
@@ -21,13 +22,13 @@ class InputMediaVideo(InputMedia):
 
     type: Literal[InputMediaType.VIDEO] = InputMediaType.VIDEO
     """Type of the result, must be *video*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     thumbnail: Optional[InputFile] = None
     """*Optional*. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
-    cover: Optional[Union[str, InputFile]] = None
+    cover: Optional[InputFileUnion] = None
     """*Optional*. Cover for the video in the message. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
-    start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    start_timestamp: Optional[DateTimeUnion] = None
     """*Optional*. Start timestamp for the video in the message"""
     caption: Optional[str] = None
     """*Optional*. Caption of the video to be sent, 0-1024 characters after entities parsing"""
@@ -56,10 +57,10 @@ class InputMediaVideo(InputMedia):
             __pydantic__self__,
             *,
             type: Literal[InputMediaType.VIDEO] = InputMediaType.VIDEO,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             thumbnail: Optional[InputFile] = None,
-            cover: Optional[Union[str, InputFile]] = None,
-            start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            cover: Optional[InputFileUnion] = None,
+            start_timestamp: Optional[DateTimeUnion] = None,
             caption: Optional[str] = None,
             parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
             caption_entities: Optional[list[MessageEntity]] = None,

--- a/aiogram/types/input_message_content_union.py
+++ b/aiogram/types/input_message_content_union.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .input_contact_message_content import InputContactMessageContent
+from .input_invoice_message_content import InputInvoiceMessageContent
+from .input_location_message_content import InputLocationMessageContent
+from .input_text_message_content import InputTextMessageContent
+from .input_venue_message_content import InputVenueMessageContent
+
+InputMessageContentUnion = Union[
+    InputTextMessageContent,
+    InputLocationMessageContent,
+    InputVenueMessageContent,
+    InputContactMessageContent,
+    InputInvoiceMessageContent,
+]

--- a/aiogram/types/input_paid_media_photo.py
+++ b/aiogram/types/input_paid_media_photo.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..enums import InputPaidMediaType
-from .input_file import InputFile
+from .input_file_union import InputFileUnion
 from .input_paid_media import InputPaidMedia
 
 
@@ -16,7 +16,7 @@ class InputPaidMediaPhoto(InputPaidMedia):
 
     type: Literal[InputPaidMediaType.PHOTO] = InputPaidMediaType.PHOTO
     """Type of the media, must be *photo*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
 
     if TYPE_CHECKING:
@@ -27,7 +27,7 @@ class InputPaidMediaPhoto(InputPaidMedia):
             __pydantic__self__,
             *,
             type: Literal[InputPaidMediaType.PHOTO] = InputPaidMediaType.PHOTO,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/input_paid_media_union.py
+++ b/aiogram/types/input_paid_media_union.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .input_paid_media_photo import InputPaidMediaPhoto
+from .input_paid_media_video import InputPaidMediaVideo
+
+InputPaidMediaUnion = Union[InputPaidMediaPhoto, InputPaidMediaVideo]

--- a/aiogram/types/input_paid_media_video.py
+++ b/aiogram/types/input_paid_media_video.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import InputPaidMediaType
+from .date_time_union import DateTimeUnion
 from .input_file import InputFile
+from .input_file_union import InputFileUnion
 from .input_paid_media import InputPaidMedia
 
 
@@ -17,13 +18,13 @@ class InputPaidMediaVideo(InputPaidMedia):
 
     type: Literal[InputPaidMediaType.VIDEO] = InputPaidMediaType.VIDEO
     """Type of the media, must be *video*"""
-    media: Union[str, InputFile]
+    media: InputFileUnion
     """File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
     thumbnail: Optional[InputFile] = None
     """*Optional*. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass 'attach://<file_attach_name>' if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. :ref:`More information on Sending Files » <sending-files>`"""
-    cover: Optional[Union[str, InputFile]] = None
+    cover: Optional[InputFileUnion] = None
     """*Optional*. Cover for the video in the message. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. :ref:`More information on Sending Files » <sending-files>`"""
-    start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None
+    start_timestamp: Optional[DateTimeUnion] = None
     """*Optional*. Start timestamp for the video in the message"""
     width: Optional[int] = None
     """*Optional*. Video width"""
@@ -42,10 +43,10 @@ class InputPaidMediaVideo(InputPaidMedia):
             __pydantic__self__,
             *,
             type: Literal[InputPaidMediaType.VIDEO] = InputPaidMediaType.VIDEO,
-            media: Union[str, InputFile],
+            media: InputFileUnion,
             thumbnail: Optional[InputFile] = None,
-            cover: Optional[Union[str, InputFile]] = None,
-            start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+            cover: Optional[InputFileUnion] = None,
+            start_timestamp: Optional[DateTimeUnion] = None,
             width: Optional[int] = None,
             height: Optional[int] = None,
             duration: Optional[int] = None,

--- a/aiogram/types/input_poll_option_union.py
+++ b/aiogram/types/input_poll_option_union.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .input_poll_option import InputPollOption
+
+InputPollOptionUnion = Union[InputPollOption, str]

--- a/aiogram/types/input_sticker.py
+++ b/aiogram/types/input_sticker.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
-    from .input_file import InputFile
+    from .input_file_union import InputFileUnion
     from .mask_position import MaskPosition
 
 
@@ -16,7 +16,7 @@ class InputSticker(TelegramObject):
     Source: https://core.telegram.org/bots/api#inputsticker
     """
 
-    sticker: Union[InputFile, str]
+    sticker: InputFileUnion
     """The added sticker. Pass a *file_id* as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, upload a new one using multipart/form-data, or pass 'attach://<file_attach_name>' to upload a new one using multipart/form-data under <file_attach_name> name. Animated and video stickers can't be uploaded via HTTP URL. :ref:`More information on Sending Files » <sending-files>`"""
     format: str
     """Format of the added sticker, must be one of 'static' for a **.WEBP** or **.PNG** image, 'animated' for a **.TGS** animation, 'video' for a **.WEBM** video"""
@@ -34,7 +34,7 @@ class InputSticker(TelegramObject):
         def __init__(
             __pydantic__self__,
             *,
-            sticker: Union[InputFile, str],
+            sticker: InputFileUnion,
             format: str,
             emoji_list: list[str],
             mask_position: Optional[MaskPosition] = None,

--- a/aiogram/types/maybe_inaccessible_message_union.py
+++ b/aiogram/types/maybe_inaccessible_message_union.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .inaccessible_message import InaccessibleMessage
+from .message import Message
+
+MaybeInaccessibleMessageUnion = Union[Message, InaccessibleMessage]

--- a/aiogram/types/media_union.py
+++ b/aiogram/types/media_union.py
@@ -1,0 +1,8 @@
+from typing import Union
+
+from .input_media_audio import InputMediaAudio
+from .input_media_document import InputMediaDocument
+from .input_media_photo import InputMediaPhoto
+from .input_media_video import InputMediaVideo
+
+MediaUnion = Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]

--- a/aiogram/types/menu_button_union.py
+++ b/aiogram/types/menu_button_union.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .menu_button_commands import MenuButtonCommands
+from .menu_button_default import MenuButtonDefault
+from .menu_button_web_app import MenuButtonWebApp
+
+MenuButtonUnion = Union[MenuButtonCommands, MenuButtonWebApp, MenuButtonDefault]

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -72,35 +72,29 @@ if TYPE_CHECKING:
     from .giveaway_completed import GiveawayCompleted
     from .giveaway_created import GiveawayCreated
     from .giveaway_winners import GiveawayWinners
-    from .inaccessible_message import InaccessibleMessage
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
-    from .input_media_animation import InputMediaAnimation
     from .input_media_audio import InputMediaAudio
     from .input_media_document import InputMediaDocument
     from .input_media_photo import InputMediaPhoto
+    from .input_media_union import InputMediaUnion
     from .input_media_video import InputMediaVideo
-    from .input_paid_media_photo import InputPaidMediaPhoto
-    from .input_paid_media_video import InputPaidMediaVideo
+    from .input_paid_media_union import InputPaidMediaUnion
     from .input_poll_option import InputPollOption
     from .invoice import Invoice
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
     from .location import Location
+    from .maybe_inaccessible_message_union import MaybeInaccessibleMessageUnion
     from .message_auto_delete_timer_changed import MessageAutoDeleteTimerChanged
     from .message_entity import MessageEntity
-    from .message_origin_channel import MessageOriginChannel
-    from .message_origin_chat import MessageOriginChat
-    from .message_origin_hidden_user import MessageOriginHiddenUser
-    from .message_origin_user import MessageOriginUser
+    from .message_origin_union import MessageOriginUnion
     from .paid_media_info import PaidMediaInfo
     from .passport_data import PassportData
     from .photo_size import PhotoSize
     from .poll import Poll
     from .proximity_alert_triggered import ProximityAlertTriggered
-    from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
-    from .reaction_type_emoji import ReactionTypeEmoji
-    from .reaction_type_paid import ReactionTypePaid
+    from .reaction_type_union import ReactionTypeUnion
     from .refunded_payment import RefundedPayment
     from .reply_keyboard_markup import ReplyKeyboardMarkup
     from .reply_keyboard_remove import ReplyKeyboardRemove
@@ -148,9 +142,7 @@ class Message(MaybeInaccessibleMessage):
     """*Optional*. The bot that actually sent the message on behalf of the business account. Available only for outgoing messages sent on behalf of the connected business account."""
     business_connection_id: Optional[str] = None
     """*Optional*. Unique identifier of the business connection from which the message was received. If non-empty, the message belongs to a chat of the corresponding business account that is independent from any potential bot chat which might share the same identifier."""
-    forward_origin: Optional[
-        Union[MessageOriginUser, MessageOriginHiddenUser, MessageOriginChat, MessageOriginChannel]
-    ] = None
+    forward_origin: Optional[MessageOriginUnion] = None
     """*Optional*. Information about the original message for forwarded messages"""
     is_topic_message: Optional[bool] = None
     """*Optional*. :code:`True`, if the message is sent to a forum topic"""
@@ -246,7 +238,7 @@ class Message(MaybeInaccessibleMessage):
     """*Optional*. The group has been migrated to a supergroup with the specified identifier. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier."""
     migrate_from_chat_id: Optional[int] = None
     """*Optional*. The supergroup has been migrated from a group with the specified identifier. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier."""
-    pinned_message: Optional[Union[Message, InaccessibleMessage]] = None
+    pinned_message: Optional[MaybeInaccessibleMessageUnion] = None
     """*Optional*. Specified message was pinned. Note that the Message object in this field will not contain further *reply_to_message* fields even if it itself is a reply."""
     invoice: Optional[Invoice] = None
     """*Optional*. Message is an invoice for a `payment <https://core.telegram.org/bots/api#payments>`_, information about the invoice. `More about payments » <https://core.telegram.org/bots/api#payments>`_"""
@@ -354,14 +346,7 @@ class Message(MaybeInaccessibleMessage):
             sender_boost_count: Optional[int] = None,
             sender_business_bot: Optional[User] = None,
             business_connection_id: Optional[str] = None,
-            forward_origin: Optional[
-                Union[
-                    MessageOriginUser,
-                    MessageOriginHiddenUser,
-                    MessageOriginChat,
-                    MessageOriginChannel,
-                ]
-            ] = None,
+            forward_origin: Optional[MessageOriginUnion] = None,
             is_topic_message: Optional[bool] = None,
             is_automatic_forward: Optional[bool] = None,
             reply_to_message: Optional[Message] = None,
@@ -409,7 +394,7 @@ class Message(MaybeInaccessibleMessage):
             message_auto_delete_timer_changed: Optional[MessageAutoDeleteTimerChanged] = None,
             migrate_to_chat_id: Optional[int] = None,
             migrate_from_chat_id: Optional[int] = None,
-            pinned_message: Optional[Union[Message, InaccessibleMessage]] = None,
+            pinned_message: Optional[MaybeInaccessibleMessageUnion] = None,
             invoice: Optional[Invoice] = None,
             successful_payment: Optional[SuccessfulPayment] = None,
             refunded_payment: Optional[RefundedPayment] = None,
@@ -3745,13 +3730,7 @@ class Message(MaybeInaccessibleMessage):
 
     def edit_media(
         self,
-        media: Union[
-            InputMediaAnimation,
-            InputMediaDocument,
-            InputMediaAudio,
-            InputMediaPhoto,
-            InputMediaVideo,
-        ],
+        media: InputMediaUnion,
         inline_message_id: Optional[str] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
         **kwargs: Any,
@@ -4177,9 +4156,7 @@ class Message(MaybeInaccessibleMessage):
 
     def react(
         self,
-        reaction: Optional[
-            list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
-        ] = None,
+        reaction: Optional[list[ReactionTypeUnion]] = None,
         is_big: Optional[bool] = None,
         **kwargs: Any,
     ) -> SetMessageReaction:
@@ -4220,7 +4197,7 @@ class Message(MaybeInaccessibleMessage):
     def answer_paid_media(
         self,
         star_count: int,
-        media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+        media: list[InputPaidMediaUnion],
         payload: Optional[str] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[str] = None,
@@ -4292,7 +4269,7 @@ class Message(MaybeInaccessibleMessage):
     def reply_paid_media(
         self,
         star_count: int,
-        media: list[Union[InputPaidMediaPhoto, InputPaidMediaVideo]],
+        media: list[InputPaidMediaUnion],
         payload: Optional[str] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[str] = None,

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pydantic import Field
@@ -55,12 +54,13 @@ if TYPE_CHECKING:
     from .chat import Chat
     from .chat_background import ChatBackground
     from .chat_boost_added import ChatBoostAdded
+    from .chat_id_union import ChatIdUnion
     from .chat_shared import ChatShared
     from .contact import Contact
+    from .date_time_union import DateTimeUnion
     from .dice import Dice
     from .document import Document
     from .external_reply_info import ExternalReplyInfo
-    from .force_reply import ForceReply
     from .forum_topic_closed import ForumTopicClosed
     from .forum_topic_created import ForumTopicCreated
     from .forum_topic_edited import ForumTopicEdited
@@ -74,18 +74,17 @@ if TYPE_CHECKING:
     from .giveaway_winners import GiveawayWinners
     from .inline_keyboard_markup import InlineKeyboardMarkup
     from .input_file import InputFile
-    from .input_media_audio import InputMediaAudio
-    from .input_media_document import InputMediaDocument
-    from .input_media_photo import InputMediaPhoto
+    from .input_file_union import InputFileUnion
     from .input_media_union import InputMediaUnion
-    from .input_media_video import InputMediaVideo
     from .input_paid_media_union import InputPaidMediaUnion
     from .input_poll_option import InputPollOption
+    from .input_poll_option_union import InputPollOptionUnion
     from .invoice import Invoice
     from .labeled_price import LabeledPrice
     from .link_preview_options import LinkPreviewOptions
     from .location import Location
     from .maybe_inaccessible_message_union import MaybeInaccessibleMessageUnion
+    from .media_union import MediaUnion
     from .message_auto_delete_timer_changed import MessageAutoDeleteTimerChanged
     from .message_entity import MessageEntity
     from .message_origin_union import MessageOriginUnion
@@ -97,7 +96,7 @@ if TYPE_CHECKING:
     from .reaction_type_union import ReactionTypeUnion
     from .refunded_payment import RefundedPayment
     from .reply_keyboard_markup import ReplyKeyboardMarkup
-    from .reply_keyboard_remove import ReplyKeyboardRemove
+    from .reply_markup_union import ReplyMarkupUnion
     from .sticker import Sticker
     from .story import Story
     from .successful_payment import SuccessfulPayment
@@ -683,7 +682,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
@@ -699,9 +698,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendAnimation:
@@ -771,7 +768,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_animation(
         self,
-        animation: Union[InputFile, str],
+        animation: InputFileUnion,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
@@ -788,9 +785,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -863,7 +858,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -875,9 +870,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendAudio:
@@ -944,7 +937,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_audio(
         self,
-        audio: Union[InputFile, str],
+        audio: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -957,9 +950,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1037,9 +1028,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendContact:
@@ -1106,9 +1095,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1169,7 +1156,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         thumbnail: Optional[InputFile] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1179,9 +1166,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendDocument:
@@ -1243,7 +1228,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_document(
         self,
-        document: Union[InputFile, str],
+        document: InputFileUnion,
         thumbnail: Optional[InputFile] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
@@ -1254,9 +1239,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1687,9 +1670,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendLocation:
@@ -1762,9 +1743,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -1829,7 +1808,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
@@ -1883,7 +1862,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_media_group(
         self,
-        media: list[Union[InputMediaAudio, InputMediaDocument, InputMediaPhoto, InputMediaVideo]],
+        media: list[MediaUnion],
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
@@ -1951,9 +1930,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -2027,9 +2004,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         disable_web_page_preview: Optional[Union[bool, Default]] = Default(
             "link_preview_is_disabled"
@@ -2095,7 +2070,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2107,9 +2082,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendPhoto:
@@ -2171,7 +2144,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_photo(
         self,
-        photo: Union[InputFile, str],
+        photo: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2184,9 +2157,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2252,7 +2223,7 @@ class Message(MaybeInaccessibleMessage):
     def reply_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         question_entities: Optional[list[MessageEntity]] = None,
         is_anonymous: Optional[bool] = None,
@@ -2263,15 +2234,13 @@ class Message(MaybeInaccessibleMessage):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendPoll:
@@ -2350,7 +2319,7 @@ class Message(MaybeInaccessibleMessage):
     def answer_poll(
         self,
         question: str,
-        options: list[Union[InputPollOption, str]],
+        options: list[InputPollOptionUnion],
         question_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         question_entities: Optional[list[MessageEntity]] = None,
         is_anonymous: Optional[bool] = None,
@@ -2361,16 +2330,14 @@ class Message(MaybeInaccessibleMessage):
         explanation_parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         explanation_entities: Optional[list[MessageEntity]] = None,
         open_period: Optional[int] = None,
-        close_date: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        close_date: Optional[DateTimeUnion] = None,
         is_closed: Optional[bool] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2456,9 +2423,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendDice:
@@ -2516,9 +2481,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2573,15 +2536,13 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         emoji: Optional[str] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendSticker:
@@ -2635,16 +2596,14 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_sticker(
         self,
-        sticker: Union[InputFile, str],
+        sticker: InputFileUnion,
         emoji: Optional[str] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2713,9 +2672,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVenue:
@@ -2794,9 +2751,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -2865,13 +2820,13 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2884,9 +2839,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVideo:
@@ -2962,13 +2915,13 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_video(
         self,
-        video: Union[InputFile, str],
+        video: InputFileUnion,
         duration: Optional[int] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
-        cover: Optional[Union[InputFile, str]] = None,
-        start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        cover: Optional[InputFileUnion] = None,
+        start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -2982,9 +2935,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -3063,7 +3014,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         duration: Optional[int] = None,
         length: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -3071,9 +3022,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVideoNote:
@@ -3131,7 +3080,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_video_note(
         self,
-        video_note: Union[InputFile, str],
+        video_note: InputFileUnion,
         duration: Optional[int] = None,
         length: Optional[int] = None,
         thumbnail: Optional[InputFile] = None,
@@ -3140,9 +3089,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -3203,7 +3150,7 @@ class Message(MaybeInaccessibleMessage):
 
     def reply_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -3212,9 +3159,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         **kwargs: Any,
     ) -> SendVoice:
@@ -3274,7 +3219,7 @@ class Message(MaybeInaccessibleMessage):
 
     def answer_voice(
         self,
-        voice: Union[InputFile, str],
+        voice: InputFileUnion,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -3284,9 +3229,7 @@ class Message(MaybeInaccessibleMessage):
         allow_paid_broadcast: Optional[bool] = None,
         message_effect_id: Optional[str] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -3546,9 +3489,9 @@ class Message(MaybeInaccessibleMessage):
 
     def copy_to(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: Optional[int] = None,
-        video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        video_start_timestamp: Optional[DateTimeUnion] = None,
         caption: Optional[str] = None,
         parse_mode: Optional[Union[str, Default]] = Default("parse_mode"),
         caption_entities: Optional[list[MessageEntity]] = None,
@@ -3559,9 +3502,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         allow_paid_broadcast: Optional[bool] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         allow_sending_without_reply: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
         **kwargs: Any,
@@ -3683,9 +3624,9 @@ class Message(MaybeInaccessibleMessage):
 
     def forward(
         self,
-        chat_id: Union[int, str],
+        chat_id: ChatIdUnion,
         message_thread_id: Optional[int] = None,
-        video_start_timestamp: Optional[Union[datetime.datetime, datetime.timedelta, int]] = None,
+        video_start_timestamp: Optional[DateTimeUnion] = None,
         disable_notification: Optional[bool] = None,
         protect_content: Optional[Union[bool, Default]] = Default("protect_content"),
         **kwargs: Any,
@@ -4207,9 +4148,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_parameters: Optional[ReplyParameters] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         **kwargs: Any,
     ) -> SendPaidMedia:
         """
@@ -4278,9 +4217,7 @@ class Message(MaybeInaccessibleMessage):
         disable_notification: Optional[bool] = None,
         protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
-        reply_markup: Optional[
-            Union[InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply]
-        ] = None,
+        reply_markup: Optional[ReplyMarkupUnion] = None,
         **kwargs: Any,
     ) -> SendPaidMedia:
         """

--- a/aiogram/types/message_origin_union.py
+++ b/aiogram/types/message_origin_union.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .message_origin_channel import MessageOriginChannel
+from .message_origin_chat import MessageOriginChat
+from .message_origin_hidden_user import MessageOriginHiddenUser
+from .message_origin_user import MessageOriginUser
+
+MessageOriginUnion = Union[
+    MessageOriginUser, MessageOriginHiddenUser, MessageOriginChat, MessageOriginChannel
+]

--- a/aiogram/types/message_reaction_updated.py
+++ b/aiogram/types/message_reaction_updated.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
     from .chat import Chat
     from .custom import DateTime
-    from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
-    from .reaction_type_emoji import ReactionTypeEmoji
-    from .reaction_type_paid import ReactionTypePaid
+    from .reaction_type_union import ReactionTypeUnion
     from .user import User
 
 
@@ -26,9 +24,9 @@ class MessageReactionUpdated(TelegramObject):
     """Unique identifier of the message inside the chat"""
     date: DateTime
     """Date of the change in Unix time"""
-    old_reaction: list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
+    old_reaction: list[ReactionTypeUnion]
     """Previous list of reaction types that were set by the user"""
-    new_reaction: list[Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]]
+    new_reaction: list[ReactionTypeUnion]
     """New list of reaction types that have been set by the user"""
     user: Optional[User] = None
     """*Optional*. The user that changed the reaction, if the user isn't anonymous"""
@@ -45,12 +43,8 @@ class MessageReactionUpdated(TelegramObject):
             chat: Chat,
             message_id: int,
             date: DateTime,
-            old_reaction: list[
-                Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]
-            ],
-            new_reaction: list[
-                Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]
-            ],
+            old_reaction: list[ReactionTypeUnion],
+            new_reaction: list[ReactionTypeUnion],
             user: Optional[User] = None,
             actor_chat: Optional[Chat] = None,
             **__pydantic_kwargs: Any,

--- a/aiogram/types/paid_media_info.py
+++ b/aiogram/types/paid_media_info.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
-    from .paid_media_photo import PaidMediaPhoto
-    from .paid_media_preview import PaidMediaPreview
-    from .paid_media_video import PaidMediaVideo
+    from .paid_media_union import PaidMediaUnion
 
 
 class PaidMediaInfo(TelegramObject):
@@ -19,7 +17,7 @@ class PaidMediaInfo(TelegramObject):
 
     star_count: int
     """The number of Telegram Stars that must be paid to buy access to the media"""
-    paid_media: list[Union[PaidMediaPreview, PaidMediaPhoto, PaidMediaVideo]]
+    paid_media: list[PaidMediaUnion]
     """Information about the paid media"""
 
     if TYPE_CHECKING:
@@ -30,7 +28,7 @@ class PaidMediaInfo(TelegramObject):
             __pydantic__self__,
             *,
             star_count: int,
-            paid_media: list[Union[PaidMediaPreview, PaidMediaPhoto, PaidMediaVideo]],
+            paid_media: list[PaidMediaUnion],
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/paid_media_union.py
+++ b/aiogram/types/paid_media_union.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .paid_media_photo import PaidMediaPhoto
+from .paid_media_preview import PaidMediaPreview
+from .paid_media_video import PaidMediaVideo
+
+PaidMediaUnion = Union[PaidMediaPreview, PaidMediaPhoto, PaidMediaVideo]

--- a/aiogram/types/passport_element_error_union.py
+++ b/aiogram/types/passport_element_error_union.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .passport_element_error_data_field import PassportElementErrorDataField
+from .passport_element_error_file import PassportElementErrorFile
+from .passport_element_error_files import PassportElementErrorFiles
+from .passport_element_error_front_side import PassportElementErrorFrontSide
+from .passport_element_error_reverse_side import PassportElementErrorReverseSide
+from .passport_element_error_selfie import PassportElementErrorSelfie
+from .passport_element_error_translation_file import PassportElementErrorTranslationFile
+from .passport_element_error_translation_files import (
+    PassportElementErrorTranslationFiles,
+)
+from .passport_element_error_unspecified import PassportElementErrorUnspecified
+
+PassportElementErrorUnion = Union[
+    PassportElementErrorDataField,
+    PassportElementErrorFrontSide,
+    PassportElementErrorReverseSide,
+    PassportElementErrorSelfie,
+    PassportElementErrorFile,
+    PassportElementErrorFiles,
+    PassportElementErrorTranslationFile,
+    PassportElementErrorTranslationFiles,
+    PassportElementErrorUnspecified,
+]

--- a/aiogram/types/prepared_inline_message.py
+++ b/aiogram/types/prepared_inline_message.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .base import TelegramObject
+
+if TYPE_CHECKING:
+    from .date_time_union import DateTimeUnion
 
 
 class PreparedInlineMessage(TelegramObject):
@@ -15,7 +17,7 @@ class PreparedInlineMessage(TelegramObject):
 
     id: str
     """Unique identifier of the prepared message"""
-    expiration_date: Union[datetime.datetime, datetime.timedelta, int]
+    expiration_date: DateTimeUnion
     """Expiration date of the prepared message, in Unix time. Expired prepared messages can no longer be used"""
 
     if TYPE_CHECKING:
@@ -26,7 +28,7 @@ class PreparedInlineMessage(TelegramObject):
             __pydantic__self__,
             *,
             id: str,
-            expiration_date: Union[datetime.datetime, datetime.timedelta, int],
+            expiration_date: DateTimeUnion,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/reaction_count.py
+++ b/aiogram/types/reaction_count.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from .base import TelegramObject
 
 if TYPE_CHECKING:
-    from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
-    from .reaction_type_emoji import ReactionTypeEmoji
-    from .reaction_type_paid import ReactionTypePaid
+    from .reaction_type_union import ReactionTypeUnion
 
 
 class ReactionCount(TelegramObject):
@@ -17,7 +15,7 @@ class ReactionCount(TelegramObject):
     Source: https://core.telegram.org/bots/api#reactioncount
     """
 
-    type: Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]
+    type: ReactionTypeUnion
     """Type of the reaction"""
     total_count: int
     """Number of times the reaction was added"""
@@ -29,7 +27,7 @@ class ReactionCount(TelegramObject):
         def __init__(
             __pydantic__self__,
             *,
-            type: Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid],
+            type: ReactionTypeUnion,
             total_count: int,
             **__pydantic_kwargs: Any,
         ) -> None:

--- a/aiogram/types/reaction_type_union.py
+++ b/aiogram/types/reaction_type_union.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
+from .reaction_type_emoji import ReactionTypeEmoji
+from .reaction_type_paid import ReactionTypePaid
+
+ReactionTypeUnion = Union[ReactionTypeEmoji, ReactionTypeCustomEmoji, ReactionTypePaid]

--- a/aiogram/types/reply_markup_union.py
+++ b/aiogram/types/reply_markup_union.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .force_reply import ForceReply
+from .inline_keyboard_markup import InlineKeyboardMarkup
+from .reply_keyboard_markup import ReplyKeyboardMarkup
+from .reply_keyboard_remove import ReplyKeyboardRemove
+
+ReplyMarkupUnion = Union[
+    InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply
+]

--- a/aiogram/types/reply_parameters.py
+++ b/aiogram/types/reply_parameters.py
@@ -6,6 +6,7 @@ from ..client.default import Default
 from .base import TelegramObject
 
 if TYPE_CHECKING:
+    from .chat_id_union import ChatIdUnion
     from .message_entity import MessageEntity
 
 
@@ -18,7 +19,7 @@ class ReplyParameters(TelegramObject):
 
     message_id: int
     """Identifier of the message that will be replied to in the current chat, or in the chat *chat_id* if it is specified"""
-    chat_id: Optional[Union[int, str]] = None
+    chat_id: Optional[ChatIdUnion] = None
     """*Optional*. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format :code:`@channelusername`). Not supported for messages sent on behalf of a business account."""
     allow_sending_without_reply: Optional[Union[bool, Default]] = Default(
         "allow_sending_without_reply"
@@ -41,7 +42,7 @@ class ReplyParameters(TelegramObject):
             __pydantic__self__,
             *,
             message_id: int,
-            chat_id: Optional[Union[int, str]] = None,
+            chat_id: Optional[ChatIdUnion] = None,
             allow_sending_without_reply: Optional[Union[bool, Default]] = Default(
                 "allow_sending_without_reply"
             ),

--- a/aiogram/types/result_chat_member_union.py
+++ b/aiogram/types/result_chat_member_union.py
@@ -1,0 +1,17 @@
+from typing import Union
+
+from .chat_member_administrator import ChatMemberAdministrator
+from .chat_member_banned import ChatMemberBanned
+from .chat_member_left import ChatMemberLeft
+from .chat_member_member import ChatMemberMember
+from .chat_member_owner import ChatMemberOwner
+from .chat_member_restricted import ChatMemberRestricted
+
+ResultChatMemberUnion = Union[
+    ChatMemberOwner,
+    ChatMemberAdministrator,
+    ChatMemberMember,
+    ChatMemberRestricted,
+    ChatMemberLeft,
+    ChatMemberBanned,
+]

--- a/aiogram/types/result_menu_button_union.py
+++ b/aiogram/types/result_menu_button_union.py
@@ -1,0 +1,7 @@
+from typing import Union
+
+from .menu_button_commands import MenuButtonCommands
+from .menu_button_default import MenuButtonDefault
+from .menu_button_web_app import MenuButtonWebApp
+
+ResultMenuButtonUnion = Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands]

--- a/aiogram/types/revenue_withdrawal_state_union.py
+++ b/aiogram/types/revenue_withdrawal_state_union.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .revenue_withdrawal_state_failed import RevenueWithdrawalStateFailed
+from .revenue_withdrawal_state_pending import RevenueWithdrawalStatePending
+from .revenue_withdrawal_state_succeeded import RevenueWithdrawalStateSucceeded
+
+RevenueWithdrawalStateUnion = Union[
+    RevenueWithdrawalStatePending, RevenueWithdrawalStateSucceeded, RevenueWithdrawalStateFailed
+]

--- a/aiogram/types/star_transaction.py
+++ b/aiogram/types/star_transaction.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from .base import TelegramObject
 from .custom import DateTime
 
 if TYPE_CHECKING:
-    from .transaction_partner_affiliate_program import (
-        TransactionPartnerAffiliateProgram,
-    )
-    from .transaction_partner_chat import TransactionPartnerChat
-    from .transaction_partner_fragment import TransactionPartnerFragment
-    from .transaction_partner_other import TransactionPartnerOther
-    from .transaction_partner_telegram_ads import TransactionPartnerTelegramAds
-    from .transaction_partner_telegram_api import TransactionPartnerTelegramApi
-    from .transaction_partner_user import TransactionPartnerUser
+    from .transaction_partner_union import TransactionPartnerUnion
 
 
 class StarTransaction(TelegramObject):
@@ -32,29 +24,9 @@ class StarTransaction(TelegramObject):
     """Date the transaction was created in Unix time"""
     nanostar_amount: Optional[int] = None
     """*Optional*. The number of 1/1000000000 shares of Telegram Stars transferred by the transaction; from 0 to 999999999"""
-    source: Optional[
-        Union[
-            TransactionPartnerUser,
-            TransactionPartnerChat,
-            TransactionPartnerAffiliateProgram,
-            TransactionPartnerFragment,
-            TransactionPartnerTelegramAds,
-            TransactionPartnerTelegramApi,
-            TransactionPartnerOther,
-        ]
-    ] = None
+    source: Optional[TransactionPartnerUnion] = None
     """*Optional*. Source of an incoming transaction (e.g., a user purchasing goods or services, Fragment refunding a failed withdrawal). Only for incoming transactions"""
-    receiver: Optional[
-        Union[
-            TransactionPartnerUser,
-            TransactionPartnerChat,
-            TransactionPartnerAffiliateProgram,
-            TransactionPartnerFragment,
-            TransactionPartnerTelegramAds,
-            TransactionPartnerTelegramApi,
-            TransactionPartnerOther,
-        ]
-    ] = None
+    receiver: Optional[TransactionPartnerUnion] = None
     """*Optional*. Receiver of an outgoing transaction (e.g., a user for a purchase refund, Fragment for a withdrawal). Only for outgoing transactions"""
 
     if TYPE_CHECKING:
@@ -68,28 +40,8 @@ class StarTransaction(TelegramObject):
             amount: int,
             date: DateTime,
             nanostar_amount: Optional[int] = None,
-            source: Optional[
-                Union[
-                    TransactionPartnerUser,
-                    TransactionPartnerChat,
-                    TransactionPartnerAffiliateProgram,
-                    TransactionPartnerFragment,
-                    TransactionPartnerTelegramAds,
-                    TransactionPartnerTelegramApi,
-                    TransactionPartnerOther,
-                ]
-            ] = None,
-            receiver: Optional[
-                Union[
-                    TransactionPartnerUser,
-                    TransactionPartnerChat,
-                    TransactionPartnerAffiliateProgram,
-                    TransactionPartnerFragment,
-                    TransactionPartnerTelegramAds,
-                    TransactionPartnerTelegramApi,
-                    TransactionPartnerOther,
-                ]
-            ] = None,
+            source: Optional[TransactionPartnerUnion] = None,
+            receiver: Optional[TransactionPartnerUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/transaction_partner_fragment.py
+++ b/aiogram/types/transaction_partner_fragment.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import TransactionPartnerType
 from .transaction_partner import TransactionPartner
 
 if TYPE_CHECKING:
-    from .revenue_withdrawal_state_failed import RevenueWithdrawalStateFailed
-    from .revenue_withdrawal_state_pending import RevenueWithdrawalStatePending
-    from .revenue_withdrawal_state_succeeded import RevenueWithdrawalStateSucceeded
+    from .revenue_withdrawal_state_union import RevenueWithdrawalStateUnion
 
 
 class TransactionPartnerFragment(TransactionPartner):
@@ -20,13 +18,7 @@ class TransactionPartnerFragment(TransactionPartner):
 
     type: Literal[TransactionPartnerType.FRAGMENT] = TransactionPartnerType.FRAGMENT
     """Type of the transaction partner, always 'fragment'"""
-    withdrawal_state: Optional[
-        Union[
-            RevenueWithdrawalStatePending,
-            RevenueWithdrawalStateSucceeded,
-            RevenueWithdrawalStateFailed,
-        ]
-    ] = None
+    withdrawal_state: Optional[RevenueWithdrawalStateUnion] = None
     """*Optional*. State of the transaction if the transaction is outgoing"""
 
     if TYPE_CHECKING:
@@ -37,13 +29,7 @@ class TransactionPartnerFragment(TransactionPartner):
             __pydantic__self__,
             *,
             type: Literal[TransactionPartnerType.FRAGMENT] = TransactionPartnerType.FRAGMENT,
-            withdrawal_state: Optional[
-                Union[
-                    RevenueWithdrawalStatePending,
-                    RevenueWithdrawalStateSucceeded,
-                    RevenueWithdrawalStateFailed,
-                ]
-            ] = None,
+            withdrawal_state: Optional[RevenueWithdrawalStateUnion] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             # DO NOT EDIT MANUALLY!!!

--- a/aiogram/types/transaction_partner_union.py
+++ b/aiogram/types/transaction_partner_union.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Union
+
+from .transaction_partner_affiliate_program import TransactionPartnerAffiliateProgram
+from .transaction_partner_chat import TransactionPartnerChat
+from .transaction_partner_fragment import TransactionPartnerFragment
+from .transaction_partner_other import TransactionPartnerOther
+from .transaction_partner_telegram_ads import TransactionPartnerTelegramAds
+from .transaction_partner_telegram_api import TransactionPartnerTelegramApi
+from .transaction_partner_user import TransactionPartnerUser
+
+TransactionPartnerUnion = Union[
+    TransactionPartnerUser,
+    TransactionPartnerChat,
+    TransactionPartnerAffiliateProgram,
+    TransactionPartnerFragment,
+    TransactionPartnerTelegramAds,
+    TransactionPartnerTelegramApi,
+    TransactionPartnerOther,
+]

--- a/aiogram/types/transaction_partner_user.py
+++ b/aiogram/types/transaction_partner_user.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..enums import TransactionPartnerType
 from .transaction_partner import TransactionPartner
@@ -8,9 +8,7 @@ from .transaction_partner import TransactionPartner
 if TYPE_CHECKING:
     from .affiliate_info import AffiliateInfo
     from .gift import Gift
-    from .paid_media_photo import PaidMediaPhoto
-    from .paid_media_preview import PaidMediaPreview
-    from .paid_media_video import PaidMediaVideo
+    from .paid_media_union import PaidMediaUnion
     from .user import User
 
 
@@ -31,7 +29,7 @@ class TransactionPartnerUser(TransactionPartner):
     """*Optional*. Bot-specified invoice payload"""
     subscription_period: Optional[int] = None
     """*Optional*. The duration of the paid subscription"""
-    paid_media: Optional[list[Union[PaidMediaPreview, PaidMediaPhoto, PaidMediaVideo]]] = None
+    paid_media: Optional[list[PaidMediaUnion]] = None
     """*Optional*. Information about the paid media bought by the user"""
     paid_media_payload: Optional[str] = None
     """*Optional*. Bot-specified paid media payload"""
@@ -50,9 +48,7 @@ class TransactionPartnerUser(TransactionPartner):
             affiliate: Optional[AffiliateInfo] = None,
             invoice_payload: Optional[str] = None,
             subscription_period: Optional[int] = None,
-            paid_media: Optional[
-                list[Union[PaidMediaPreview, PaidMediaPhoto, PaidMediaVideo]]
-            ] = None,
+            paid_media: Optional[list[PaidMediaUnion]] = None,
             paid_media_payload: Optional[str] = None,
             gift: Optional[Gift] = None,
             **__pydantic_kwargs: Any,

--- a/docs/api/methods/get_chat_administrators.rst
+++ b/docs/api/methods/get_chat_administrators.rst
@@ -2,7 +2,7 @@
 getChatAdministrators
 #####################
 
-Returns: :obj:`list[Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned]]`
+Returns: :obj:`list[ResultChatMemberUnion]`
 
 .. automodule:: aiogram.methods.get_chat_administrators
     :members:
@@ -19,7 +19,7 @@ As bot method
 
 .. code-block::
 
-    result: list[Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned]] = await bot.get_chat_administrators(...)
+    result: list[ResultChatMemberUnion] = await bot.get_chat_administrators(...)
 
 
 Method as object
@@ -35,7 +35,7 @@ With specific bot
 
 .. code-block:: python
 
-    result: list[Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned]] = await bot(GetChatAdministrators(...))
+    result: list[ResultChatMemberUnion] = await bot(GetChatAdministrators(...))
 
 
 

--- a/docs/api/methods/get_chat_member.rst
+++ b/docs/api/methods/get_chat_member.rst
@@ -2,7 +2,7 @@
 getChatMember
 #############
 
-Returns: :obj:`Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned]`
+Returns: :obj:`ResultChatMemberUnion`
 
 .. automodule:: aiogram.methods.get_chat_member
     :members:
@@ -19,7 +19,7 @@ As bot method
 
 .. code-block::
 
-    result: Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned] = await bot.get_chat_member(...)
+    result: ResultChatMemberUnion = await bot.get_chat_member(...)
 
 
 Method as object
@@ -35,7 +35,7 @@ With specific bot
 
 .. code-block:: python
 
-    result: Union[ChatMemberOwner, ChatMemberAdministrator, ChatMemberMember, ChatMemberRestricted, ChatMemberLeft, ChatMemberBanned] = await bot(GetChatMember(...))
+    result: ResultChatMemberUnion = await bot(GetChatMember(...))
 
 
 

--- a/docs/api/methods/get_chat_menu_button.rst
+++ b/docs/api/methods/get_chat_menu_button.rst
@@ -2,7 +2,7 @@
 getChatMenuButton
 #################
 
-Returns: :obj:`Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands]`
+Returns: :obj:`ResultMenuButtonUnion`
 
 .. automodule:: aiogram.methods.get_chat_menu_button
     :members:
@@ -19,7 +19,7 @@ As bot method
 
 .. code-block::
 
-    result: Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands] = await bot.get_chat_menu_button(...)
+    result: ResultMenuButtonUnion = await bot.get_chat_menu_button(...)
 
 
 Method as object
@@ -35,4 +35,4 @@ With specific bot
 
 .. code-block:: python
 
-    result: Union[MenuButtonDefault, MenuButtonWebApp, MenuButtonCommands] = await bot(GetChatMenuButton(...))
+    result: ResultMenuButtonUnion = await bot(GetChatMenuButton(...))


### PR DESCRIPTION
Implemented Union types across various modules to consolidate and simplify type annotations. This change replaces repetitive union declarations with reusable Union aliases, improving code readability and maintainability. Updates applied to affected classes, methods, and imports accordingly.

Fixes: #1592 