### PR TITLE
Docs: bot paremeter missing in dispatcher/webhook

### DIFF
--- a/docs/dispatcher/webhook.rst
+++ b/docs/dispatcher/webhook.rst
@@ -115,7 +115,7 @@ or :meth:`aiogram.dispatcher.dispatcher.Dispatcher.feed_update` methods.
 .. code-block:: python
 
     update = Update.model_validate(await request.json(), context={"bot": bot})
-    await dispatcher.feed_update(update)
+    await dispatcher.feed_update(bot, update)
 
 
 .. note::


### PR DESCRIPTION
Docs updated

# Description
bot parameter is required in dispatcher.feed_update method but is not present in the documentation
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
