### PR TITLE
fix(types): allow missing ChatMemberRestricted can_react_to_messages

### DIFF
--- a/.butcher/schema/schema.json
+++ b/.butcher/schema/schema.json
@@ -7429,10 +7429,10 @@
             {
               "type": "Boolean",
               "description": "True, if the user is allowed to react to messages",
-              "html_description": "<td><em>True</em>, if the user is allowed to react to messages</td>",
-              "rst_description": ":code:`True`, if the user is allowed to react to messages\n",
+              "html_description": "<td><em>Optional</em>. <em>True</em>, if the user is allowed to react to messages</td>",
+              "rst_description": "*Optional*. :code:`True`, if the user is allowed to react to messages\n",
               "name": "can_react_to_messages",
-              "required": true
+              "required": false
             },
             {
               "type": "Boolean",

--- a/.butcher/types/ChatMemberRestricted/entity.json
+++ b/.butcher/types/ChatMemberRestricted/entity.json
@@ -126,10 +126,10 @@
       {
         "type": "Boolean",
         "description": "True, if the user is allowed to react to messages",
-        "html_description": "<td><em>True</em>, if the user is allowed to react to messages</td>",
-        "rst_description": ":code:`True`, if the user is allowed to react to messages\n",
+        "html_description": "<td><em>Optional</em>. <em>True</em>, if the user is allowed to react to messages</td>",
+        "rst_description": "*Optional*. :code:`True`, if the user is allowed to react to messages\n",
         "name": "can_react_to_messages",
-        "required": true
+        "required": false
       },
       {
         "type": "Boolean",

--- a/CHANGES/1812.bugfix.rst
+++ b/CHANGES/1812.bugfix.rst
@@ -1,0 +1,1 @@
+Allowed missing ``can_react_to_messages`` in ``ChatMemberRestricted`` payloads returned by Telegram.

--- a/aiogram/types/chat_member_restricted.py
+++ b/aiogram/types/chat_member_restricted.py
@@ -43,8 +43,8 @@ class ChatMemberRestricted(ChatMember):
     """:code:`True`, if the user is allowed to send animations, games, stickers and use inline bots"""
     can_add_web_page_previews: bool
     """:code:`True`, if the user is allowed to add web page previews to their messages"""
-    can_react_to_messages: bool
-    """:code:`True`, if the user is allowed to react to messages"""
+    can_react_to_messages: bool | None = None
+    """*Optional*. :code:`True`, if the user is allowed to react to messages"""
     can_edit_tag: bool
     """:code:`True`, if the user is allowed to edit their own tag"""
     can_change_info: bool
@@ -80,7 +80,7 @@ class ChatMemberRestricted(ChatMember):
             can_send_polls: bool,
             can_send_other_messages: bool,
             can_add_web_page_previews: bool,
-            can_react_to_messages: bool,
+            can_react_to_messages: bool | None = None,
             can_edit_tag: bool,
             can_change_info: bool,
             can_invite_users: bool,

--- a/tests/test_utils/test_chat_member.py
+++ b/tests/test_utils/test_chat_member.py
@@ -94,3 +94,13 @@ CHAT_MEMBER_RESTRICTED = ChatMemberRestricted(
 def test_chat_member_resolution(data: dict, resolved_type: type[ChatMember]) -> None:
     chat_member = ChatMemberAdapter.validate_python(data)
     assert isinstance(chat_member, resolved_type)
+
+
+def test_chat_member_restricted_allows_missing_can_react_to_messages() -> None:
+    data = CHAT_MEMBER_RESTRICTED.copy()
+    data.pop("can_react_to_messages")
+
+    chat_member = ChatMemberAdapter.validate_python(data)
+
+    assert isinstance(chat_member, ChatMemberRestricted)
+    assert chat_member.can_react_to_messages is None


### PR DESCRIPTION
Summary
- make ChatMemberRestricted.can_react_to_messages optional when Telegram omits it
- update butcher metadata so regeneration preserves the optional field
- add regression coverage for restricted chat members without can_react_to_messages

Tests
- python -m pytest tests/test_utils/test_chat_member.py
- python -m ruff check aiogram tests
- python -m ruff format --check aiogram tests

Fixes #1812