### PR TITLE
Fix missing dispatcher contextual argument on webhook feed path

### DIFF
--- a/CHANGES/1855.bugfix.rst
+++ b/CHANGES/1855.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed missing ``dispatcher`` contextual argument for filters, handlers and middlewares
+when updates are fed via webhook (:class:`aiogram.webhook.aiohttp_server.SimpleRequestHandler`,
+:class:`aiogram.webhook.aiohttp_server.TokenBasedRequestHandler`) or direct
+:meth:`aiogram.dispatcher.dispatcher.Dispatcher.feed_update` calls.
+Previously it was only injected by ``start_polling``, so a callback declaring a required
+``dispatcher`` parameter worked in polling mode but failed with ``TypeError`` in webhook mode,
+aborting event propagation for sibling handlers as well.

--- a/aiogram/dispatcher/dispatcher.py
+++ b/aiogram/dispatcher/dispatcher.py
@@ -165,6 +165,7 @@ class Dispatcher(Router):
                 self.update.trigger,
                 update,
                 {
+                    "dispatcher": self,
                     **self.workflow_data,
                     **kwargs,
                     "bot": bot,

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -163,6 +163,57 @@ class TestDispatcher:
         )
         assert result == "test"
 
+    async def test_feed_update_injects_dispatcher(self, dispatcher: Dispatcher, bot: MockedBot):
+        seen = {}
+
+        async def dispatcher_filter(message: Message, dispatcher: Dispatcher) -> bool:
+            seen["filter"] = dispatcher
+            return True
+
+        @dispatcher.message(dispatcher_filter)
+        async def my_handler(message: Message, dispatcher: Dispatcher):
+            seen["handler"] = dispatcher
+            return message.text
+
+        result = await dispatcher.feed_update(bot=bot, update=UPDATE)
+        assert result == "test"
+        assert seen["filter"] is dispatcher
+        assert seen["handler"] is dispatcher
+
+    async def test_feed_update_dispatcher_kwarg_override(
+        self, dispatcher: Dispatcher, bot: MockedBot
+    ):
+        sentinel = object()
+
+        @dispatcher.message()
+        async def my_handler(message: Message, dispatcher):
+            return dispatcher
+
+        result = await dispatcher.feed_update(bot=bot, update=UPDATE, dispatcher=sentinel)
+        assert result is sentinel
+
+    async def test_feed_update_dispatcher_workflow_data_override(self, bot: MockedBot):
+        sentinel = object()
+        dp = Dispatcher(dispatcher=sentinel)
+
+        @dp.message()
+        async def my_handler(message: Message, dispatcher):
+            return dispatcher
+
+        result = await dp.feed_update(bot=bot, update=UPDATE)
+        assert result is sentinel
+
+    async def test_feed_update_polling_parity(self, dispatcher: Dispatcher, bot: MockedBot):
+        @dispatcher.message()
+        async def my_handler(message: Message, dispatcher):
+            return dispatcher
+
+        # same kwargs as _run_polling passes (dispatcher.py workflow_data)
+        result = await dispatcher.feed_update(
+            bot=bot, update=UPDATE, dispatcher=dispatcher, bots=[bot]
+        )
+        assert result is dispatcher
+
     async def test_listen_updates(self, bot: MockedBot):
         dispatcher = Dispatcher()
         bot.add_result_for(

--- a/tests/test_webhook/test_aiohttp_server.py
+++ b/tests/test_webhook/test_aiohttp_server.py
@@ -10,9 +10,11 @@ from aiohttp import MultipartReader, web
 from aiohttp.test_utils import TestClient
 from aiohttp.web_app import Application
 
-from aiogram import Dispatcher, F
+from aiogram import Bot, Dispatcher, F
+from aiogram.filters import Filter
+from aiogram.fsm.storage.base import StorageKey
 from aiogram.methods import GetMe, Request
-from aiogram.types import BufferedInputFile, Message, User
+from aiogram.types import BufferedInputFile, InlineQuery, Message, User
 from aiogram.webhook.aiohttp_server import (
     SimpleRequestHandler,
     TokenBasedRequestHandler,
@@ -205,6 +207,48 @@ class TestSimpleRequestHandler:
         client: TestClient = await aiohttp_client(app)
         resp = await self.make_reqest(client=client)
         assert resp.status == 401
+
+    @pytest.mark.parametrize("handle_in_background", [True, False])
+    async def test_filter_requiring_dispatcher(
+        self, bot: MockedBot, aiohttp_client, handle_in_background: bool
+    ):
+        """Regression: webhook-fed updates must expose `dispatcher` to filters/handlers
+        the same way polling does (FSM-state filter shape from the original report)."""
+        app = Application()
+        dp = Dispatcher()
+        handled = Event()
+
+        class StateFilter(Filter):
+            async def __call__(self, query: InlineQuery, bot: Bot, dispatcher: Dispatcher) -> bool:
+                key = StorageKey(bot_id=bot.id, chat_id=42, user_id=42)
+                return await dispatcher.storage.get_state(key) == "playing"
+
+        @dp.inline_query(StateFilter())
+        async def handle_inline_query(query: InlineQuery):
+            handled.set()
+
+        await dp.storage.set_state(StorageKey(bot_id=bot.id, chat_id=42, user_id=42), "playing")
+
+        handler = SimpleRequestHandler(
+            dispatcher=dp, bot=bot, handle_in_background=handle_in_background
+        )
+        handler.register(app, path="/webhook")
+        client: TestClient = await aiohttp_client(app)
+
+        resp = await client.post(
+            "/webhook",
+            json={
+                "update_id": 1,
+                "inline_query": {
+                    "id": "query",
+                    "from": {"id": 42, "first_name": "Test", "is_bot": False},
+                    "query": "42:: ",
+                    "offset": "",
+                },
+            },
+        )
+        assert resp.status == 200
+        await asyncio.wait_for(handled.wait(), timeout=3)
 
 
 class TestTokenBasedRequestHandler:


### PR DESCRIPTION
# Description

Filters, handlers and middlewares that declare a `dispatcher: Dispatcher` parameter received it only under `start_polling`, which injects `"dispatcher": self` into the workflow kwargs. The webhook request handlers (`SimpleRequestHandler` / `TokenBasedRequestHandler`) feed updates with only their constructor extras, so on the webhook path such a callback failed with `TypeError: ... missing 1 required positional argument: 'dispatcher'`.

The failure was especially hard to diagnose:

- the `TypeError` is raised during filter evaluation, so it aborts propagation of the **whole event** — sibling handlers registered after the failing one never run either;
- with `handle_in_background=True` (the default) the exception disappears into a detached task (`Task exception was never retrieved`) and the update is silently dropped;
- with `handle_in_background=False` the request fails with HTTP 500 and Telegram keeps re-delivering the update.

`Dispatcher.feed_update` now injects `"dispatcher": self` as the weakest entry of the context dict (before `**self.workflow_data`, `**kwargs`, `"bot": bot`), so every feed path — polling, webhook handlers, `feed_raw_update`, `feed_webhook_update` and direct `feed_update` calls — provides the same contextual data. Polling behavior is unchanged (it already passed the same object via kwargs, which keep precedence), and explicit overrides via workflow data or kwargs still win.

Fixes #1855

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New unit tests: filter + handler receive the `Dispatcher` instance via plain `feed_update`; explicit kwarg override and workflow-data override keep precedence; polling-parity kwargs (`dispatcher=dp, bots=[bot]`) select the same handler (`tests/test_dispatcher/test_dispatcher.py`)
- [x] New regression test: FSM-state filter requiring `dispatcher` on `inline_query` fed over HTTP through `SimpleRequestHandler`, parametrized over both `handle_in_background` modes (`tests/test_webhook/test_aiohttp_server.py`)
- [x] Full suite: 1865 passed, 52 skipped, coverage 100% (both touched files at 100%)
- [x] `ruff check --preview` / `ruff format --check` / `mypy aiogram` all clean
- [x] Verified against the original community MRE (state-dependent inline-query filter): before the fix the filtered handler fired only under polling; after the fix it fires identically under polling and both webhook modes

**Test Configuration**:
* Operating System: macOS 26.5.1
* Python version: 3.13.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
