### PR TITLE
docs: dispatcher.get.get_context is a sync function

### DIFF
--- a/CHANGES/1854.doc.rst
+++ b/CHANGES/1854.doc.rst
@@ -1,0 +1,1 @@
+Remove await from `dispatcher.fsm.get_context` in "Changing state for another user" doc 

--- a/docs/dispatcher/finite_state_machine/index.rst
+++ b/docs/dispatcher/finite_state_machine/index.rst
@@ -102,7 +102,7 @@ To do this, you can use the ``get_context`` method of the FSM middleware through
     @example_router.message(Command("example"))
     async def command_example(message: Message, dispatcher: Dispatcher, bot: Bot):
         user_id = ...  # Get the user ID in the way that you need
-        state = await dispatcher.fsm.get_context(
+        state = dispatcher.fsm.get_context(
             bot=bot,
             chat_id=user_id,
             user_id=user_id,


### PR DESCRIPTION
Removing await from `dispatcher.fsm.get_context` in docs

Call from tests: 
https://github.com/aiogram/aiogram/blob/d53b604f0ead4a5d3dd4db39c01b9acff5f8aad6/tests/test_issues/test_1743_channel_post_with_scenes.py#L92-L96


And the function definition itself:
https://github.com/aiogram/aiogram/blob/d53b604f0ead4a5d3dd4db39c01b9acff5f8aad6/aiogram/fsm/middleware.py#L94-L113
