### PR TITLE
Remove :noindex: from `aiogram.Bot` class docs page

### DIFF
--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -19,4 +19,3 @@ For example :code:`sendMessage` named :code:`send_message` and has the same spec
     :member-order: bysource
     :special-members: __init__
     :undoc-members: True
-    :noindex:


### PR DESCRIPTION
# Description

As far as I've seen, there was no issue created about that. I saw a bit of a wrong behaviour and wanted to make a contribution to your project.

I work on a private project related to Telegram bots. We are currently writing bot docs (we use MkDocs along with mkdocstrings if that's relevant), so lots of links and refs to `aiogram` classes appear in our pages. When we type [`aiogram.client.bot.Bot`][], it doesn't work despite the fact that inventory from your docs is loaded. There's workaround in simple markdown pages: we can just use traditional `[]()` links, but for automatic symbol refs it just makes a broken link.

I'm not very familiar with Sphinx, but I think that's caused by `:noindex:` option under calss reference in `bot.rst`. Removal of this option fixes the reference problem. Although, the Sphinx produces the following the following warnings:

```
~/repos/aiogram/aiogram/client/bot.py:docstring of aiogram.client.bot.Bot.download_file:1: WARNING: duplicate object description of aiogram.client.bot.Bot.download_file, other instance in api/bot, use :no-index: for one of them
~/repos/aiogram/aiogram/client/bot.py:docstring of aiogram.client.bot.Bot.download:1: WARNING: duplicate object description of aiogram.client.bot.Bot.download, other instance in api/bot, use :no-index: for one of them
```

You've included that option so that there was no confusion with page `docs/api/download_file.rst`, but it excluded the whole class with other methods from the index.

That means that neither mine or yours is the right solution. I see two ways of how we can resolve this:

1. Rewrite bot.rst like this:

    ```
    .. autoclass:: aiogram.client.bot.Bot
        :members: __init__,token,id,context,me
        :show-inheritance:
        :member-order: bysource
        :special-members: __init__
        :undoc-members: True

    .. automethod:: aiogram.client.bot.Bot.download_file
        :noindex:

    .. automethod:: aiogram.client.bot.Bot.download
        :noindex:
    ```

    Though, it's not very clear solution, as it simply breaks the class description into three parts.

2. Remove `automethod` mentions of these methods from the page "How to download file?" (`docs/api/download_file.rst`), or add `:noindex:` option, or restructure it all in some other way. This approach also implies changing cross-references, so that navigation would be as convenient as it is now, I guess.

Right now, with this PR, I just want to start a conversation. That's a bit of a small deal, but that thing is better to be fixed. Please, discuss in the comments what solution out of all you see as a better one.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I've set it all up and run `sphinx-autobuild --watch aiogram/ docs/ docs/_build/` instruction for quick appearance check of the pages.
    
    Current change doesn't affect the visual appearance of pages in any way. Other proposed above certainly affect it.

- [ ] Then I've changed inventory link in the development repo of our project to the local one (`plugins.mkdocstrings.handlers.python.inventories` option, that is) and tested how these broken links appear. Without `:noindex:` all works just fine. I guess, with `Bot.download` method there might be some confusion, but at least links work and no errors appear.

**Test Configuration**:
* Operating System: WSL Ubuntu distribution on Windows 11
* Python version: Python 3.12.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes *(no need to run unit tests in the first place, though)*
