### PR TITLE
test(types): cover StickerSet without deprecated flags

### DIFF
--- a/CHANGES/1446.bugfix.rst
+++ b/CHANGES/1446.bugfix.rst
@@ -1,0 +1,1 @@
+Added regression coverage for ``StickerSet`` payloads without deprecated ``is_animated`` and ``is_video`` fields.

--- a/tests/test_api/test_methods/test_get_sticker_set.py
+++ b/tests/test_api/test_methods/test_get_sticker_set.py
@@ -4,6 +4,19 @@ from tests.mocked_bot import MockedBot
 
 
 class TestGetStickerSet:
+    def test_sticker_set_deserializes_without_deprecated_format_flags(self):
+        sticker_set = StickerSet.model_validate(
+            {
+                "name": "test",
+                "title": "test",
+                "sticker_type": "regular",
+                "stickers": [],
+            }
+        )
+
+        assert sticker_set.is_animated is None
+        assert sticker_set.is_video is None
+
     async def test_bot_method(self, bot: MockedBot):
         prepare_result = bot.add_result_for(
             GetStickerSet,


### PR DESCRIPTION
Summary
- add regression coverage for StickerSet payloads without deprecated is_animated and is_video fields
- protects getStickerSet deserialization behavior for Bot API 7.2+ payloads

Tests
- python -m pytest tests/test_api/test_methods/test_get_sticker_set.py
- python -m ruff check aiogram tests
- python -m ruff format --check aiogram tests

Fixes #1446