### PR TITLE
Update ruff pre-commit hook to v0.15.11 and rename ruff hook id

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,9 @@ repos:
       - id: "check-json"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.14.0'
+    rev: 'v0.15.11'
     hooks:
-      - id: ruff
+      - id: ruff-check
         files: &files '^(aiogram|tests|examples)'
       - id: ruff-format
         files: *files

--- a/CHANGES/1801.misc.rst
+++ b/CHANGES/1801.misc.rst
@@ -1,0 +1,1 @@
+Bump ``ruff`` pre-commit hook from ``v0.14.0`` to ``v0.15.11`` and rename hook id from ``ruff`` to ``ruff-check``


### PR DESCRIPTION
## Changes

- Bumped `ruff-pre-commit` hook version from `v0.14.0` to `v0.15.11`
- Renamed hook id from `ruff` to `ruff-check`

## Reason

Since `v0.5.0`, the [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) project
renamed the `ruff` hook to `ruff-check` to clearly distinguish linting (`ruff check`)
from formatting (`ruff format`).

Using the legacy hook id `ruff` caused pre-commit to emit a deprecation warning:

```
[WARNING] The `ruff` hook is deprecated. Use `ruff-check` instead.
```

This change removes the warning and aligns `.pre-commit-config.yaml`
with the current recommendations of the ruff project.


## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:
* Python version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
