### PR TITLE
[#1653, #1654] docs: fix code block formatting in router.rst

### DIFF
--- a/CHANGES/1666.doc.rst
+++ b/CHANGES/1666.doc.rst
@@ -1,0 +1,1 @@
+Fixed broken code block formatting in ``router.rst`` caused by incorrect indentation of directive options.

--- a/docs/dispatcher/router.rst
+++ b/docs/dispatcher/router.rst
@@ -232,7 +232,7 @@ Example:
 
 .. code-block:: python
     :caption: module_1.py
-:name: module_1
+    :name: module_1
 
     router2 = Router()
 
@@ -242,7 +242,7 @@ Example:
 
 .. code-block:: python
     :caption: module_2.py
-:name: module_2
+    :name: module_2
 
     from module_2 import router2
 


### PR DESCRIPTION
# Description

This pull request fixes issue #1653, where code blocks in the documentation were broken due to incorrect indentation. The affected syntax was:

```rst
.. code-block:: python
    :caption: module_1.py
:name: module_1
```

The issue was caused by a missing indentation for the `:name:` directive, which broke Sphinx rendering. The fix was straightforward and involved properly aligning directive options under the `.. code-block::` line.

Additionally, this PR supersedes #1654, which aimed to fix the same issue but has been inactive for over three weeks.

Fixes #1653  
Closes #1654

## Type of change

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by cloning the repository and building the documentation locally using Sphinx. The affected code blocks now render correctly without any warnings or formatting issues.

**Test Configuration**:
* Operating System: Ubuntu 24.04 LTS
* Python version: 3.12.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes