### PR TITLE
docs(callback-data): clarify injected parameter name

### DIFF
--- a/CHANGES/1759.doc.rst
+++ b/CHANGES/1759.doc.rst
@@ -1,0 +1,1 @@
+Clarified that parsed ``CallbackData`` is injected into handlers as ``callback_data``.

--- a/docs/dispatcher/filters/callback_data.rst
+++ b/docs/dispatcher/filters/callback_data.rst
@@ -52,6 +52,10 @@ So... Now you can use this class to generate any callbacks with defined structur
         ...
         print("bar =", callback_data.bar)
 
+The parsed callback data instance is injected into the handler under the
+:code:`callback_data` name. If you use another parameter name, pass it explicitly
+through a custom filter or rename the handler argument to :code:`callback_data`.
+
 Also can be used in :doc:`Keyboard builder </utils/keyboard>`:
 
 .. code-block:: python


### PR DESCRIPTION
Summary
- document that parsed CallbackData is injected into handlers as callback_data
- clarify what to do when users choose another handler parameter name

Checks
- git diff --check origin/dev-3.x..HEAD

Fixes #1759