### PR TITLE
Emit UserWarning for non-filter left operands in MagicFilter

### DIFF
--- a/CHANGES/1799.feature.rst
+++ b/CHANGES/1799.feature.rst
@@ -8,11 +8,10 @@ This catches the common operator-precedence pitfall where an expression such as
 
     F.text == "confirm" | F.text == "cancel"
 
-is silently parsed by Python as the always-``False`` chained comparison
+is silently parsed by Python as the chained comparison
 ``F.text == ("confirm" | F.text) == "cancel"`` instead of the intended
 ``(F.text == "confirm") | (F.text == "cancel")``.
 
-The warning fires at handler-registration time (module import), before any
-events are processed, and includes the corrected parenthesised form.
-Runtime behaviour is fully preserved — the warning is non-breaking and can be
-silenced with :func:`warnings.filterwarnings` if needed.
+When that expression is evaluated, the warning includes the corrected
+parenthesised form. Runtime behaviour is fully preserved — the warning is
+non-breaking and can be silenced with :func:`warnings.filterwarnings` if needed.

--- a/CHANGES/1799.feature.rst
+++ b/CHANGES/1799.feature.rst
@@ -1,0 +1,18 @@
+Emit a :class:`UserWarning` from :class:`~aiogram.utils.magic_filter.MagicFilter`
+when a non-filter value appears as the **left operand** of ``|`` or ``&``
+(i.e. ``__ror__`` / ``__rand__`` is called with a non-\ ``MagicFilter`` argument).
+
+This catches the common operator-precedence pitfall where an expression such as
+
+.. code-block:: python
+
+    F.text == "confirm" | F.text == "cancel"
+
+is silently parsed by Python as the always-``False`` chained comparison
+``F.text == ("confirm" | F.text) == "cancel"`` instead of the intended
+``(F.text == "confirm") | (F.text == "cancel")``.
+
+The warning fires at handler-registration time (module import), before any
+events are processed, and includes the corrected parenthesised form.
+Runtime behaviour is fully preserved — the warning is non-breaking and can be
+silenced with :func:`warnings.filterwarnings` if needed.

--- a/aiogram/utils/magic_filter.py
+++ b/aiogram/utils/magic_filter.py
@@ -1,9 +1,31 @@
+import warnings
 from collections.abc import Iterable
 from typing import Any
 
 from magic_filter import MagicFilter as _MagicFilter
 from magic_filter import MagicT as _MagicT
 from magic_filter.operations import BaseOperation
+
+_WARN_OR = (
+    "Possible operator precedence mistake: {value!r} is on the left side of '|'.\n"
+    "Because '|' binds tighter than '==', the expression\n"
+    "    F.x == 'a' | F.x == 'b'\n"
+    "is parsed by Python as:\n"
+    "    F.x == ('a' | F.x) == 'b'   # always False\n"
+    "Correct forms:\n"
+    "    (F.x == 'a') | (F.x == 'b')\n"
+    "    F.x.in_({{'a', 'b'}})"
+)
+
+_WARN_AND = (
+    "Possible operator precedence mistake: {value!r} is on the left side of '&'.\n"
+    "Because '&' binds tighter than '==', the expression\n"
+    "    F.x == 'a' & F.y == 'b'\n"
+    "is parsed by Python as:\n"
+    "    F.x == ('a' & F.y) == 'b'   # always False\n"
+    "Correct form:\n"
+    "    (F.x == 'a') & (F.y == 'b')"
+)
 
 
 class AsFilterResultOperation(BaseOperation):
@@ -21,3 +43,21 @@ class AsFilterResultOperation(BaseOperation):
 class MagicFilter(_MagicFilter):
     def as_(self: _MagicT, name: str) -> _MagicT:
         return self._extend(AsFilterResultOperation(name=name))
+
+    def __ror__(self: _MagicT, other: Any) -> _MagicT:
+        if not isinstance(other, _MagicFilter):
+            warnings.warn(
+                message=_WARN_OR.format(value=other),
+                category=UserWarning,
+                stacklevel=2,
+            )
+        return super().__ror__(other)
+
+    def __rand__(self: _MagicT, other: Any) -> _MagicT:
+        if not isinstance(other, _MagicFilter):
+            warnings.warn(
+                message=_WARN_AND.format(value=other),
+                category=UserWarning,
+                stacklevel=2,
+            )
+        return super().__rand__(other)

