### PR TITLE
CallableObject Improvements

### DIFF
--- a/CHANGES/1721.bugfix.rst
+++ b/CHANGES/1721.bugfix.rst
@@ -1,0 +1,9 @@
+Bug Fixes
+=========
+
+CallableObject Improvements
+---------------------------
+
+- Correctly detects and awaits coroutine-returning sync callables
+- Supports callable classes with a sync __call__ method
+- Ensures sync functions still run safely in asyncio.to_thread


### PR DESCRIPTION
# Description

Fixes an issue in `CallableObject` and improves its behavior:  
- Callable classes with an `async __call__` method are now correctly detected and awaited.  
- Synchronous callbacks that return coroutines are now properly awaited.  
- Ensures sync functions still run safely in `asyncio.to_thread`.

Fixes #1721

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually with sync and async callables, including callable classes. Verified that:  
- Coroutine-returning sync functions are awaited correctly  
- Sync functions run in `asyncio.to_thread` when necessary  
- No regression in existing async callables  

- [x] Test A: sync function returning a coroutine  
- [x] Test B: callable class with sync `__call__`  

**Test Configuration**:
* Operating System: Any
* Python version: 3.9+

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
