### PR TITLE
Fix: Add alias for `amount` field in `StarAmount` to match API response (star_count)

### DIFF
--- a/CHANGES/1680.bugfix.rst
+++ b/CHANGES/1680.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue in the :code:`StarAmount` type where the field :code:`amount` was not correctly deserialized when retrieving the business account star balance.
+The response from the Telegram API contains the field `star_count`, which now correctly maps to the `amount` field in the `StarAmount` class.

--- a/aiogram/types/star_amount.py
+++ b/aiogram/types/star_amount.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
+from pydantic import Field
+
 from .base import TelegramObject
 
 
@@ -12,7 +14,7 @@ class StarAmount(TelegramObject):
     Source: https://core.telegram.org/bots/api#staramount
     """
 
-    amount: int
+    amount: int = Field(..., alias="star_count")
     """Integer amount of Telegram Stars, rounded to 0; can be negative"""
     nanostar_amount: Optional[int] = None
     """*Optional*. The number of 1/1000000000 shares of Telegram Stars; from -999999999 to 999999999; can be negative if and only if *amount* is non-positive"""


### PR DESCRIPTION
# Description

Fixed the issue with the mapping of the `StarAmount` type  to match the Telegram API response. The issue occurred when trying to retrieve the amount of stars, as the field `amount` was missing in the response, while Telegram returns `star_count`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Called the `get_business_account_star_balance` method and verified that the returned `StarAmount` object now correctly maps the `star_count` field to the `amount` attribute.

- [x] Test with actual Telegram bot API to ensure the fix works as expected

**Test Configuration**:
* Operating System: Windows 10
* Python version: 3.13.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

