### PR TITLE
chore: bump `pydantic` upper bound from <2.11 to <2.12

### DIFF
--- a/CHANGES/1659.misc.rst
+++ b/CHANGES/1659.misc.rst
@@ -1,0 +1,1 @@
+Bump pydantic upper bound from <2.11 to <2.12.

--- a/CHANGES/1659.misc.rst
+++ b/CHANGES/1659.misc.rst
@@ -1,1 +1,2 @@
 Bump pydantic upper bound from <2.11 to <2.12.
+Upgrading `pydantic` to version 2.11 significantly reduces resource consumption, more details on the `pydantic blog post <https://pydantic.dev/articles/pydantic-v2-11-release>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.12",
-    "pydantic>=2.4.1,<2.11",
+    "pydantic>=2.4.1,<2.12",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",


### PR DESCRIPTION
# Description

Bump pydantic upper bound from <2.11 to <2.12.

Upgrading `pydantic` to version 2.11 significantly reduces resource consumption

pydantic blog post: https://pydantic.dev/articles/pydantic-v2-11-release