### PR TITLE
fix(types): align request middleware typing with actual return value

### DIFF
--- a/CHANGES/1723.bugfix.rst
+++ b/CHANGES/1723.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed type hinting for session middlewares where the return type was incorrectly marked as :class:`aiogram.methods.base.Response` instead of the concrete :class:`aiogram.methods.base.TelegramType`.

--- a/aiogram/client/session/base.py
+++ b/aiogram/client/session/base.py
@@ -256,7 +256,7 @@ class BaseSession(abc.ABC):
         timeout: int | None = None,
     ) -> TelegramType:
         middleware = self.middleware.wrap_middlewares(self.make_request, timeout=timeout)
-        return cast(TelegramType, await middleware(bot, method))
+        return await middleware(bot, method)
 
     async def __aenter__(self) -> Self:
         return self

--- a/aiogram/client/session/middlewares/base.py
+++ b/aiogram/client/session/middlewares/base.py
@@ -7,7 +7,7 @@ from aiogram.methods.base import TelegramType
 
 if TYPE_CHECKING:
     from aiogram.client.bot import Bot
-    from aiogram.methods import Response, TelegramMethod
+    from aiogram.methods import TelegramMethod
 
 
 class NextRequestMiddlewareType(Protocol[TelegramType]):  # pragma: no cover
@@ -15,7 +15,7 @@ class NextRequestMiddlewareType(Protocol[TelegramType]):  # pragma: no cover
         self,
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         pass
 
 
@@ -25,7 +25,7 @@ class RequestMiddlewareType(Protocol):  # pragma: no cover
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         pass
 
 
@@ -40,7 +40,7 @@ class BaseRequestMiddleware(ABC):
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         """
         Execute middleware
 
@@ -48,5 +48,5 @@ class BaseRequestMiddleware(ABC):
         :param bot: bot for request making
         :param method: Request method (Subclass of :class:`aiogram.methods.base.TelegramMethod`)
 
-        :return: :class:`aiogram.methods.Response`
+        :return: Concrete Telegram type (e.g. Message, User, etc.)
         """

--- a/aiogram/client/session/middlewares/request_logging.py
+++ b/aiogram/client/session/middlewares/request_logging.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiogram import loggers
 from aiogram.methods import TelegramMethod
-from aiogram.methods.base import Response, TelegramType
+from aiogram.methods.base import TelegramType
 
 from .base import BaseRequestMiddleware, NextRequestMiddlewareType
 
@@ -27,7 +27,7 @@ class RequestLogging(BaseRequestMiddleware):
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         if type(method) not in self.ignore_methods:
             loggers.middlewares.info(
                 "Make request with method=%r by bot id=%d",

--- a/docs/api/session/middleware.rst
+++ b/docs/api/session/middleware.rst
@@ -35,7 +35,7 @@ Register using decorator
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         # do something with request
         return await make_request(bot, method)
 
@@ -67,7 +67,7 @@ Function based session middleware
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         try:
             # do something with request
             return await make_request(bot, method)


### PR DESCRIPTION
# Description

Currently, the type hints for `NextRequestMiddlewareType`, `RequestMiddlewareType`, and `BaseRequestMiddleware` claim to return a `Response[TelegramType]`. However, at runtime, the `BaseSession` unwraps the response, returning the concrete `TelegramType`.

This mismatch causes static type checkers (like Pyright/MyPy) to incorrectly expect a `Response` wrapper, leading to errors when users try to access result attributes in their custom middlewares.

Fixes #1723

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Ran `pyright` on a middleware implementation. Verified that `reveal_type` on the request result now correctly shows `TelegramType` instead of `Response[TelegramType]`.
- Executed a test bot with `RequestLogging middleware` enabled. Confirmed the message was sent successfully and the middleware correctly handled the unwrapped `Message` object without attribute errors.

**Test Configuration**:
* Operating System: Arch Linux (KDE Plasma 6.2)
* Python version: 3.13.11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
