### PR TITLE
Typed command arg parsing and DeeplinkCommand filter

### DIFF
--- a/CHANGES/1844.feature.rst
+++ b/CHANGES/1844.feature.rst
@@ -1,0 +1,3 @@
+Added typed argument parsing for commands and deeplinks via ``Command[T]``,
+``DeeplinkData``, ``DeeplinkCommand`` and built-in codecs ``PositionalCodec``,
+``NamedCodec``, ``Base64Codec``.

--- a/aiogram/filters/__init__.py
+++ b/aiogram/filters/__init__.py
@@ -1,4 +1,5 @@
 from .base import Filter
+from .callback_data import CallbackData, CallbackDataException, CallbackQueryFilter
 from .chat_member_updated import (
     ADMINISTRATOR,
     CREATOR,
@@ -14,7 +15,9 @@ from .chat_member_updated import (
     RESTRICTED,
     ChatMemberUpdatedFilter,
 )
-from .command import Command, CommandObject, CommandStart
+from .command.base import Command, CommandObject, CommandStart
+from .command.data.base import DeeplinkData, DeeplinkDataException
+from .command.deeplink import DeeplinkCommand
 from .exception import ExceptionMessageFilter, ExceptionTypeFilter
 from .logic import and_f, invert_f, or_f
 from .magic_data import MagicData
@@ -40,6 +43,12 @@ __all__ = (
     "Command",
     "CommandObject",
     "CommandStart",
+    "DeeplinkData",
+    "DeeplinkDataException",
+    "DeeplinkCommand",
+    "CallbackData",
+    "CallbackQueryFilter",
+    "CallbackDataException",
     "ExceptionMessageFilter",
     "ExceptionTypeFilter",
     "Filter",

--- a/aiogram/filters/command/__init__.py
+++ b/aiogram/filters/command/__init__.py
@@ -1,0 +1,24 @@
+from aiogram.filters.command.base import Command, CommandException, CommandObject, CommandStart
+from aiogram.filters.command.data import (
+    ArgsCodec,
+    Base64Codec,
+    DeeplinkData,
+    DeeplinkDataException,
+    NamedCodec,
+    PositionalCodec,
+)
+from aiogram.filters.command.deeplink import DeeplinkCommand
+
+__all__ = (
+    "Command",
+    "CommandException",
+    "CommandObject",
+    "CommandStart",
+    "DeeplinkData",
+    "DeeplinkDataException",
+    "ArgsCodec",
+    "PositionalCodec",
+    "NamedCodec",
+    "Base64Codec",
+    "DeeplinkCommand",
+)

--- a/aiogram/filters/command/base.py
+++ b/aiogram/filters/command/base.py
@@ -4,9 +4,12 @@ import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, replace
 from re import Match, Pattern
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+
+from pydantic import BaseModel
 
 from aiogram.filters.base import Filter
+from aiogram.filters.command.data.codecs import PositionalCodec
 from aiogram.types import BotCommand, Message
 from aiogram.utils.deep_linking import decode_payload
 
@@ -14,15 +17,18 @@ if TYPE_CHECKING:
     from magic_filter import MagicFilter
 
     from aiogram import Bot
+    from aiogram.filters.command.data.codecs import ArgsCodec
 
 CommandPatternType = str | re.Pattern[str] | BotCommand
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class CommandException(Exception):
     pass
 
 
-class Command(Filter):
+class Command(Filter, Generic[T]):
     """
     This filter can be helpful for handling commands from the text messages.
 
@@ -30,17 +36,25 @@ class Command(Filter):
     """
 
     __slots__ = (
+        "codec",
         "commands",
+        "data",
         "ignore_case",
         "ignore_mention",
         "magic",
         "prefix",
     )
 
+    if TYPE_CHECKING:
+        data: type[T] | None
+        codec: ArgsCodec | None
+
     def __init__(
         self,
         *values: CommandPatternType,
         commands: Sequence[CommandPatternType] | CommandPatternType | None = None,
+        data: type[T] | None = None,
+        codec: ArgsCodec | None = None,
         prefix: str = "/",
         ignore_case: bool = False,
         ignore_mention: bool = False,
@@ -58,36 +72,38 @@ class Command(Filter):
             bot can not handle commands intended for other bots
         :param magic: Validate command object via Magic filter after all checks done
         """
+        if codec is not None and data is None:
+            raise ValueError("codec= requires data= to be set")
+
         if commands is None:
             commands = []
         if isinstance(commands, (str, re.Pattern, BotCommand)):
             commands = [commands]
 
         if not isinstance(commands, Iterable):
-            msg = (
+            raise ValueError(
                 "Command filter only supports str, re.Pattern, BotCommand object or their Iterable"
             )
-            raise ValueError(msg)
 
         items = []
         for command in (*values, *commands):
             if isinstance(command, BotCommand):
                 command = command.command
             if not isinstance(command, (str, re.Pattern)):
-                msg = (
+                raise ValueError(
                     "Command filter only supports str, re.Pattern, BotCommand object"
                     " or their Iterable"
                 )
-                raise ValueError(msg)
             if ignore_case and isinstance(command, str):
                 command = command.casefold()
             items.append(command)
 
         if not items:
-            msg = "At least one command should be specified"
-            raise ValueError(msg)
+            raise ValueError("At least one command should be specified")
 
         self.commands = tuple(items)
+        self.data = data
+        self.codec = (codec or PositionalCodec(sep=" ")) if data else None
         self.prefix = prefix
         self.ignore_case = ignore_case
         self.ignore_mention = ignore_mention
@@ -96,6 +112,7 @@ class Command(Filter):
     def __str__(self) -> str:
         return self._signature_to_string(
             *self.commands,
+            data=self.data,
             prefix=self.prefix,
             ignore_case=self.ignore_case,
             ignore_mention=self.ignore_mention,
@@ -124,14 +141,13 @@ class Command(Filter):
         return result
 
     @classmethod
-    def extract_command(cls, text: str) -> CommandObject:
+    def extract_command(cls, text: str) -> CommandObject[T]:
         # First step: separate command with arguments
         # "/command@mention arg1 arg2" -> "/command@mention", ["arg1 arg2"]
         try:
             full_command, *args = text.split(maxsplit=1)
         except ValueError as e:
-            msg = "not enough values to unpack"
-            raise CommandException(msg) from e
+            raise CommandException("not enough values to unpack") from e
 
         # Separate command into valuable parts
         # "/command@mention" -> "/", ("command", "@", "mention")
@@ -143,19 +159,17 @@ class Command(Filter):
             args=args[0] if args else None,
         )
 
-    def validate_prefix(self, command: CommandObject) -> None:
+    def validate_prefix(self, command: CommandObject[T]) -> None:
         if command.prefix not in self.prefix:
-            msg = "Invalid command prefix"
-            raise CommandException(msg)
+            raise CommandException("Invalid command prefix")
 
-    async def validate_mention(self, bot: Bot, command: CommandObject) -> None:
+    async def validate_mention(self, bot: Bot, command: CommandObject[T]) -> None:
         if command.mention and not self.ignore_mention:
             me = await bot.me()
             if me.username and command.mention.lower() != me.username.lower():
-                msg = "Mention did not match"
-                raise CommandException(msg)
+                raise CommandException("Mention did not match")
 
-    def validate_command(self, command: CommandObject) -> CommandObject:
+    def validate_command(self, command: CommandObject[T]) -> CommandObject[T]:
         for allowed_command in cast(Sequence[CommandPatternType], self.commands):
             # Command can be presented as regexp pattern or raw string
             # then need to validate that in different ways
@@ -170,10 +184,30 @@ class Command(Filter):
 
             if command_name == allowed_command:  # String
                 return command
-        msg = "Command did not match pattern"
-        raise CommandException(msg)
+        raise CommandException("Command did not match pattern")
 
-    async def parse_command(self, text: str, bot: Bot) -> CommandObject:
+    def _has_data(self) -> bool:
+        return self.data is not None and self.codec is not None
+
+    def _parse_args(self, args: str) -> Any:
+        return self.codec.decode(args, self.data)  # type: ignore[union-attr, arg-type]
+
+    def do_magic(self, command: CommandObject[T]) -> CommandObject[T]:
+        if self._has_data():
+            try:
+                parsed = self._parse_args(command.args or "")
+            except Exception as e:
+                raise CommandException(f"Failed to parse command args: {e}") from e
+            command = replace(command, parsed=parsed)
+
+        if self.magic is None:
+            return command
+        result = self.magic.resolve(command)
+        if not result:
+            raise CommandException("Rejected via magic filter")
+        return replace(command, magic_result=result)
+
+    async def parse_command(self, text: str, bot: Bot) -> CommandObject[T]:
         """
         Extract command from the text and validate
 
@@ -184,25 +218,18 @@ class Command(Filter):
         command = self.extract_command(text)
         self.validate_prefix(command=command)
         await self.validate_mention(bot=bot, command=command)
-        command = self.validate_command(command)
-        command = self.do_magic(command=command)
-        return cast(CommandObject, command)
-
-    def do_magic(self, command: CommandObject) -> Any:
-        if self.magic is None:
-            return command
-        result = self.magic.resolve(command)
-        if not result:
-            msg = "Rejected via magic filter"
-            raise CommandException(msg)
-        return replace(command, magic_result=result)
+        command = self.validate_command(command=command)
+        return self.do_magic(command=command)
 
 
 @dataclass(frozen=True)
-class CommandObject:
+class CommandObject(Generic[T]):
     """
-    Instance of this object is always has command and it prefix.
-    Can be passed as keyword argument **command** to the handler
+    Instance of this object is always has command and its prefix.
+    Can be passed as keyword argument **command** to the handler.
+
+    When used with :class:`Command` and a typed ``data=`` model,
+    the :attr:`parsed` field will contain the deserialized typed arguments.
     """
 
     prefix: str = "/"
@@ -211,11 +238,14 @@ class CommandObject:
     """Command without prefix and mention"""
     mention: str | None = None
     """Mention (if available)"""
-    args: str | None = field(repr=False, default=None)
+    args: str | None = None
     """Command argument"""
     regexp_match: Match[str] | None = field(repr=False, default=None)
     """Will be presented match result if the command is presented as regexp in filter"""
     magic_result: Any | None = field(repr=False, default=None)
+    """Result returned by the magic filter"""
+    parsed: T | None = None
+    """Typed parsed arguments when :class:`~aiogram.filters.DeeplinkData` is used"""
 
     @property
     def mentioned(self) -> bool:
@@ -237,7 +267,12 @@ class CommandObject:
         return line
 
 
-class CommandStart(Command):
+class CommandStart(Command[Any]):
+    __slots__ = (
+        "deep_link",
+        "deep_link_encoded",
+    )
+
     def __init__(
         self,
         deep_link: bool | None = None,
@@ -265,7 +300,24 @@ class CommandStart(Command):
             deep_link_encoded=self.deep_link_encoded,
         )
 
-    async def parse_command(self, text: str, bot: Bot) -> CommandObject:
+    def validate_deeplink(self, command: CommandObject[Any]) -> CommandObject[Any]:
+        if self.deep_link is None:
+            return command
+        if self.deep_link is False:
+            if command.args:
+                raise CommandException("Deep-link was not expected")
+            return command
+        if not command.args:
+            raise CommandException("Deep-link was missing")
+        if self.deep_link_encoded:
+            try:
+                args = decode_payload(command.args)
+            except UnicodeDecodeError as e:
+                raise CommandException(f"Failed to decode Base64: {e}") from e
+            return replace(command, args=args)
+        return command
+
+    async def parse_command(self, text: str, bot: Bot) -> CommandObject[Any]:
         """
         Extract command from the text and validate
 
@@ -278,26 +330,4 @@ class CommandStart(Command):
         await self.validate_mention(bot=bot, command=command)
         command = self.validate_command(command)
         command = self.validate_deeplink(command=command)
-        command = self.do_magic(command=command)
-        return cast(CommandObject, command)
-
-    def validate_deeplink(self, command: CommandObject) -> CommandObject:
-        if self.deep_link is None:
-            return command
-        if self.deep_link is False:
-            if command.args:
-                msg = "Deep-link was not expected"
-                raise CommandException(msg)
-            return command
-        if not command.args:
-            msg = "Deep-link was missing"
-            raise CommandException(msg)
-        args = command.args
-        if self.deep_link_encoded:
-            try:
-                args = decode_payload(args)
-            except UnicodeDecodeError as e:
-                msg = f"Failed to decode Base64: {e}"
-                raise CommandException(msg) from e
-            return replace(command, args=args)
-        return command
+        return self.do_magic(command=command)

--- a/aiogram/filters/command/data/__init__.py
+++ b/aiogram/filters/command/data/__init__.py
@@ -1,0 +1,16 @@
+from aiogram.filters.command.data.base import DeeplinkData, DeeplinkDataException
+from aiogram.filters.command.data.codecs import (
+    ArgsCodec,
+    Base64Codec,
+    NamedCodec,
+    PositionalCodec,
+)
+
+__all__ = (
+    "DeeplinkData",
+    "DeeplinkDataException",
+    "ArgsCodec",
+    "PositionalCodec",
+    "NamedCodec",
+    "Base64Codec",
+)

--- a/aiogram/filters/command/data/base.py
+++ b/aiogram/filters/command/data/base.py
@@ -1,0 +1,83 @@
+import re
+from typing import Any, ClassVar
+
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from aiogram.filters.command.data.codecs import ArgsCodec, Base64Codec, PositionalCodec
+
+PAYLOAD_MAX_LEN = 64
+
+
+class DeeplinkDataException(Exception):
+    """Raised when :class:`DeeplinkData` cannot be packed or unpacked."""
+
+
+class DeeplinkData(BaseModel):
+    """
+    Base class for typed deeplink payload.
+    """
+
+    __codec__: ClassVar[ArgsCodec] = PositionalCodec(sep="_")
+    __prefix__: ClassVar[str | None] = None
+
+    def __init_subclass__(
+        cls,
+        codec: ArgsCodec | None = None,
+        prefix: str | None = None,
+        encoded: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if codec is not None or encoded:
+            inner = codec or PositionalCodec(sep="_")
+            cls.__codec__ = Base64Codec(inner) if encoded else inner
+        if prefix is not None:
+            cls.__prefix__ = prefix
+
+        super().__init_subclass__(**kwargs)
+
+    def pack(self) -> str:
+        """
+        Serialize to payload string using the class-level prefix and codec.
+
+        :raises DeeplinkDataException: If prefix is missing or payload exceeds 64 bytes.
+        """
+        prefix = self.__prefix__
+        if not prefix:
+            raise DeeplinkDataException("prefix is required — set prefix= on the class")
+        args = self.__codec__.encode(self)
+        payload = f"{prefix}{args}" if args else prefix
+        if re.search(r"[^A-Za-z0-9_\-]", payload):
+            raise DeeplinkDataException(
+                f"Payload {payload!r} contains characters not allowed in deeplink. "
+                f"Use Base64Codec."
+            )
+        if len(payload.encode()) > PAYLOAD_MAX_LEN:
+            raise DeeplinkDataException(
+                f"Resulted payload is too long! len({payload!r}.encode()) > {PAYLOAD_MAX_LEN}. "
+            )
+        return payload
+
+    @classmethod
+    def unpack(cls, payload: str) -> Self:
+        """
+        Deserialize from payload string using the class-level prefix and codec.
+
+        :param payload: Full payload string (e.g. ``"order42SALE"``).
+        :raises DeeplinkDataException: If payload does not match expected prefix.
+        """
+        prefix = cls.__prefix__
+
+        if prefix:
+            if payload == prefix:
+                raw = ""
+            elif payload.startswith(prefix):
+                raw = payload[len(prefix) :]
+            else:
+                raise DeeplinkDataException(
+                    f"Bad prefix ({payload!r} does not start with {prefix!r})"
+                )
+        else:
+            raw = payload
+
+        return cls.__codec__.decode(raw, cls)

--- a/aiogram/filters/command/data/codecs.py
+++ b/aiogram/filters/command/data/codecs.py
@@ -1,0 +1,148 @@
+import types
+import typing
+from decimal import Decimal
+from enum import Enum
+from fractions import Fraction
+from typing import Any, Protocol, TypeVar, runtime_checkable
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from aiogram.utils.payload import decode_payload, encode_payload
+
+T = TypeVar("T", bound=BaseModel)
+
+_UNION_TYPES = {typing.Union, types.UnionType}
+
+
+@runtime_checkable
+class ArgsCodec(Protocol):
+    def encode(self, model: BaseModel) -> str: ...
+    def decode(self, args: str, model_cls: type[T]) -> T: ...
+
+
+class PositionalCodec(ArgsCodec):
+    """
+    Serializes fields as positional values joined by :code:`sep`.
+
+    :param sep: separator between field values
+    """
+
+    def __init__(self, sep: str = " ") -> None:
+        self.sep = sep
+
+    def encode(self, model: BaseModel) -> str:
+        parts: list[str] = []
+        for name, value in model.model_dump(mode="python").items():
+            encoded = _encode_value(name, value)
+            if self.sep in encoded:
+                raise ValueError(
+                    f"Separator {self.sep!r} found in field {name!r}={encoded!r}. "
+                    f"Use a different sep or Base64Codec."
+                )
+            parts.append(encoded)
+        while parts and parts[-1] == "":
+            parts.pop()
+        return self.sep.join(parts)
+
+    def decode(self, args: str, model_cls: type[T]) -> T:
+        parts = args.split(self.sep) if args else []
+        model_fields = model_cls.model_fields
+
+        if len(parts) > len(model_fields):
+            raise ValueError(
+                f"Args has {len(parts)} segments but "
+                f"{model_cls.__name__!r} has {len(model_fields)} fields"
+            )
+
+        kwargs: dict[str, Any] = {
+            name: _decode_field(parts[i] if i < len(parts) else "", field)
+            for i, (name, field) in enumerate(model_fields.items())
+        }
+        return model_cls(**kwargs)
+
+
+class NamedCodec(ArgsCodec):
+    """
+    Serializes fields as :code:`key=value` pairs joined by :code:`sep`. Order-independent.
+
+    :param sep: separator between pairs
+    :param kv_sep: separator between key and value
+    """
+
+    def __init__(self, sep: str = " ", kv_sep: str = "=") -> None:
+        self.sep = sep
+        self.kv_sep = kv_sep
+
+    def encode(self, model: BaseModel) -> str:
+        parts: list[str] = []
+        for name, value in model.model_dump(mode="python").items():
+            encoded = _encode_value(name, value)
+            if encoded == "":
+                continue
+            parts.append(f"{name}{self.kv_sep}{encoded}")
+        return self.sep.join(parts)
+
+    def decode(self, args: str, model_cls: type[T]) -> T:
+        kwargs: dict[str, Any] = {}
+        if args:
+            for token in args.split(self.sep):
+                if self.kv_sep not in token:
+                    raise ValueError(f"Token {token!r} is not a valid key{self.kv_sep}value pair")
+                key, _, value = token.partition(self.kv_sep)
+                key = key.strip()
+                field = model_cls.model_fields.get(key)
+                if field is not None:
+                    value = _decode_field(value, field)
+                kwargs[key] = value
+
+        for name, field in model_cls.model_fields.items():
+            if name not in kwargs:
+                kwargs[name] = _decode_field("", field)
+        return model_cls(**kwargs)
+
+
+class Base64Codec:
+    """
+    Wraps any :class:`ArgsCodec` with base64url encoding of the entire payload.
+    Makes the payload deeplink-safe regardless of field content.
+
+    :param inner: The codec to wrap. Defaults to :class:`PositionalCodec` with ``sep="_"``.
+    """
+
+    def __init__(self, inner: ArgsCodec | None = None) -> None:
+        self.inner: ArgsCodec = inner if inner is not None else PositionalCodec(sep="_")
+
+    def encode(self, model: BaseModel) -> str:
+        return encode_payload(self.inner.encode(model))
+
+    def decode(self, args: str, model_cls: type[T]) -> T:
+        return self.inner.decode(decode_payload(args) if args else "", model_cls)
+
+
+def _encode_value(key: str, value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, Enum):
+        return str(value.value)
+    if isinstance(value, UUID):
+        return value.hex
+    if isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, (int, str, float, Decimal, Fraction)):
+        return str(value)
+    raise ValueError(
+        f"Attribute {key}={value!r} of type {type(value).__name__!r} can not be packed to payload"
+    )
+
+
+def _decode_field(raw: str, field: FieldInfo) -> Any:
+    if not raw:
+        if field.default is not PydanticUndefined and field.default != "":
+            return field.default
+        if type(None) in typing.get_args(field.annotation):
+            return None
+        return ""
+    return raw

--- a/aiogram/filters/command/deeplink.py
+++ b/aiogram/filters/command/deeplink.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from aiogram.filters.command.base import CommandStart
+
+if TYPE_CHECKING:
+    from magic_filter import MagicFilter
+
+    from aiogram.filters.command.data.base import DeeplinkData
+
+T = TypeVar("T", bound="DeeplinkData")
+
+
+class DeeplinkCommand(CommandStart, Generic[T]):
+    def __init__(
+        self,
+        data: type[T] | None = None,
+        ignore_case: bool = False,
+        ignore_mention: bool = False,
+        magic: MagicFilter | None = None,
+    ) -> None:
+        if data is not None and data.__prefix__ is None:
+            raise ValueError(f"{data.__name__} has no prefix. Set prefix= on the class.")
+        super().__init__(
+            deep_link=True,
+            deep_link_encoded=False,
+            ignore_case=ignore_case,
+            ignore_mention=ignore_mention,
+            magic=magic,
+        )
+        self._data = data
+
+    def __str__(self) -> str:
+        return self._signature_to_string(
+            self._data,
+            ignore_case=self.ignore_case,
+            ignore_mention=self.ignore_mention,
+            magic=self.magic,
+        )
+
+    def _has_data(self) -> bool:
+        return self._data is not None
+
+    def _parse_args(self, args: str) -> Any:
+        return self._data.unpack(args)  # type: ignore[union-attr]

--- a/aiogram/handlers/message.py
+++ b/aiogram/handlers/message.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import cast
+from typing import Any, cast
 
 from aiogram.filters import CommandObject
 from aiogram.handlers.base import BaseHandler, BaseHandlerMixin
@@ -22,7 +22,7 @@ class MessageHandler(BaseHandler[Message], ABC):
 
 class MessageHandlerCommandMixin(BaseHandlerMixin[Message]):
     @property
-    def command(self) -> CommandObject | None:
+    def command(self) -> CommandObject[Any] | None:
         if "command" in self.data:
-            return cast(CommandObject, self.data["command"])
+            return cast(CommandObject[Any], self.data["command"])
         return None

--- a/examples/command_typed_args.py
+++ b/examples/command_typed_args.py
@@ -1,0 +1,147 @@
+import asyncio
+import logging
+import random
+import sys
+from os import getenv
+
+from pydantic import BaseModel
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+from aiogram.filters import Command, CommandObject, CommandStart, DeeplinkCommand, or_f
+from aiogram.filters.command import DeeplinkData, NamedCodec, PositionalCodec
+from aiogram.types import Message
+from aiogram.utils.deep_linking import create_start_link
+
+TOKEN = getenv("BOT_TOKEN")
+
+dp = Dispatcher()
+
+
+class RollArgs(BaseModel):
+    sides: int = 6
+    count: int = 1
+
+
+@dp.message(Command("roll", data=RollArgs, codec=PositionalCodec(sep=" ")))
+async def cmd_roll(message: Message, command: CommandObject[RollArgs]) -> None:
+    """Roll dice. Usage: /roll [sides] [count]"""
+    results = [random.randint(1, command.parsed.sides) for _ in range(command.parsed.count)]
+    await message.answer(f"🎲 {results} (sum: {sum(results)})")
+
+
+class RemindArgs(BaseModel):
+    text: str = ""
+    delay: int = 5
+
+
+@dp.message(Command("remind", data=RemindArgs, codec=NamedCodec()))
+async def cmd_remind(message: Message, command: CommandObject[RemindArgs]) -> None:
+    """Set a reminder. Usage: /remind text=Buy_milk delay=10"""
+    await message.answer(f"⏰ Remind '{command.parsed.text}' in {command.parsed.delay} min.")
+
+
+class InvitePayload(DeeplinkData, prefix="inv", encoded=True):
+    """Encoded deeplink payload. Example payload: ``invNDJfYWRtaW4``"""
+
+    group_id: int
+    role: str = "member"
+
+
+@dp.message(DeeplinkCommand(data=InvitePayload))
+async def deeplink_invite(message: Message, command: CommandObject[InvitePayload]) -> None:
+    """Handles /start with an encoded invite payload."""
+    await message.answer(
+        f"👋 Welcome to group #{command.parsed.group_id} as {command.parsed.role}!"
+    )
+
+
+class OrderPayload(DeeplinkData, prefix="order"):
+    """Plain deeplink payload. Example payload: ``order99_SALE``"""
+
+    order_id: int
+    promo: str | None = None
+
+
+@dp.message(DeeplinkCommand(data=OrderPayload))
+async def deeplink_order(message: Message, command: CommandObject[OrderPayload]) -> None:
+    """Handles /start with a plain order payload."""
+    await message.answer(
+        f"🛒 Order #{command.parsed.order_id}, promo: {command.parsed.promo or '—'}"
+    )
+
+
+class PromoData(DeeplinkData, prefix="deal"):
+    """Combined payload for /promo and /start deeplink. Example: ``dealSALE_50``"""
+
+    code: str = ""
+    discount: int = 0
+
+
+@dp.message(
+    or_f(
+        Command("promo", data=PromoData, codec=PositionalCodec(sep=" ")),
+        DeeplinkCommand(data=PromoData),
+    )
+)
+async def cmd_promo(message: Message, command: CommandObject[PromoData]) -> None:
+    """Apply a promo code. Via command: /promo SALE 50  |  Via deeplink: /start dealSALE_50"""
+    await message.answer(f"🏷 Promo {command.parsed.code}: {command.parsed.discount}% off!")
+
+
+class BanArgs(BaseModel):
+    user_id: int
+    reason: str
+
+
+@dp.message(Command("ban", data=BanArgs, codec=PositionalCodec(sep=" ")))
+async def cmd_ban(message: Message, command: CommandObject[BanArgs]) -> None:
+    """Ban a user. Usage: /ban <user_id> <reason>"""
+    await message.answer(f"🔨 Banned {command.parsed.user_id}: {command.parsed.reason}")
+
+
+@dp.message(Command("ban"))
+async def cmd_ban_usage(message: Message) -> None:
+    """Fallback when /ban is sent without required arguments."""
+    await message.answer("Usage: /ban <user_id> <reason>")
+
+
+@dp.message(CommandStart())
+async def cmd_start(message: Message) -> None:
+    await message.answer(
+        "Hello! This bot demonstrates typed command arguments.\n\n"
+        "<b>Positional args</b>\n"
+        "/roll &lt;sides&gt; &lt;count&gt; — roll dice\n\n"
+        "<b>Named args</b>\n"
+        "/remind text=Buy_milk delay=10\n\n"
+        "<b>Required args (fallback on missing)</b>\n"
+        "/ban &lt;user_id&gt; &lt;reason&gt;\n\n"
+        "<b>Deeplinks</b>\n"
+        "/genlinks — get clickable /start links\n\n"
+        "<b>Combined (command + deeplink)</b>\n"
+        "/promo CODE DISCOUNT"
+    )
+
+
+@dp.message(Command("genlinks"))
+async def cmd_genlinks(message: Message, bot: Bot) -> None:
+    invite_link = await create_start_link(bot, InvitePayload(group_id=42, role="admin").pack())
+    order_link = await create_start_link(bot, OrderPayload(order_id=99, promo="SALE").pack())
+    promo_link = await create_start_link(bot, PromoData(code="SALE", discount=50).pack())
+
+    await message.answer(
+        f"Invite (encoded):\n{invite_link}\n\n"
+        f"Order (plain):\n{order_link}\n\n"
+        f"Promo (combined):\n{promo_link}"
+    )
+
+
+async def main() -> None:
+    bot = Bot(token=TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    asyncio.run(main())

--- a/tests/test_filters/command/test_codecs.py
+++ b/tests/test_filters/command/test_codecs.py
@@ -1,0 +1,138 @@
+from decimal import Decimal
+from enum import Enum, auto
+from fractions import Fraction
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+
+from aiogram.filters.command.data.codecs import (
+    Base64Codec,
+    NamedCodec,
+    PositionalCodec,
+    _encode_value,
+)
+
+
+class MyStrEnum(str, Enum):
+    FOO = "foo"
+
+
+class MyIntEnum(Enum):
+    BAR = auto()
+
+
+class MyModel(BaseModel):
+    name: str
+    count: int
+
+
+class MyModelOpt(BaseModel):
+    name: str
+    count: int | None = None
+
+
+class MyB64(BaseModel):
+    text: str
+    num: int
+
+
+class TestEncodeValue:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, ""),
+            (True, "1"),
+            (False, "0"),
+            (MyIntEnum.BAR, "1"),
+            (MyStrEnum.FOO, "foo"),
+            ("hello", "hello"),
+            (42, "42"),
+            (3.14, "3.14"),
+            (UUID("123e4567-e89b-12d3-a456-426655440000"), "123e4567e89b12d3a456426655440000"),
+            (Decimal("9.99"), "9.99"),
+            (Fraction("3/2"), "3/2"),
+        ],
+    )
+    def test_positive(self, value, expected):
+        assert _encode_value("field", value) == expected
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match="can not be packed"):
+            _encode_value("field", object())
+
+
+class TestPositionalCodec:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            (MyModel(name="alice", count=5), "alice 5"),
+            (MyModelOpt(name="alice"), "alice"),
+        ],
+    )
+    def test_encode(self, model, expected):
+        assert PositionalCodec(sep=" ").encode(model) == expected
+
+    def test_encode_sep_in_value_raises(self):
+        with pytest.raises(ValueError, match="Separator"):
+            PositionalCodec(sep=" ").encode(MyModel(name="a b", count=1))
+
+    @pytest.mark.parametrize(
+        "args,model_cls,expected",
+        [
+            ("alice 5", MyModel, MyModel(name="alice", count=5)),
+            ("alice", MyModelOpt, MyModelOpt(name="alice", count=None)),
+        ],
+    )
+    def test_decode(self, args, model_cls, expected):
+        assert PositionalCodec(sep=" ").decode(args, model_cls) == expected
+
+    def test_decode_too_many_segments_raises(self):
+        with pytest.raises(ValueError, match="segments"):
+            PositionalCodec(sep=" ").decode("a b c", MyModel)
+
+
+class TestNamedCodec:
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            ("name=alice count=5", MyModel(name="alice", count=5)),
+            ("count=5 name=alice", MyModel(name="alice", count=5)),
+            ("name=alice", MyModelOpt(name="alice", count=None)),
+        ],
+    )
+    def test_decode(self, args, expected):
+        assert NamedCodec().decode(args, type(expected)) == expected
+
+    def test_decode_malformed_token_raises(self):
+        with pytest.raises(ValueError, match="key=value"):
+            NamedCodec().decode("namealice", MyModel)
+
+    def test_decode_value_contains_kv_sep(self):
+        assert NamedCodec(kv_sep="=").decode("name=a=b count=5", MyModel) == MyModel(name="a=b", count=5)
+
+    @pytest.mark.parametrize("model", [
+        MyModel(name="bob", count=99),
+        MyModelOpt(name="alice"),
+    ])
+    def test_roundtrip(self, model):
+        codec = NamedCodec()
+        assert codec.decode(codec.encode(model), type(model)) == model
+
+
+class TestBase64Codec:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            MyB64(text="hello", num=42),
+            MyB64(text="path/value", num=0),
+        ],
+    )
+    def test_roundtrip(self, model):
+        assert Base64Codec().decode(Base64Codec().encode(model), MyB64) == model
+
+    def test_decode_empty_uses_defaults(self):
+        class WithDefault(BaseModel):
+            page: int = 1
+
+        assert Base64Codec().decode("", WithDefault) == WithDefault(page=1)

--- a/tests/test_filters/command/test_command_data.py
+++ b/tests/test_filters/command/test_command_data.py
@@ -1,0 +1,72 @@
+import pytest
+
+from aiogram.filters.command.data.base import DeeplinkData, DeeplinkDataException
+from aiogram.filters.command.data.codecs import PositionalCodec
+
+
+class MyOrder(DeeplinkData, prefix="order", codec=PositionalCodec(sep="_")):
+    order_id: int
+    promo: str | None = None
+
+
+class PackNoPfx(DeeplinkData):
+    val: str
+
+
+class PackWithSpace(DeeplinkData, prefix="s"):
+    val: str
+
+
+class PackTooLong(DeeplinkData, prefix="p", codec=PositionalCodec(sep="_")):
+    val: str
+
+
+class TestDeeplinkData:
+    def test_pack(self):
+        assert MyOrder(order_id=42).pack() == "order42"
+        assert MyOrder(order_id=7, promo="SALE").pack() == "order7_SALE"
+
+    @pytest.mark.parametrize("model,match", [
+        (PackNoPfx(val="x"),        "prefix is required"),
+        (PackWithSpace(val="a b"),  "not allowed"),
+        (PackTooLong(val="x" * 64), "too long"),
+    ])
+    def test_pack_raises(self, model, match):
+        with pytest.raises(DeeplinkDataException, match=match):
+            model.pack()
+
+    def test_unpack(self):
+        assert MyOrder.unpack("order42") == MyOrder(order_id=42)
+        assert MyOrder.unpack("order7_SALE") == MyOrder(order_id=7, promo="SALE")
+
+    def test_unpack_bad_prefix_raises(self):
+        with pytest.raises(DeeplinkDataException, match="Bad prefix"):
+            MyOrder.unpack("wrong42")
+
+    def test_unpack_optional(self):
+        class MyCmd(DeeplinkData, prefix="x", codec=PositionalCodec(sep="_")):
+            val: str
+            tag: str | None = None
+
+        assert MyCmd.unpack("xhello") == MyCmd(val="hello")
+        assert MyCmd.unpack("xhello_sale") == MyCmd(val="hello", tag="sale")
+
+        class AllOpt(DeeplinkData, prefix="p", codec=PositionalCodec(sep="_")):
+            val: str | None = None
+
+        assert AllOpt.unpack("p") == AllOpt(val=None)
+
+    def test_unpack_optional_without_default(self):
+        class MyData(DeeplinkData, prefix="x", codec=PositionalCodec(sep="_")):
+            id: int
+            extra: int | None
+
+        assert MyData.unpack("x1") == MyData(id=1, extra=None)
+
+    def test_encoded_roundtrip(self):
+        class MyB64(DeeplinkData, prefix="b", encoded=True):
+            text: str
+            num: int = 0
+
+        model = MyB64(text="hello world", num=7)
+        assert MyB64.unpack(model.pack()) == model

--- a/tests/test_filters/command/test_command_filter.py
+++ b/tests/test_filters/command/test_command_filter.py
@@ -1,0 +1,82 @@
+import datetime
+
+import pytest
+from pydantic import BaseModel
+
+from aiogram import F
+from aiogram.filters import Command
+from aiogram.filters.command.data.codecs import Base64Codec, PositionalCodec
+from aiogram.types import Chat, Message
+from tests.mocked_bot import MockedBot
+
+
+def _msg(text: str) -> Message:
+    return Message(
+        message_id=1,
+        text=text,
+        chat=Chat(id=1, type="private"),
+        date=datetime.datetime.now(),
+    )
+
+
+class MyArgs(BaseModel):
+    action: str
+    target: str | None = None
+
+
+class TestCommand:
+    def test_codec_requires_data(self):
+        with pytest.raises(ValueError):
+            Command("do", codec=PositionalCodec(sep=" "))
+
+    def test_no_data_codec_is_none(self):
+        cmd = Command("ping")
+        assert cmd.codec is None
+
+    def test_explicit_codec_used(self):
+        codec = PositionalCodec(sep=" ")
+        cmd = Command("do", data=MyArgs, codec=codec)
+        assert cmd.codec is codec
+
+    def test_default_codec_is_positional_space(self):
+        cmd = Command("do", data=MyArgs)
+        assert isinstance(cmd.codec, PositionalCodec)
+        assert cmd.codec.sep == " "
+
+
+class TestCommandFilter:
+    @pytest.mark.parametrize(
+        "text,expected_parsed",
+        [
+            ("/do run server", MyArgs(action="run", target="server")),
+            ("/do run", MyArgs(action="run")),
+            ("/do a b c", False),
+        ],
+    )
+    async def test_call(self, text, expected_parsed, bot: MockedBot):
+        cmd = Command("do", data=MyArgs, codec=PositionalCodec(sep=" "))
+        result = await cmd(_msg(text), bot)
+        if expected_parsed is False:
+            assert result is False
+        else:
+            assert result["command"].parsed == expected_parsed
+
+    async def test_no_data_parsed_is_none(self, bot: MockedBot):
+        result = await Command("ping")(_msg("/ping"), bot)
+        assert result
+        assert result["command"].parsed is None
+
+    async def test_magic_on_parsed(self, bot: MockedBot):
+        cmd = Command(
+            "do", data=MyArgs, codec=PositionalCodec(sep=" "), magic=F.parsed.action == "run"
+        )
+        assert await cmd(_msg("/do run"), bot)
+        assert not await cmd(_msg("/do stop"), bot)
+
+    async def test_base64_codec_roundtrip(self, bot: MockedBot):
+        codec = Base64Codec(PositionalCodec(sep=" "))
+        cmd = Command("do", data=MyArgs, codec=codec)
+        encoded = codec.encode(MyArgs(action="run", target="srv"))
+        result = await cmd(_msg(f"/do {encoded}"), bot)
+        assert result
+        assert result["command"].parsed == MyArgs(action="run", target="srv")

--- a/tests/test_filters/command/test_deeplink.py
+++ b/tests/test_filters/command/test_deeplink.py
@@ -1,0 +1,101 @@
+import datetime
+import sys
+from typing import Optional, Union
+
+import pytest
+
+from aiogram import F
+from aiogram.filters.command import DeeplinkCommand
+from aiogram.filters.command.data.base import DeeplinkData
+from aiogram.filters.command.data.codecs import Base64Codec, PositionalCodec
+from aiogram.types import Chat, Message
+from tests.mocked_bot import MockedBot
+
+
+def _msg(text: str) -> Message:
+    return Message(
+        message_id=1,
+        text=text,
+        chat=Chat(id=1, type="private"),
+        date=datetime.datetime.now(),
+    )
+
+
+class MyOrder(DeeplinkData, prefix="order", codec=PositionalCodec(sep="_")):
+    order_id: int
+    promo: str | None = None
+
+
+class TestDeeplinkCommand:
+    def test_no_prefix_on_data_raises(self):
+        class NoPfx(DeeplinkData):
+            val: str
+
+        with pytest.raises(ValueError, match="no prefix"):
+            DeeplinkCommand(NoPfx)
+
+class TestDeeplinkCommandFilter:
+    @pytest.mark.parametrize(
+        "text,expected_parsed",
+        [
+            (f"/start {MyOrder(order_id=42).pack()}", MyOrder(order_id=42)),
+            (
+                f"/start {MyOrder(order_id=7, promo='SALE').pack()}",
+                MyOrder(order_id=7, promo="SALE"),
+            ),
+            ("/start wrongprefix99", False),
+            ("/start", False),
+        ],
+    )
+    async def test_call(self, text, expected_parsed, bot: MockedBot):
+        result = await DeeplinkCommand(MyOrder)(_msg(text), bot)
+        if expected_parsed is False:
+            assert result is False
+        else:
+            assert result["command"].parsed == expected_parsed
+
+    async def test_no_data_accepts_any_deeplink(self, bot: MockedBot):
+        result = await DeeplinkCommand()(_msg("/start anything"), bot)
+        assert result["command"].args == "anything"
+        assert result["command"].parsed is None
+
+    async def test_magic_on_parsed(self, bot: MockedBot):
+        cmd = DeeplinkCommand(MyOrder, magic=F.parsed.order_id == 10)
+        assert await cmd(_msg(f"/start {MyOrder(order_id=10).pack()}"), bot)
+        assert not await cmd(_msg(f"/start {MyOrder(order_id=99).pack()}"), bot)
+
+    async def test_base64_codec(self, bot: MockedBot):
+        class MyB64(DeeplinkData, prefix="b", codec=Base64Codec(PositionalCodec(sep=" "))):
+            text: str
+
+        payload = MyB64(text="path/value").pack()
+        result = await DeeplinkCommand(MyB64)(_msg(f"/start {payload}"), bot)
+        assert result["command"].parsed == MyB64(text="path/value")
+
+    async def test_encoded_class_roundtrip(self, bot: MockedBot):
+        class EncodedOrder(DeeplinkData, prefix="order", encoded=True):
+            order_id: int
+
+        payload = EncodedOrder(order_id=7).pack()
+        result = await DeeplinkCommand(EncodedOrder)(_msg(f"/start {payload}"), bot)
+        assert result["command"].parsed == EncodedOrder(order_id=7)
+
+    @pytest.mark.parametrize("hint", [Union[int, None], Optional[int]])
+    async def test_optional_without_default(self, hint, bot: MockedBot):
+        class MyData(DeeplinkData, prefix="x", codec=PositionalCodec(sep="_")):
+            id: int
+            extra: hint
+
+        payload = MyData(id=1, extra=None).pack()
+        result = await DeeplinkCommand(MyData)(_msg(f"/start {payload}"), bot)
+        assert result["command"].parsed == MyData(id=1, extra=None)
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="UnionType requires Python 3.10+")
+    async def test_optional_union_syntax(self, bot: MockedBot):
+        class MyData(DeeplinkData, prefix="y", codec=PositionalCodec(sep="_")):
+            id: int
+            extra: int | None
+
+        payload = MyData(id=2, extra=None).pack()
+        result = await DeeplinkCommand(MyData)(_msg(f"/start {payload}"), bot)
+        assert result["command"].parsed == MyData(id=2, extra=None)


### PR DESCRIPTION
# Description

This PR adds typed argument parsing for commands and deeplinks: instead of splitting `command.args` manually, you declare a Pydantic model and the framework deserializes it automatically, similar to how `CallbackData` works for inline buttons. A usage example is available in `examples/command_typed_args.py`.

I am ready to add documentation once the implementation is approved.

- `command.py` refactored into a `command/` package
- `Command[T]` accepts `data=` and `codec=`, parsed result is available as `command.parsed`
- `PositionalCodec` for space-separated values, `NamedCodec` for `key=value` pairs, `Base64Codec` for base64url-encoded payloads
- `DeeplinkData` — Pydantic base class for typed `/start` payloads with `pack()` / `unpack()`
- `DeeplinkCommand[T]` routes by payload prefix and populates `command.parsed`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
