### PR TITLE
Fixed severe (exponential) slowdown when validating nested unions

### DIFF
--- a/CHANGES/1842.bugfix.rst
+++ b/CHANGES/1842.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed severe (exponential) slowdown when validating nested :class:`aiogram.types.rich_block.RichBlock`
+structures (e.g. nested ``blockquote``/``collage``/``details`` blocks).
+Subtype unions whose members share a unique constant tag field (``RichBlockUnion``, ``ReactionTypeUnion``,
+``ChatMemberUnion``, ``MessageOriginUnion`` and others) are now generated as Pydantic *discriminated* unions
+keyed on that field (``type``/``status``/``source``), so the correct member is selected directly instead of
+being found via smart-union backtracking.

--- a/aiogram/types/background_fill_union.py
+++ b/aiogram/types/background_fill_union.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .background_fill_freeform_gradient import BackgroundFillFreeformGradient
 from .background_fill_gradient import BackgroundFillGradient
 from .background_fill_solid import BackgroundFillSolid
 
-BackgroundFillUnion: TypeAlias = (
-    BackgroundFillSolid | BackgroundFillGradient | BackgroundFillFreeformGradient
-)
+BackgroundFillUnion: TypeAlias = Annotated[
+    BackgroundFillSolid | BackgroundFillGradient | BackgroundFillFreeformGradient,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/background_type_union.py
+++ b/aiogram/types/background_type_union.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .background_type_chat_theme import BackgroundTypeChatTheme
 from .background_type_fill import BackgroundTypeFill
 from .background_type_pattern import BackgroundTypePattern
 from .background_type_wallpaper import BackgroundTypeWallpaper
 
-BackgroundTypeUnion: TypeAlias = (
-    BackgroundTypeFill | BackgroundTypeWallpaper | BackgroundTypePattern | BackgroundTypeChatTheme
-)
+BackgroundTypeUnion: TypeAlias = Annotated[
+    BackgroundTypeFill | BackgroundTypeWallpaper | BackgroundTypePattern | BackgroundTypeChatTheme,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/bot_command_scope_union.py
+++ b/aiogram/types/bot_command_scope_union.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .bot_command_scope_all_chat_administrators import (
     BotCommandScopeAllChatAdministrators,
@@ -12,12 +14,13 @@ from .bot_command_scope_chat_administrators import BotCommandScopeChatAdministra
 from .bot_command_scope_chat_member import BotCommandScopeChatMember
 from .bot_command_scope_default import BotCommandScopeDefault
 
-BotCommandScopeUnion: TypeAlias = (
+BotCommandScopeUnion: TypeAlias = Annotated[
     BotCommandScopeDefault
     | BotCommandScopeAllPrivateChats
     | BotCommandScopeAllGroupChats
     | BotCommandScopeAllChatAdministrators
     | BotCommandScopeChat
     | BotCommandScopeChatAdministrators
-    | BotCommandScopeChatMember
-)
+    | BotCommandScopeChatMember,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/chat_boost_source_union.py
+++ b/aiogram/types/chat_boost_source_union.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .chat_boost_source_gift_code import ChatBoostSourceGiftCode
 from .chat_boost_source_giveaway import ChatBoostSourceGiveaway
 from .chat_boost_source_premium import ChatBoostSourcePremium
 
-ChatBoostSourceUnion: TypeAlias = (
-    ChatBoostSourcePremium | ChatBoostSourceGiftCode | ChatBoostSourceGiveaway
-)
+ChatBoostSourceUnion: TypeAlias = Annotated[
+    ChatBoostSourcePremium | ChatBoostSourceGiftCode | ChatBoostSourceGiveaway,
+    Field(discriminator="source"),
+]

--- a/aiogram/types/chat_member_union.py
+++ b/aiogram/types/chat_member_union.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .chat_member_administrator import ChatMemberAdministrator
 from .chat_member_banned import ChatMemberBanned
@@ -9,11 +11,12 @@ from .chat_member_member import ChatMemberMember
 from .chat_member_owner import ChatMemberOwner
 from .chat_member_restricted import ChatMemberRestricted
 
-ChatMemberUnion: TypeAlias = (
+ChatMemberUnion: TypeAlias = Annotated[
     ChatMemberOwner
     | ChatMemberAdministrator
     | ChatMemberMember
     | ChatMemberRestricted
     | ChatMemberLeft
-    | ChatMemberBanned
-)
+    | ChatMemberBanned,
+    Field(discriminator="status"),
+]

--- a/aiogram/types/input_media_union.py
+++ b/aiogram/types/input_media_union.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_media_animation import InputMediaAnimation
 from .input_media_audio import InputMediaAudio
@@ -9,11 +11,12 @@ from .input_media_live_photo import InputMediaLivePhoto
 from .input_media_photo import InputMediaPhoto
 from .input_media_video import InputMediaVideo
 
-InputMediaUnion: TypeAlias = (
+InputMediaUnion: TypeAlias = Annotated[
     InputMediaAnimation
     | InputMediaAudio
     | InputMediaDocument
     | InputMediaLivePhoto
     | InputMediaPhoto
-    | InputMediaVideo
-)
+    | InputMediaVideo,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/input_paid_media_union.py
+++ b/aiogram/types/input_paid_media_union.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_paid_media_live_photo import InputPaidMediaLivePhoto
 from .input_paid_media_photo import InputPaidMediaPhoto
 from .input_paid_media_video import InputPaidMediaVideo
 
-InputPaidMediaUnion: TypeAlias = (
-    InputPaidMediaLivePhoto | InputPaidMediaPhoto | InputPaidMediaVideo
-)
+InputPaidMediaUnion: TypeAlias = Annotated[
+    InputPaidMediaLivePhoto | InputPaidMediaPhoto | InputPaidMediaVideo,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/input_poll_media_union.py
+++ b/aiogram/types/input_poll_media_union.py
@@ -1,4 +1,6 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_media_animation import InputMediaAnimation
 from .input_media_audio import InputMediaAudio
@@ -9,7 +11,7 @@ from .input_media_photo import InputMediaPhoto
 from .input_media_venue import InputMediaVenue
 from .input_media_video import InputMediaVideo
 
-InputPollMediaUnion: TypeAlias = (
+InputPollMediaUnion: TypeAlias = Annotated[
     InputMediaAnimation
     | InputMediaAudio
     | InputMediaDocument
@@ -17,5 +19,6 @@ InputPollMediaUnion: TypeAlias = (
     | InputMediaLocation
     | InputMediaPhoto
     | InputMediaVenue
-    | InputMediaVideo
-)
+    | InputMediaVideo,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/input_poll_option_media_union.py
+++ b/aiogram/types/input_poll_option_media_union.py
@@ -1,4 +1,6 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_media_animation import InputMediaAnimation
 from .input_media_link import InputMediaLink
@@ -9,7 +11,7 @@ from .input_media_sticker import InputMediaSticker
 from .input_media_venue import InputMediaVenue
 from .input_media_video import InputMediaVideo
 
-InputPollOptionMediaUnion: TypeAlias = (
+InputPollOptionMediaUnion: TypeAlias = Annotated[
     InputMediaAnimation
     | InputMediaLink
     | InputMediaLivePhoto
@@ -17,5 +19,6 @@ InputPollOptionMediaUnion: TypeAlias = (
     | InputMediaPhoto
     | InputMediaSticker
     | InputMediaVenue
-    | InputMediaVideo
-)
+    | InputMediaVideo,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/input_profile_photo_union.py
+++ b/aiogram/types/input_profile_photo_union.py
@@ -1,6 +1,10 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_profile_photo_animated import InputProfilePhotoAnimated
 from .input_profile_photo_static import InputProfilePhotoStatic
 
-InputProfilePhotoUnion: TypeAlias = InputProfilePhotoStatic | InputProfilePhotoAnimated
+InputProfilePhotoUnion: TypeAlias = Annotated[
+    InputProfilePhotoStatic | InputProfilePhotoAnimated, Field(discriminator="type")
+]

--- a/aiogram/types/input_story_content_union.py
+++ b/aiogram/types/input_story_content_union.py
@@ -1,6 +1,10 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .input_story_content_photo import InputStoryContentPhoto
 from .input_story_content_video import InputStoryContentVideo
 
-InputStoryContentUnion: TypeAlias = InputStoryContentPhoto | InputStoryContentVideo
+InputStoryContentUnion: TypeAlias = Annotated[
+    InputStoryContentPhoto | InputStoryContentVideo, Field(discriminator="type")
+]

--- a/aiogram/types/menu_button_union.py
+++ b/aiogram/types/menu_button_union.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .menu_button_commands import MenuButtonCommands
 from .menu_button_default import MenuButtonDefault
 from .menu_button_web_app import MenuButtonWebApp
 
-MenuButtonUnion: TypeAlias = MenuButtonCommands | MenuButtonWebApp | MenuButtonDefault
+MenuButtonUnion: TypeAlias = Annotated[
+    MenuButtonCommands | MenuButtonWebApp | MenuButtonDefault, Field(discriminator="type")
+]

--- a/aiogram/types/message_origin_union.py
+++ b/aiogram/types/message_origin_union.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .message_origin_channel import MessageOriginChannel
 from .message_origin_chat import MessageOriginChat
 from .message_origin_hidden_user import MessageOriginHiddenUser
 from .message_origin_user import MessageOriginUser
 
-MessageOriginUnion: TypeAlias = (
-    MessageOriginUser | MessageOriginHiddenUser | MessageOriginChat | MessageOriginChannel
-)
+MessageOriginUnion: TypeAlias = Annotated[
+    MessageOriginUser | MessageOriginHiddenUser | MessageOriginChat | MessageOriginChannel,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/owned_gift_union.py
+++ b/aiogram/types/owned_gift_union.py
@@ -1,6 +1,10 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .owned_gift_regular import OwnedGiftRegular
 from .owned_gift_unique import OwnedGiftUnique
 
-OwnedGiftUnion: TypeAlias = OwnedGiftRegular | OwnedGiftUnique
+OwnedGiftUnion: TypeAlias = Annotated[
+    OwnedGiftRegular | OwnedGiftUnique, Field(discriminator="type")
+]

--- a/aiogram/types/paid_media_union.py
+++ b/aiogram/types/paid_media_union.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .paid_media_live_photo import PaidMediaLivePhoto
 from .paid_media_photo import PaidMediaPhoto
 from .paid_media_preview import PaidMediaPreview
 from .paid_media_video import PaidMediaVideo
 
-PaidMediaUnion: TypeAlias = PaidMediaLivePhoto | PaidMediaPhoto | PaidMediaPreview | PaidMediaVideo
+PaidMediaUnion: TypeAlias = Annotated[
+    PaidMediaLivePhoto | PaidMediaPhoto | PaidMediaPreview | PaidMediaVideo,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/passport_element_error_union.py
+++ b/aiogram/types/passport_element_error_union.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .passport_element_error_data_field import PassportElementErrorDataField
 from .passport_element_error_file import PassportElementErrorFile
@@ -14,7 +16,7 @@ from .passport_element_error_translation_files import (
 )
 from .passport_element_error_unspecified import PassportElementErrorUnspecified
 
-PassportElementErrorUnion: TypeAlias = (
+PassportElementErrorUnion: TypeAlias = Annotated[
     PassportElementErrorDataField
     | PassportElementErrorFrontSide
     | PassportElementErrorReverseSide
@@ -23,5 +25,6 @@ PassportElementErrorUnion: TypeAlias = (
     | PassportElementErrorFiles
     | PassportElementErrorTranslationFile
     | PassportElementErrorTranslationFiles
-    | PassportElementErrorUnspecified
-)
+    | PassportElementErrorUnspecified,
+    Field(discriminator="source"),
+]

--- a/aiogram/types/reaction_type_union.py
+++ b/aiogram/types/reaction_type_union.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .reaction_type_custom_emoji import ReactionTypeCustomEmoji
 from .reaction_type_emoji import ReactionTypeEmoji
 from .reaction_type_paid import ReactionTypePaid
 
-ReactionTypeUnion: TypeAlias = ReactionTypeEmoji | ReactionTypeCustomEmoji | ReactionTypePaid
+ReactionTypeUnion: TypeAlias = Annotated[
+    ReactionTypeEmoji | ReactionTypeCustomEmoji | ReactionTypePaid, Field(discriminator="type")
+]

--- a/aiogram/types/revenue_withdrawal_state_union.py
+++ b/aiogram/types/revenue_withdrawal_state_union.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .revenue_withdrawal_state_failed import RevenueWithdrawalStateFailed
 from .revenue_withdrawal_state_pending import RevenueWithdrawalStatePending
 from .revenue_withdrawal_state_succeeded import RevenueWithdrawalStateSucceeded
 
-RevenueWithdrawalStateUnion: TypeAlias = (
-    RevenueWithdrawalStatePending | RevenueWithdrawalStateSucceeded | RevenueWithdrawalStateFailed
-)
+RevenueWithdrawalStateUnion: TypeAlias = Annotated[
+    RevenueWithdrawalStatePending | RevenueWithdrawalStateSucceeded | RevenueWithdrawalStateFailed,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/rich_block_union.py
+++ b/aiogram/types/rich_block_union.py
@@ -1,4 +1,6 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .rich_block_anchor import RichBlockAnchor
 from .rich_block_animation import RichBlockAnimation
@@ -22,7 +24,7 @@ from .rich_block_thinking import RichBlockThinking
 from .rich_block_video import RichBlockVideo
 from .rich_block_voice_note import RichBlockVoiceNote
 
-RichBlockUnion: TypeAlias = (
+RichBlockUnion: TypeAlias = Annotated[
     RichBlockParagraph
     | RichBlockSectionHeading
     | RichBlockPreformatted
@@ -43,5 +45,6 @@ RichBlockUnion: TypeAlias = (
     | RichBlockPhoto
     | RichBlockVideo
     | RichBlockVoiceNote
-    | RichBlockThinking
-)
+    | RichBlockThinking,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/story_area_type_union.py
+++ b/aiogram/types/story_area_type_union.py
@@ -1,4 +1,6 @@
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .story_area_type_link import StoryAreaTypeLink
 from .story_area_type_location import StoryAreaTypeLocation
@@ -6,10 +8,11 @@ from .story_area_type_suggested_reaction import StoryAreaTypeSuggestedReaction
 from .story_area_type_unique_gift import StoryAreaTypeUniqueGift
 from .story_area_type_weather import StoryAreaTypeWeather
 
-StoryAreaTypeUnion: TypeAlias = (
+StoryAreaTypeUnion: TypeAlias = Annotated[
     StoryAreaTypeLocation
     | StoryAreaTypeSuggestedReaction
     | StoryAreaTypeLink
     | StoryAreaTypeWeather
-    | StoryAreaTypeUniqueGift
-)
+    | StoryAreaTypeUniqueGift,
+    Field(discriminator="type"),
+]

--- a/aiogram/types/transaction_partner_union.py
+++ b/aiogram/types/transaction_partner_union.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
+
+from pydantic import Field
 
 from .transaction_partner_affiliate_program import TransactionPartnerAffiliateProgram
 from .transaction_partner_chat import TransactionPartnerChat
@@ -10,12 +12,13 @@ from .transaction_partner_telegram_ads import TransactionPartnerTelegramAds
 from .transaction_partner_telegram_api import TransactionPartnerTelegramApi
 from .transaction_partner_user import TransactionPartnerUser
 
-TransactionPartnerUnion: TypeAlias = (
+TransactionPartnerUnion: TypeAlias = Annotated[
     TransactionPartnerUser
     | TransactionPartnerChat
     | TransactionPartnerAffiliateProgram
     | TransactionPartnerFragment
     | TransactionPartnerTelegramAds
     | TransactionPartnerTelegramApi
-    | TransactionPartnerOther
-)
+    | TransactionPartnerOther,
+    Field(discriminator="type"),
+]

--- a/tests/test_issues/test_1842_rich_block_union_discriminator.py
+++ b/tests/test_issues/test_1842_rich_block_union_discriminator.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #1842.
+
+Subtype unions whose members share a unique constant tag field (``type`` /
+``status`` / ``source``) are generated as Pydantic *discriminated* unions. This
+keeps validation linear: Pydantic jumps straight to the matching member instead
+of trying every option with smart-union backtracking, which is exponential for
+nested structures such as ``RichBlockUnion`` (``blockquote`` inside
+``blockquote`` ...).
+
+These tests guard two things against future Pydantic updates:
+
+* the discrimination is actually in effect (deterministic, timing-independent);
+* deeply nested validation stays fast (does not regress to exponential).
+"""
+
+import signal
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from aiogram.methods import AnswerWebAppQuery, EditMessageMedia
+from aiogram.types import (
+    InputMediaPhoto,
+    RichBlockBlockQuotation,
+    RichBlockParagraph,
+    RichMessage,
+)
+
+
+def _nested_blockquote(depth: int) -> dict:
+    """Build ``depth`` nested ``blockquote`` blocks with a paragraph at the leaf."""
+    node: dict = {"type": "blockquote", "blocks": [{"type": "paragraph", "text": "leaf"}]}
+    for _ in range(depth):
+        node = {"type": "blockquote", "blocks": [node]}
+    return node
+
+
+class TestRichBlockUnionIsDiscriminated:
+    def test_invalid_block_type_raises_discriminated_union_error(self):
+        # A discriminated union reports a single ``union_tag_invalid`` error at
+        # the block location. A non-discriminated (smart) union would instead
+        # emit one error per member, with much deeper/locations -- so this both
+        # proves discrimination is in effect and pins the user-facing error.
+        with pytest.raises(ValidationError) as exc_info:
+            RichMessage.model_validate({"blocks": [{"type": "definitely_not_a_block"}]})
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["type"] == "union_tag_invalid"
+        assert errors[0]["loc"] == ("blocks", 0)
+
+    def test_nested_blocks_resolve_to_concrete_types(self):
+        message = RichMessage.model_validate({"blocks": [_nested_blockquote(depth=4)]})
+
+        node = message.blocks[0]
+        for _ in range(5):  # 1 outer + 4 nested blockquotes
+            assert isinstance(node, RichBlockBlockQuotation)
+            node = node.blocks[0]
+        assert isinstance(node, RichBlockParagraph)
+        assert node.text == "leaf"
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "SIGALRM"),
+    reason="performance guard relies on SIGALRM (POSIX only)",
+)
+def test_nested_rich_block_validation_is_not_exponential():
+    # Correct (discriminated) validation is effectively instant even very deep.
+    # If this regresses to smart-union backtracking, depth 30 is ~4**30 attempts
+    # and would not finish, so the alarm aborts and fails the test instead of
+    # hanging the suite.
+    payload = {"blocks": [_nested_blockquote(depth=30)]}
+
+    def _abort(signum, frame):
+        raise TimeoutError
+
+    previous_handler = signal.signal(signal.SIGALRM, _abort)
+    try:
+        signal.setitimer(signal.ITIMER_REAL, 5.0)
+        start = time.perf_counter()
+        RichMessage.model_validate(payload)
+        elapsed = time.perf_counter() - start
+    except TimeoutError:
+        pytest.fail(
+            "Validating a depth-30 nested RichBlock exceeded 5s -- "
+            "RichBlockUnion likely regressed to a non-discriminated (exponential) union."
+        )
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+    assert elapsed < 1.0
+
+
+class TestMethodFieldDiscriminatedUnion:
+    def test_input_media_union_field_selects_member_by_tag(self):
+        method = EditMessageMedia.model_validate(
+            {"media": {"type": "photo", "media": "https://example.org/photo.jpg"}}
+        )
+        assert isinstance(method.media, InputMediaPhoto)
+
+    def test_input_media_union_field_rejects_unknown_tag(self):
+        with pytest.raises(ValidationError) as exc_info:
+            EditMessageMedia.model_validate({"media": {"type": "nope", "media": "x"}})
+
+        errors = exc_info.value.errors()
+        assert errors[0]["type"] == "union_tag_invalid"
+
+    def test_inline_query_result_union_field_is_not_discriminated(self):
+        # InlineQueryResultUnion declares ``type`` in the generator config, but
+        # cached/non-cached members share tag values (e.g. both photo variants
+        # use ``type="photo"``), so it must stay a plain smart union. A field
+        # forcing a discriminator here would crash Pydantic at schema build time.
+        method = AnswerWebAppQuery.model_validate(
+            {
+                "web_app_query_id": "q",
+                "result": {
+                    "type": "article",
+                    "id": "1",
+                    "title": "t",
+                    "input_message_content": {"message_text": "x"},
+                },
+            }
+        )
+        assert type(method.result).__name__ == "InlineQueryResultArticle"


### PR DESCRIPTION
# Description

Fixed severe (exponential) slowdown when validating nested :class:`aiogram.types.rich_block.RichBlock`
structures (e.g. nested ``blockquote``/``collage``/``details`` blocks).
Subtype unions whose members share a unique constant tag field (``RichBlockUnion``, ``ReactionTypeUnion``,
``ChatMemberUnion``, ``MessageOriginUnion`` and others) are now generated as Pydantic *discriminated* unions
keyed on that field (``type``/``status``/``source``), so the correct member is selected directly instead of
being found via smart-union backtracking.

Fixes #1842