### PR TITLE
fix: resolve warning "Expected type 'None', got 'Application' instead"

### DIFF
--- a/aiogram/webhook/aiohttp_server.py
+++ b/aiogram/webhook/aiohttp_server.py
@@ -5,7 +5,7 @@ from asyncio import Transport
 from typing import Any, Awaitable, Callable, Dict, Optional, Set, Tuple, cast
 
 from aiohttp import JsonPayload, MultipartWriter, Payload, web
-from aiohttp.abc import Application
+from aiohttp.web_app import Application
 from aiohttp.typedefs import Handler
 from aiohttp.web_middlewares import middleware
 


### PR DESCRIPTION
Resolves warning "Expected type 'None', got 'Application' instead"

Before:

![image_2025-05-07_11-23-32](https://github.com/user-attachments/assets/a1a9e8e2-c828-419f-b34a-92b2c3f41dd3)

After:

![image](https://github.com/user-attachments/assets/8e0c3c11-559e-47ee-8d91-d5dd39d888f5)