--- a/aiogram/utils/magic_filter.py
+++ b/aiogram/utils/magic_filter.py
@@ -11,7 +11,7 @@ _WARN_OR = (
     "Because '|' binds tighter than '==', the expression\n"
     "    F.x == 'a' | F.x == 'b'\n"
     "is parsed by Python as:\n"
-    "    F.x == ('a' | F.x) == 'b'   # always False\n"
+    "    F.x == ('a' | F.x) == 'b'   # likely not what you intended\n"
     "Correct forms:\n"
     "    (F.x == 'a') | (F.x == 'b')\n"
     "    F.x.in_({{'a', 'b'}})"
@@ -22,7 +22,7 @@ _WARN_AND = (
     "Because '&' binds tighter than '==', the expression\n"
     "    F.x == 'a' & F.y == 'b'\n"
     "is parsed by Python as:\n"
-    "    F.x == ('a' & F.y) == 'b'   # always False\n"
+    "    F.x == ('a' & F.y) == 'b'   # likely not what you intended\n"
     "Correct form:\n"
     "    (F.x == 'a') & (F.y == 'b')"
 )

--- a/tests/test_utils/test_magic_filter.py
+++ b/tests/test_utils/test_magic_filter.py
@@ -98,18 +98,14 @@ class TestMagicFilter:
         Python parses this as:
             F.text == ("confirm" | F.text) == "cancel"   # semantically broken
         The warning must fire at expression evaluation time.
-        Resolving the buggy filter raises TypeError because magic_filter internally
-        tries to evaluate str | str — demonstrating why the warning matters.
+        This test intentionally validates only the warning, because the expression
+        is not parsed as a normal MagicFilter OR expression and must not be treated
+        as a resolvable MagicFilter.
         """
         with pytest.warns(UserWarning, match="Possible operator precedence mistake"):
             # fmt: off
-            buggy_filter = F.text == "confirm" | F.text == "cancel"
+            _ = F.text == "confirm" | F.text == "cancel"
             # fmt: on
-        # The result is still a MagicFilter object (runtime behaviour preserved)
-        assert isinstance(buggy_filter, MagicFilter)
-        # Resolving raises TypeError: the expression is semantically broken
-        with pytest.raises(TypeError):
-            buggy_filter.resolve(MyObject(text="confirm"))
 
     def test_correct_or_pattern_matches(self):
         """Sanity check: the correctly parenthesised form resolves as expected."""

--- a/tests/test_utils/test_magic_filter.py
+++ b/tests/test_utils/test_magic_filter.py
@@ -1,5 +1,9 @@
+import os
+import warnings
 from dataclasses import dataclass
 from re import Match
+
+import pytest
 
 from aiogram import F
 from aiogram.utils.magic_filter import MagicFilter
@@ -8,9 +12,12 @@ from aiogram.utils.magic_filter import MagicFilter
 @dataclass
 class MyObject:
     text: str
+    caption: str = ""
 
 
 class TestMagicFilter:
+    # --- existing .as_() tests ---
+
     def test_operation_as(self):
         magic: MagicFilter = F.text.regexp(r"^(\d+)$").as_("match")
 
@@ -33,3 +40,161 @@ class TestMagicFilter:
 
         result = magic.resolve([])
         assert result is None
+
+    # --- __ror__ / __rand__ warning tests ---
+
+    @pytest.mark.parametrize(
+        "left_operand",
+        [
+            pytest.param("confirm", id="str"),
+            pytest.param(42, id="int"),
+            pytest.param(True, id="bool"),
+            pytest.param(3.14, id="float"),
+            pytest.param(None, id="None"),
+            pytest.param([], id="list"),
+        ],
+    )
+    def test_ror_non_filter_warns(self, left_operand):
+        """__ror__ with a non-MagicFilter left operand should emit UserWarning."""
+        with pytest.warns(UserWarning, match="Possible operator precedence mistake") as rec:
+            result = left_operand | F.text
+        assert isinstance(result, MagicFilter)
+        # repr of the offending value must appear in the warning text
+        assert repr(left_operand) in str(rec[0].message)
+
+    @pytest.mark.parametrize(
+        "left_operand",
+        [
+            pytest.param("value", id="str"),
+            pytest.param(42, id="int"),
+            pytest.param(True, id="bool"),
+            pytest.param(3.14, id="float"),
+        ],
+    )
+    def test_rand_non_filter_warns(self, left_operand):
+        """__rand__ with a non-MagicFilter left operand should emit UserWarning."""
+        with pytest.warns(UserWarning, match="Possible operator precedence mistake") as rec:
+            result = left_operand & F.text
+        assert isinstance(result, MagicFilter)
+        assert repr(left_operand) in str(rec[0].message)
+
+    def test_ror_warning_stacklevel_points_to_caller(self):
+        """The warning must reference the caller's line, not magic_filter.py internals."""
+        with pytest.warns(UserWarning) as rec:
+            _ = "oops" | F.text  # this is the line that should be reported
+        # Warning filename must be THIS test file, not aiogram/utils/magic_filter.py
+        assert os.path.basename(rec[0].filename) == "test_magic_filter.py"
+
+    def test_rand_warning_stacklevel_points_to_caller(self):
+        """The warning must reference the caller's line, not magic_filter.py internals."""
+        with pytest.warns(UserWarning) as rec:
+            _ = "oops" & F.text  # this is the line that should be reported
+        assert os.path.basename(rec[0].filename) == "test_magic_filter.py"
+
+    def test_real_world_bug_pattern_warns(self):
+        """
+        The canonical bug from the issue:
+            F.text == "confirm" | F.text == "cancel"
+        Python parses this as:
+            F.text == ("confirm" | F.text) == "cancel"   # semantically broken
+        The warning must fire at expression evaluation time.
+        Resolving the buggy filter raises TypeError because magic_filter internally
+        tries to evaluate str | str — demonstrating why the warning matters.
+        """
+        with pytest.warns(UserWarning, match="Possible operator precedence mistake"):
+            # fmt: off
+            buggy_filter = F.text == "confirm" | F.text == "cancel"
+            # fmt: on
+        # The result is still a MagicFilter object (runtime behaviour preserved)
+        assert isinstance(buggy_filter, MagicFilter)
+        # Resolving raises TypeError: the expression is semantically broken
+        with pytest.raises(TypeError):
+            buggy_filter.resolve(MyObject(text="confirm"))
+
+    def test_correct_or_pattern_matches(self):
+        """Sanity check: the correctly parenthesised form resolves as expected."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            good_filter = (F.text == "confirm") | (F.text == "cancel")
+        assert good_filter.resolve(MyObject(text="confirm"))
+        assert good_filter.resolve(MyObject(text="cancel"))
+        assert not good_filter.resolve(MyObject(text="other"))
+
+    # --- false-positive guard tests (must never warn) ---
+
+    def test_ror_filter_no_warning(self):
+        """__ror__ between two MagicFilter instances must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = (F.text == "a") | (F.text == "b")
+        assert isinstance(result, MagicFilter)
+
+    def test_rand_filter_no_warning(self):
+        """__rand__ between two MagicFilter instances must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = (F.text == "a") & (F.caption == "b")
+        assert isinstance(result, MagicFilter)
+
+    def test_or_truthy_no_warning(self):
+        """F.text | F.caption (truthy OR) must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = F.text | F.caption
+        assert isinstance(result, MagicFilter)
+
+    def test_prebuilt_filter_or_no_warning(self):
+        """Pre-built filter variables joined with | must NOT emit any warning."""
+        f1 = F.text == "a"
+        f2 = F.text == "b"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = f1 | f2
+        assert isinstance(result, MagicFilter)
+
+    def test_prebuilt_filter_and_no_warning(self):
+        """Pre-built filter variables joined with & must NOT emit any warning."""
+        f1 = F.text == "a"
+        f2 = F.caption == "b"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = f1 & f2
+        assert isinstance(result, MagicFilter)
+
+    def test_chained_or_three_no_warning(self):
+        """Chained (f1 | f2 | f3) must NOT emit any warning."""
+        f1 = F.text == "a"
+        f2 = F.text == "b"
+        f3 = F.text == "c"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = f1 | f2 | f3
+        assert isinstance(result, MagicFilter)
+
+    def test_mixed_and_or_no_warning(self):
+        """(F.x == v) & (F.y == v) | (F.z == v) must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = (F.text == "a") & (F.caption == "b") | (F.text == "c")
+        assert isinstance(result, MagicFilter)
+
+    def test_filter_and_subfilter_no_warning(self):
+        """F.x & (F.y == v) must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = F.text & (F.caption == "b")
+        assert isinstance(result, MagicFilter)
+
+    def test_negation_no_warning(self):
+        """~F.x must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = ~F.text
+        assert isinstance(result, MagicFilter)
+
+    def test_in_no_warning(self):
+        """F.x.in_({...}) must NOT emit any warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = F.text.in_({"a", "b", "c"})
+        assert isinstance(result, MagicFilter)


### PR DESCRIPTION
# Description

Fixes #1799

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
