### PR TITLE
misc: simplify running non-async callback using asyncio.to_thread

### DIFF
--- a/CHANGES/1661.misc.rst
+++ b/CHANGES/1661.misc.rst
@@ -1,0 +1,1 @@
+Replaced ```loop.run_in_executor``` with ```asyncio.to_thread``` for improved readability and consistency.

--- a/aiogram/dispatcher/event/handler.py
+++ b/aiogram/dispatcher/event/handler.py
@@ -41,11 +41,7 @@ class CallableObject:
         wrapped = partial(self.callback, *args, **self._prepare_kwargs(kwargs))
         if self.awaitable:
             return await wrapped()
-
-        loop = asyncio.get_event_loop()
-        context = contextvars.copy_context()
-        wrapped = partial(context.run, wrapped)
-        return await loop.run_in_executor(None, wrapped)
+        return await asyncio.to_thread(wrapped)
 
 
 @dataclass


### PR DESCRIPTION
# Description

Replaced `loop.run_in_executor` with `asyncio.to_thread` for improved readability and consistency.  
This change does not affect functionality but simplifies the code.  

No related issue.

## Type of change

- [x] Miscellaneous (code cleanup, refactoring, minor improvements)

# How Has This Been Tested?

Since this is a non-functional change, no new tests were required.  
Existing tests were run to ensure there were no regressions.

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Existing unit tests pass locally with my changes
