### PR TITLE
CallbackData with default prefix

### DIFF
--- a/aiogram/filters/callback_data.py
+++ b/aiogram/filters/callback_data.py
@@ -47,24 +47,26 @@ class CallbackData(BaseModel):
 
     This class should be used as super-class of user-defined callbacks.
 
-    The class-keyword :code:`prefix` is required to define prefix
-    and also the argument :code:`sep` can be passed to define separator (default is :code:`:`).
+    An optional class-keyword :code:`prefix` can be passed to define prefix.
+    If no prefix is provided, the class name will be used as the prefix.
+
+    An optional argument :code:`sep` can be passed to define the separator
+    (default is :code:`:`).
     """
 
     if TYPE_CHECKING:
         __separator__: ClassVar[str]
         """Data separator (default is :code:`:`)"""
         __prefix__: ClassVar[str]
-        """Callback prefix"""
+        """Callback prefix (default is class name)"""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        if "prefix" not in kwargs:
-            raise ValueError(
-                f"prefix required, usage example: "
-                f"`class {cls.__name__}(CallbackData, prefix='my_callback'): ...`"
-            )
+        # If no prefix is provided explicitly, default to the class name
+        prefix = kwargs.pop("prefix", None)
+        if prefix is None:
+            prefix = cls.__name__
         cls.__separator__ = kwargs.pop("sep", ":")
-        cls.__prefix__ = kwargs.pop("prefix")
+        cls.__prefix__ = prefix
         if cls.__separator__ in cls.__prefix__:
             raise ValueError(
                 f"Separator symbol {cls.__separator__!r} can not be used "

--- a/tests/test_filters/test_callback_data.py
+++ b/tests/test_filters/test_callback_data.py
@@ -28,13 +28,18 @@ class MyCallback(CallbackData, prefix="test"):
 
 
 class TestCallbackData:
-    def test_init_subclass_prefix_required(self):
-        assert MyCallback.__prefix__ == "test"
+    def test_init_subclass_prefix_optional(self):
+        # Case 1: Explicitly provided prefix
+        class ExplicitCallbackData(CallbackData, prefix="explicit"):
+            pass
 
-        with pytest.raises(ValueError, match="prefix required.+"):
+        assert ExplicitCallbackData.__prefix__ == "explicit"
 
-            class MyInvalidCallback(CallbackData):
-                pass
+        # Case 2: No prefix provided; should default to class name
+        class DefaultCallbackData(CallbackData):
+            pass
+
+        assert DefaultCallbackData.__prefix__ == "DefaultCallbackData"
 
     def test_init_subclass_sep_validation(self):
         assert MyCallback.__separator__ == ":"


### PR DESCRIPTION
# Description

This PR modifies `CallbackData` and makes the prefix optional. By default the class name is used as prefix.

This makes it less tedious to define a large number of custom `CallbackData` classes. For instance:

```python
class SettingsActions:
    class GoBack(CallbackData):
        pass

    class ShowFirstMenu(CallbackData):
        pass

    class ShowSecondMenu(CallbackData):
        pass

    class SetSomeFlag(CallbackData):
        flag: bool
```

**NOTE:** This PR does not touch the documentation, because I was not sure how welcome this change would be. It made my own code easier to maintain. If you think it's useful, I'll update the documentation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

This PR removes one test that checks that an exception is raised when the prefix is not provided. And adds one test that checks the new behavior.

- [x] Test that the prefix is set to class name, when not given explicitly
- [x] Test that the prefix can be set explicitly

**Test Configuration**:
* Operating System: Linux
* Python version: 3.10.12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
