### PR TITLE
Bump pydantic (`<2.13` -> `<2.14`) and other dev/test deps

### DIFF
--- a/CHANGES/1795.misc.rst
+++ b/CHANGES/1795.misc.rst
@@ -1,0 +1,1 @@
+Bumped upper version bounds for ``pydantic`` (``<2.14``) and ``pymongo`` (``<4.17``); refreshed dev/test dependencies (``ruff``, ``packaging``, ``pytest``, ``pytest-html``, ``pytest-cov``, ``pytz``).

--- a/aiogram/fsm/storage/pymongo.py
+++ b/aiogram/fsm/storage/pymongo.py
@@ -136,4 +136,5 @@ class PyMongoStorage(BaseStorage):
         )
         if not update_result:
             await self._collection.delete_one({"_id": document_id})
+            return {}
         return cast(dict[str, Any], update_result.get("data", {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "magic-filter>=1.0.12,<1.1",
     "aiohttp>=3.9.0,<3.14",
-    "pydantic>=2.4.1,<2.13",
+    "pydantic>=2.4.1,<2.14",
     "aiofiles>=23.2.1,<26.0",
     "certifi>=2023.7.22",
     "typing-extensions>=4.7.0,<=5.0",
@@ -64,7 +64,7 @@ redis = [
 ]
 mongo = [
     "motor>=3.3.2,<3.8",
-    "pymongo>4.5,<4.16",
+    "pymongo>4.5,<4.17",
 ]
 proxy = [
     "aiohttp-socks~=0.10.1",
@@ -94,22 +94,22 @@ docs = [
 
 [dependency-groups]
 dev = [
-    "ruff~=0.14",
+    "ruff~=0.15",
     "mypy==1.10.1",
     "toml~=0.10.2",
     "pre-commit~=4.3",
-    "packaging~=25.0",
+    "packaging~=26.0",
     "motor-types==1.0.0b4",
 ]
 test = [
-    "pytest==9.0.1",
-    "pytest-html==4.1.1",
+    "pytest==9.0.3",
+    "pytest-html>=4.2,<4.3",
     "pytest-mock==3.15.1",
     "pytest-mypy==1.0.1",
-    "pytest-cov==7.0.0",
+    "pytest-cov>=7.1,<7.2",
     "pytest-aiohttp==1.1.0",
     "aresponses==3.0.0",
-    "pytz==2025.2",
+    "pytz>=2026,<2027",
     "pycryptodomex==3.23.0",
 ]
 

--- a/tests/test_api/test_client/test_bot.py
+++ b/tests/test_api/test_client/test_bot.py
@@ -122,7 +122,7 @@ class TestBot:
 
         # https://github.com/Tinche/aiofiles#writing-tests-for-aiofiles
         aiofiles.threadpool.wrap.register(MagicMock)(
-            lambda *args, **kwargs: aiofiles.threadpool.binary.AsyncBufferedIOBase(*args, **kwargs)
+            aiofiles.threadpool.binary.AsyncBufferedIOBase
         )
 
         mock_file = MagicMock()

--- a/tests/test_webhook/test_aiohttp_server.py
+++ b/tests/test_webhook/test_aiohttp_server.py
@@ -178,8 +178,8 @@ class TestSimpleRequestHandler:
             new_callable=AsyncMock,
         ) as mocked_silent_call_request:
             method_called_event = asyncio.Event()
-            mocked_silent_call_request.side_effect = (
-                lambda *args, **kwargs: method_called_event.set()
+            mocked_silent_call_request.side_effect = lambda *args, **kwargs: (
+                method_called_event.set()
             )
 
             handler_event.clear()


### PR DESCRIPTION
# Description

Bumps upper version bounds for pydantic (`<2.13` → `<2.14`) and pymongo (`<4.16` → `<4.17`) to allow installation alongside their latest releases. Also refreshes dev/test tooling: `ruff~=0.15`, `packaging ~=26.0`, `pytest 9.0.3`, `pytest-html 4.2.x`, `pytest-cov 7.1.x`, and `pytz 2026.x.`

# How Has This Been Tested?
  - `just test`

# Test Configuration:
- Operating System: Windows 11
- Python version: 3.10+