### PR TITLE
Drop PyPy 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,6 @@ jobs:
           - macos-latest
           # - windows-latest
         python-version:
-          - "pypy3.10"
           - "pypy3.11"
 
     defaults:

--- a/CHANGES/1805.removal.rst
+++ b/CHANGES/1805.removal.rst
@@ -1,0 +1,1 @@
+Dropped PyPy 3.10 support because required optional dependencies no longer support it.


### PR DESCRIPTION
# Description

Drops PyPy 3.10 from the test matrix and marks it as unsupported.

`aiogram[signature]` can no longer be installed on PyPy 3.10 because recent `cryptography` builds rely on PyO3, which no longer supports PyPy 3.10.
Installing Rust in the container does not fix this, so this is an upstream compatibility limitation rather than a missing build dependency.

PyPy support remains covered by PyPy 3.11.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
  - `just test`
 
# Reproduced PyPy 3.10 installation failure:
```bash
docker run --rm -it pypy:3.10 bash

apt-get update
apt-get install -y curl

curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
. "$HOME/.cargo/env"

python -m pip install -U pip
python -m pip install "aiogram[signature]"
```
Test Configuration:

- Operating System: Windows 11 locally, Debian-based pypy:3.10 Docker image for reproduction
- Python version: CPython 3.14 locally, PyPy 3.10 in Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes