### PR TITLE
Add link_preview_options to Message.send_copy

### DIFF
--- a/CHANGES/1620.bugfix.rst
+++ b/CHANGES/1620.bugfix.rst
@@ -1,0 +1,1 @@
+Added the ``link_preview_options`` parameter to :meth:`aiogram.types.message.Message.send_copy`. When copying a text message, the new parameter is forwarded to :class:`aiogram.methods.send_message.SendMessage`; if it is not provided, the original message's ``link_preview_options`` are used as a fallback.

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -3658,6 +3658,7 @@ class Message(MaybeInaccessibleMessage):
         business_connection_id: str | None = None,
         parse_mode: str | None = None,
         message_effect_id: str | None = None,
+        link_preview_options: LinkPreviewOptions | None = None,
     ) -> (
         ForwardMessage
         | SendAnimation
@@ -3696,6 +3697,9 @@ class Message(MaybeInaccessibleMessage):
         :param business_connection_id:
         :param parse_mode:
         :param message_effect_id:
+        :param link_preview_options: Link preview generation options for the copied message.
+            Only applied when the source message is a text message; falls back to
+            the original message's ``link_preview_options`` when not provided.
         :return:
         """
         from ..methods import (
@@ -3735,6 +3739,7 @@ class Message(MaybeInaccessibleMessage):
             return SendMessage(
                 text=self.text,
                 entities=self.entities,
+                link_preview_options=link_preview_options or self.link_preview_options,
                 **kwargs,
             ).as_(self._bot)
         if self.audio:

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -75,6 +75,7 @@ from aiogram.types import (
     InlineKeyboardMarkup,
     InputMediaPhoto,
     Invoice,
+    LinkPreviewOptions,
     Location,
     ManagedBotCreated,
     MessageAutoDeleteTimerChanged,
@@ -1263,6 +1264,27 @@ class TestMessage:
         )
         assert isinstance(method, expected_method)
         assert method.parse_mode == custom_parse_mode
+
+    def test_send_copy_link_preview_options_forwarded(self):
+        options = LinkPreviewOptions(is_disabled=True)
+        method = TEST_MESSAGE_TEXT.send_copy(chat_id=42, link_preview_options=options)
+        assert isinstance(method, SendMessage)
+        assert method.link_preview_options is options
+
+    def test_send_copy_link_preview_options_inherits_from_source(self):
+        source_options = LinkPreviewOptions(prefer_small_media=True)
+        message = TEST_MESSAGE_TEXT.model_copy(update={"link_preview_options": source_options})
+        method = message.send_copy(chat_id=42)
+        assert isinstance(method, SendMessage)
+        assert method.link_preview_options is source_options
+
+    def test_send_copy_link_preview_options_explicit_overrides_source(self):
+        source_options = LinkPreviewOptions(prefer_small_media=True)
+        override = LinkPreviewOptions(is_disabled=True)
+        message = TEST_MESSAGE_TEXT.model_copy(update={"link_preview_options": source_options})
+        method = message.send_copy(chat_id=42, link_preview_options=override)
+        assert isinstance(method, SendMessage)
+        assert method.link_preview_options is override
 
     def test_edit_text(self):
         message = Message(


### PR DESCRIPTION
Closes #1620.

### What

Adds a `link_preview_options` parameter to `Message.send_copy`.

### Why

`Message.send_copy` currently drops `link_preview_options` entirely — a text message copied via `send_copy` cannot disable its link preview, and does not preserve the source message's link preview settings.

### How

- Added `link_preview_options: LinkPreviewOptions | None = None` to the `send_copy` signature.
- Threaded it into the `SendMessage` branch only, since `link_preview_options` is not valid for the other copy targets (audio/photo/video/etc).
- Falls back to `self.link_preview_options` when not explicitly provided — same fallback pattern already used for `reply_markup` and `message_effect_id` in this method.
- Added a changelog fragment `CHANGES/1620.bugfix.rst`.

### Tests

Added three tests in `test_message.py`, mirroring the existing `test_send_copy_custom_parse_mode` style:

- `test_send_copy_link_preview_options_forwarded` — explicit value is passed through
- `test_send_copy_link_preview_options_inherits_from_source` — falls back to the source message's options when not provided
- `test_send_copy_link_preview_options_explicit_overrides_source` — explicit value wins over source

Local run: full `tests/test_api/test_types/test_message.py` (240 tests) passes, `ruff check` and `ruff format --check` are clean on the changed files.

### Notes

- `send_copy` is not part of the `.butcher` codegen (it's a hand-written legacy shortcut per the method's own docstring), so this change is applied directly.
- Only `link_preview_options` is added in this PR to stay focused on the linked issue. The `send_copy` signature also lacks several newer fields (`show_caption_above_media`, `protect_content`, `allow_paid_broadcast`, `suggested_post_parameters`, `direct_messages_topic_id`) — happy to open a separate PR for those if that scope is welcome.