### PR TITLE
fix(keyboard): expose ReplyKeyboardBuilder.as_markup options

### DIFF
--- a/CHANGES/1423.bugfix.rst
+++ b/CHANGES/1423.bugfix.rst
@@ -1,0 +1,1 @@
+Improved ``ReplyKeyboardBuilder.as_markup`` type hints for reply keyboard options.

--- a/aiogram/utils/keyboard.py
+++ b/aiogram/utils/keyboard.py
@@ -337,9 +337,9 @@ class InlineKeyboardBuilder(KeyboardBuilder[InlineKeyboardButton]):
             ),
         )
 
-    def as_markup(self, **kwargs: Any) -> InlineKeyboardMarkup:
+    def as_markup(self) -> InlineKeyboardMarkup:
         """Construct an InlineKeyboardMarkup"""
-        return cast(InlineKeyboardMarkup, super().as_markup(**kwargs))
+        return cast(InlineKeyboardMarkup, super().as_markup())
 
     def __init__(self, markup: list[list[InlineKeyboardButton]] | None = None) -> None:
         super().__init__(button_type=InlineKeyboardButton, markup=markup)
@@ -405,9 +405,28 @@ class ReplyKeyboardBuilder(KeyboardBuilder[KeyboardButton]):
             ),
         )
 
-    def as_markup(self, **kwargs: Any) -> ReplyKeyboardMarkup:
+    def as_markup(
+        self,
+        *,
+        is_persistent: bool | None = None,
+        resize_keyboard: bool | None = None,
+        one_time_keyboard: bool | None = None,
+        input_field_placeholder: str | None = None,
+        selective: bool | None = None,
+        **kwargs: Any,
+    ) -> ReplyKeyboardMarkup:
         """Construct a ReplyKeyboardMarkup"""
-        return cast(ReplyKeyboardMarkup, super().as_markup(**kwargs))
+        return cast(
+            ReplyKeyboardMarkup,
+            super().as_markup(
+                is_persistent=is_persistent,
+                resize_keyboard=resize_keyboard,
+                one_time_keyboard=one_time_keyboard,
+                input_field_placeholder=input_field_placeholder,
+                selective=selective,
+                **kwargs,
+            ),
+        )
 
     def __init__(self, markup: list[list[KeyboardButton]] | None = None) -> None:
         super().__init__(button_type=KeyboardButton, markup=markup)

--- a/docs/utils/keyboard.rst
+++ b/docs/utils/keyboard.rst
@@ -85,7 +85,7 @@ Reply Keyboard
 
         Add new button to markup
 
-    .. method:: as_markup() -> aiogram.types.reply_keyboard_markup.ReplyKeyboardMarkup
+    .. method:: as_markup(is_persistent: Optional[bool] = None, resize_keyboard: Optional[bool] = None, one_time_keyboard: Optional[bool] = None, input_field_placeholder: Optional[str] = None, selective: Optional[bool] = None, **kwargs: Any) -> aiogram.types.reply_keyboard_markup.ReplyKeyboardMarkup
         :noindex:
 
         Construct an ReplyKeyboardMarkup

--- a/tests/test_utils/test_keyboard.py
+++ b/tests/test_utils/test_keyboard.py
@@ -294,6 +294,21 @@ class TestKeyboardBuilder:
     def test_as_markup(self, builder, expected):
         assert isinstance(builder.as_markup(), expected)
 
+    def test_reply_keyboard_as_markup_options(self):
+        markup = ReplyKeyboardBuilder().as_markup(
+            is_persistent=True,
+            resize_keyboard=True,
+            one_time_keyboard=True,
+            input_field_placeholder="Placeholder",
+            selective=True,
+        )
+
+        assert markup.is_persistent is True
+        assert markup.resize_keyboard is True
+        assert markup.one_time_keyboard is True
+        assert markup.input_field_placeholder == "Placeholder"
+        assert markup.selective is True
+
     @pytest.mark.parametrize(
         "builder,button_kwargs,icon_custom_emoji_id,style",
         [


### PR DESCRIPTION
Summary
- expose ReplyKeyboardMarkup options in ReplyKeyboardBuilder.as_markup signature
- keep InlineKeyboardBuilder.as_markup as a no-argument method
- add coverage for reply keyboard markup options
- update keyboard builder docs for the typed as_markup signature

Tests
- python -m pytest tests/test_utils/test_keyboard.py
- python -m ruff check aiogram tests
- python -m ruff format --check aiogram tests

Fixes #1423