### PR TITLE
Relax aiohttp versions range

### DIFF
--- a/CHANGES/1700.misc.rst
+++ b/CHANGES/1700.misc.rst
@@ -1,0 +1,1 @@
+Increased max :code:`aiohttp` version support from “<3.12” to “<3.13”

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
-    "aiohttp>=3.9.0,<3.12",
+    "aiohttp>=3.9.0,<3.13",
     "pydantic>=2.4.1,<2.12",
     "aiofiles>=23.2.1,<24.2",
     "certifi>=2023.7.22",


### PR DESCRIPTION
# Description

Bumped `aiohttp` maximum version to `3.13`. This makes `aiogram` compatible with other packages that have `aiohttp>=3.13` requirement.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `uv run pytest` -> "collected 1647 items" -> all passed

**Test Configuration**:
* Operating System: Windows
* Python version: Python 3.13.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
