### PR TITLE
Document webhook security constraints for proxy deployments (#47)

### DIFF
--- a/CHANGES/47.misc.rst
+++ b/CHANGES/47.misc.rst
@@ -1,0 +1,1 @@
+Documented webhook security constraints for proxy deployments, including trust requirements for :code:`X-Forwarded-For` and recommended defense-in-depth checks.

--- a/docs/dispatcher/webhook.rst
+++ b/docs/dispatcher/webhook.rst
@@ -66,6 +66,19 @@ It can be acy using firewall rules or nginx configuration or middleware on appli
 
 So, aiogram has an implementation of the IP filtering middleware for aiohttp.
 
+`aiogram` IP filtering middleware reads the left-most IP address from `X-Forwarded-For`.
+
+.. warning::
+
+    `X-Forwarded-For` is trustworthy only if all webhook traffic goes through a trusted reverse proxy that rewrites this header.
+    If your application is directly reachable from the Internet, this header can be forged.
+
+For production deployments, use defense in depth:
+
+- Always set and verify :code:`X-Telegram-Bot-Api-Secret-Token`
+- Restrict network access to the webhook endpoint (firewall, security groups, ACL)
+- Ensure the backend app is not publicly reachable and accepts requests only from the trusted proxy
+
 .. autofunction:: aiogram.webhook.aiohttp_server.ip_filter_middleware
 
 .. autoclass:: aiogram.webhook.security.IPFilter

--- a/docs/locale/uk_UA/LC_MESSAGES/dispatcher/webhook.po
+++ b/docs/locale/uk_UA/LC_MESSAGES/dispatcher/webhook.po
@@ -203,45 +203,95 @@ msgstr ""
 
 #: ../../dispatcher/webhook.rst:51
 msgid "Security"
-msgstr ""
+msgstr "Безпека"
 
 #: ../../dispatcher/webhook.rst:53
 msgid ""
 "Telegram supports two methods to verify incoming requests that they are "
 "from Telegram:"
-msgstr ""
+msgstr "Telegram підтримує два методи перевірки вхідних запитів, що вони надходять від Telegram:"
 
 #: ../../dispatcher/webhook.rst:56
 msgid "Using a secret token"
-msgstr ""
+msgstr "Використання секретного токена"
 
 #: ../../dispatcher/webhook.rst:58
 msgid ""
 "When you set webhook, you can specify a secret token and then use it to "
 "verify incoming requests."
 msgstr ""
+"Коли ви налаштовуєте webhook, ви можете вказати секретний токен і потім "
+"використовувати його для перевірки вхідних запитів."
 
 #: ../../dispatcher/webhook.rst:61
 msgid "Using IP filtering"
-msgstr ""
+msgstr "Використання фільтрації за IP"
 
 #: ../../dispatcher/webhook.rst:63
 msgid ""
 "You can specify a list of IP addresses from which you expect incoming "
 "requests, and then use it to verify incoming requests."
 msgstr ""
+"Ви можете вказати список IP-адрес, з яких очікуєте вхідні запити, і "
+"використовувати його для перевірки запитів."
 
 #: ../../dispatcher/webhook.rst:65
 msgid ""
 "It can be acy using firewall rules or nginx configuration or middleware "
 "on application level."
 msgstr ""
+"Це можна зробити за допомогою правил firewall, конфігурації nginx або "
+"middleware на рівні застосунку."
 
 #: ../../dispatcher/webhook.rst:67
 msgid ""
 "So, aiogram has an implementation of the IP filtering middleware for "
 "aiohttp."
 msgstr ""
+"Тому в aiogram є реалізація middleware для фільтрації за IP для aiohttp."
+
+#: ../../dispatcher/webhook.rst:69
+msgid ""
+"`aiogram` IP filtering middleware reads the left-most IP address from "
+"`X-Forwarded-For`."
+msgstr ""
+"IP-фільтр middleware в `aiogram` читає крайню ліву IP-адресу з "
+"`X-Forwarded-For`."
+
+#: ../../dispatcher/webhook.rst:73
+msgid ""
+"`X-Forwarded-For` is trustworthy only if all webhook traffic goes through a"
+" trusted reverse proxy that rewrites this header. If your application is "
+"directly reachable from the Internet, this header can be forged."
+msgstr ""
+"`X-Forwarded-For` можна вважати надійним лише тоді, коли весь webhook-"
+"трафік проходить через довірений reverse proxy, який перезаписує цей "
+"заголовок. Якщо ваш застосунок напряму доступний з Інтернету, цей "
+"заголовок можна підробити."
+
+#: ../../dispatcher/webhook.rst:76
+msgid "For production deployments, use defense in depth:"
+msgstr "Для production-деплойментів використовуйте багаторівневий захист:"
+
+#: ../../dispatcher/webhook.rst:78
+msgid "Always set and verify :code:`X-Telegram-Bot-Api-Secret-Token`"
+msgstr "Завжди встановлюйте та перевіряйте :code:`X-Telegram-Bot-Api-Secret-Token`"
+
+#: ../../dispatcher/webhook.rst:79
+msgid ""
+"Restrict network access to the webhook endpoint (firewall, security "
+"groups, ACL)"
+msgstr ""
+"Обмежуйте мережевий доступ до webhook endpoint (firewall, security groups, "
+"ACL)"
+
+#: ../../dispatcher/webhook.rst:80
+msgid ""
+"Ensure the backend app is not publicly reachable and accepts requests only "
+"from the trusted proxy"
+msgstr ""
+"Переконайтеся, що backend-застосунок не доступний публічно та приймає "
+"запити лише від довіреного proxy"
 
 #: ../../dispatcher/webhook.rst:75
 msgid "Examples"


### PR DESCRIPTION
# Description

Fixes #47

This PR clarifies webhook security behavior for proxy deployments.

Summary:
- document that `X-Forwarded-For` can be trusted only behind a trusted reverse proxy that rewrites this header
- explain that direct public exposure makes `X-Forwarded-For` forgeable
- add a defense-in-depth checklist: verify `X-Telegram-Bot-Api-Secret-Token`, restrict network access, and keep backend reachable only via trusted proxy
- add Ukrainian translation updates for this security section

## Type of change

- [x] Documentation (typos, code examples or any documentation update)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `msgfmt -c -o /tmp/webhook.mo docs/locale/uk_UA/LC_MESSAGES/dispatcher/webhook.po`
- [x] `uv run sphinx-build -b html docs docs/_build/html-webhook docs/dispatcher/webhook.rst`
- [x] `uv run sphinx-build -b html -D language=uk_UA docs docs/_build/html-webhook-uk docs/dispatcher/webhook.rst`

Note: Sphinx currently reports unrelated pre-existing documentation errors in other files (e.g., `CHANGES.rst`, `docs/utils/i18n.rst`).

**Test Configuration**:
- Operating System: Linux
- Python version: 3.13.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
