### PR TITLE
fix(types): make can_react_to_messages and can_edit_tag optional in ChatMemberRestricted

### DIFF
--- a/.butcher/types/ChatMemberRestricted/entity.json
+++ b/.butcher/types/ChatMemberRestricted/entity.json
@@ -126,18 +126,18 @@
       {
         "type": "Boolean",
         "description": "True, if the user is allowed to react to messages",
-        "html_description": "<td><em>True</em>, if the user is allowed to react to messages</td>",
-        "rst_description": ":code:`True`, if the user is allowed to react to messages\n",
+        "html_description": "<td><em>Optional</em>. <em>True</em>, if the user is allowed to react to messages</td>",
+        "rst_description": "*Optional*. :code:`True`, if the user is allowed to react to messages\n",
         "name": "can_react_to_messages",
-        "required": true
+        "required": false
       },
       {
         "type": "Boolean",
         "description": "True, if the user is allowed to edit their own tag",
-        "html_description": "<td><em>True</em>, if the user is allowed to edit their own tag</td>",
-        "rst_description": ":code:`True`, if the user is allowed to edit their own tag\n",
+        "html_description": "<td><em>Optional</em>. <em>True</em>, if the user is allowed to edit their own tag</td>",
+        "rst_description": "*Optional*. :code:`True`, if the user is allowed to edit their own tag\n",
         "name": "can_edit_tag",
-        "required": true
+        "required": false
       },
       {
         "type": "Boolean",

--- a/CHANGES/1824.bugfix.rst
+++ b/CHANGES/1824.bugfix.rst
@@ -1,0 +1,1 @@
+Made :code:`can_react_to_messages` and :code:`can_edit_tag` optional (``bool | None = None``) in :class:`aiogram.types.ChatMemberRestricted` to handle ``my_chat_member`` updates where Telegram omits these fields, preventing a :class:`pydantic.ValidationError` at runtime.

--- a/aiogram/types/chat_member_restricted.py
+++ b/aiogram/types/chat_member_restricted.py
@@ -43,10 +43,10 @@ class ChatMemberRestricted(ChatMember):
     """:code:`True`, if the user is allowed to send animations, games, stickers and use inline bots"""
     can_add_web_page_previews: bool
     """:code:`True`, if the user is allowed to add web page previews to their messages"""
-    can_react_to_messages: bool
-    """:code:`True`, if the user is allowed to react to messages"""
-    can_edit_tag: bool
-    """:code:`True`, if the user is allowed to edit their own tag"""
+    can_react_to_messages: bool | None = None
+    """*Optional*. :code:`True`, if the user is allowed to react to messages"""
+    can_edit_tag: bool | None = None
+    """*Optional*. :code:`True`, if the user is allowed to edit their own tag"""
     can_change_info: bool
     """:code:`True`, if the user is allowed to change the chat title, photo and other settings"""
     can_invite_users: bool
@@ -80,8 +80,8 @@ class ChatMemberRestricted(ChatMember):
             can_send_polls: bool,
             can_send_other_messages: bool,
             can_add_web_page_previews: bool,
-            can_react_to_messages: bool,
-            can_edit_tag: bool,
+            can_react_to_messages: bool | None = None,
+            can_edit_tag: bool | None = None,
             can_change_info: bool,
             can_invite_users: bool,
             can_pin_messages: bool,

--- a/tests/test_api/test_types/test_chat_member_restricted.py
+++ b/tests/test_api/test_types/test_chat_member_restricted.py
@@ -1,0 +1,63 @@
+import datetime
+
+import pytest
+
+from aiogram.types import ChatMemberRestricted, User
+
+
+class TestChatMemberRestricted:
+    def _make_user(self) -> User:
+        return User(id=42, is_bot=False, first_name="Test")
+
+    def _base_kwargs(self, user: User) -> dict:
+        return {
+            "user": user,
+            "is_member": True,
+            "can_send_messages": True,
+            "can_send_audios": True,
+            "can_send_documents": True,
+            "can_send_photos": True,
+            "can_send_videos": True,
+            "can_send_video_notes": True,
+            "can_send_voice_notes": True,
+            "can_send_polls": True,
+            "can_send_other_messages": True,
+            "can_add_web_page_previews": True,
+            "can_change_info": True,
+            "can_invite_users": True,
+            "can_pin_messages": True,
+            "can_manage_topics": True,
+            "until_date": datetime.datetime(2099, 1, 1),
+        }
+
+    def test_full(self):
+        """All fields including optional ones present."""
+        user = self._make_user()
+        member = ChatMemberRestricted(
+            **self._base_kwargs(user),
+            can_react_to_messages=True,
+            can_edit_tag=False,
+        )
+        assert member.can_react_to_messages is True
+        assert member.can_edit_tag is False
+
+    def test_missing_can_react_to_messages(self):
+        """Telegram sometimes omits can_react_to_messages — must not raise ValidationError."""
+        user = self._make_user()
+        member = ChatMemberRestricted(**self._base_kwargs(user))
+        assert member.can_react_to_messages is None
+
+    def test_missing_can_edit_tag(self):
+        """Telegram sometimes omits can_edit_tag — must not raise ValidationError."""
+        user = self._make_user()
+        member = ChatMemberRestricted(**self._base_kwargs(user))
+        assert member.can_edit_tag is None
+
+    def test_missing_both_optional_fields(self):
+        """Both new optional fields absent simultaneously — real-world scenario from issue #1812."""
+        user = self._make_user()
+        member = ChatMemberRestricted(**self._base_kwargs(user))
+        assert member.can_react_to_messages is None
+        assert member.can_edit_tag is None
+        assert member.status == "restricted"
+        assert member.is_member is True


### PR DESCRIPTION
## Problem

Fixes #1812

When a bot receives a `my_chat_member` update with `status: restricted`, Telegram **sometimes omits** the `can_react_to_messages` and `can_edit_tag` fields. This causes a hard crash:

```
pydantic_core.ValidationError: 2 validation errors for Response[list[Update]]
  ...can_react_to_messages
    Field required [type=missing, ...]
  ...can_edit_tag
    Field required [type=missing, ...]
```

Both fields were added in newer Bot API versions and are not always present in responses for restricted members — particularly when the restriction was applied before these fields were introduced.

## Fix

Mark both fields as `Optional` with a default of `None`:

```python
# Before
can_react_to_messages: bool
can_edit_tag: bool

# After
can_react_to_messages: bool | None = None
can_edit_tag: bool | None = None
```

The `.butcher` schema is also updated so re-running codegen does not revert this fix.

## Precedent

This mirrors the pattern already used for `tag: str | None = None` in the same model, and matches how `ChatPermissions` handles its optional boolean fields.

## Tests

Added `tests/test_api/test_types/test_chat_member_restricted.py` covering:
- Both fields present (existing behaviour)
- `can_react_to_messages` absent → parses cleanly, value is `None`
- `can_edit_tag` absent → parses cleanly, value is `None`
- Both absent simultaneously (the real-world scenario from #1812)