### PR TITLE
(fix): documentation mistake

### DIFF
--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -4400,7 +4400,6 @@ class Message(MaybeInaccessibleMessage):
 
         - :code:`chat_id`
         - :code:`message_id`
-        - :code:`business_connection_id`
 
         Use this method to change the chosen reactions on a message. Service messages of some types can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel. Bots can't use paid reactions. Returns :code:`True` on success.
 


### PR DESCRIPTION
# Description

Fix one documentation mistake where business_connection_id was wrongly mentioned in the react bound method

Fixes 

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not tested. Documentation fix according to [BOT API](https://core.telegram.org/bots/api#setmessagereaction) documentation.

# Checklist:

- [x] I have made corresponding changes to the documentation

