### PR TITLE
Fix live photo identification

### DIFF
--- a/CHANGES/1841.bugfix.rst
+++ b/CHANGES/1841.bugfix.rst
@@ -1,0 +1,1 @@
+Fix invalid `content_type` property identification for a live photo message

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         SendDocument,
         SendGame,
         SendInvoice,
+        SendLivePhoto,
         SendLocation,
         SendMediaGroup,
         SendMessage,
@@ -712,6 +713,8 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.DOCUMENT
         if self.game:
             return ContentType.GAME
+        if self.live_photo:
+            return ContentType.LIVE_PHOTO
         if self.photo:
             return ContentType.PHOTO
         if self.sticker:
@@ -850,8 +853,6 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.POLL_OPTION_ADDED
         if self.poll_option_deleted:
             return ContentType.POLL_OPTION_DELETED
-        if self.live_photo:
-            return ContentType.LIVE_PHOTO
         if self.rich_message:
             return ContentType.RICH_MESSAGE
         if self.community_chat_added:
@@ -3930,6 +3931,7 @@ class Message(MaybeInaccessibleMessage):
         | SendDocument
         | SendLocation
         | SendMessage
+        | SendLivePhoto
         | SendPhoto
         | SendPoll
         | SendDice
@@ -3974,6 +3976,7 @@ class Message(MaybeInaccessibleMessage):
             SendDocument,
             SendLocation,
             SendMessage,
+            SendLivePhoto,
             SendPhoto,
             SendPoll,
             SendSticker,
@@ -3998,118 +4001,127 @@ class Message(MaybeInaccessibleMessage):
             "message_effect_id": message_effect_id or self.effect_id,
         }
 
-        if self.text:
-            return SendMessage(
-                text=self.text,
-                entities=self.entities,
-                link_preview_options=link_preview_options or self.link_preview_options,
-                **kwargs,
-            ).as_(self._bot)
-        if self.audio:
-            return SendAudio(
-                audio=self.audio.file_id,
-                caption=self.caption,
-                title=self.audio.title,
-                performer=self.audio.performer,
-                duration=self.audio.duration,
-                caption_entities=self.caption_entities,
-                **kwargs,
-            ).as_(self._bot)
-        if self.animation:
-            return SendAnimation(
-                animation=self.animation.file_id,
-                caption=self.caption,
-                caption_entities=self.caption_entities,
-                **kwargs,
-            ).as_(self._bot)
-        if self.document:
-            return SendDocument(
-                document=self.document.file_id,
-                caption=self.caption,
-                caption_entities=self.caption_entities,
-                **kwargs,
-            ).as_(self._bot)
-        if self.photo:
-            return SendPhoto(
-                photo=self.photo[-1].file_id,
-                caption=self.caption,
-                caption_entities=self.caption_entities,
-                **kwargs,
-            ).as_(self._bot)
-        if self.sticker:
-            return SendSticker(
-                sticker=self.sticker.file_id,
-                **kwargs,
-            ).as_(self._bot)
-        if self.video:
-            return SendVideo(
-                video=self.video.file_id,
-                caption=self.caption,
-                caption_entities=self.caption_entities,
-                **kwargs,
-            ).as_(self._bot)
-        if self.video_note:
-            return SendVideoNote(
-                video_note=self.video_note.file_id,
-                **kwargs,
-            ).as_(self._bot)
-        if self.voice:
-            return SendVoice(
-                voice=self.voice.file_id,
-                **kwargs,
-            ).as_(self._bot)
-        if self.contact:
-            return SendContact(
-                phone_number=self.contact.phone_number,
-                first_name=self.contact.first_name,
-                last_name=self.contact.last_name,
-                vcard=self.contact.vcard,
-                **kwargs,
-            ).as_(self._bot)
-        if self.venue:
-            return SendVenue(
-                latitude=self.venue.location.latitude,
-                longitude=self.venue.location.longitude,
-                title=self.venue.title,
-                address=self.venue.address,
-                foursquare_id=self.venue.foursquare_id,
-                foursquare_type=self.venue.foursquare_type,
-                **kwargs,
-            ).as_(self._bot)
-        if self.location:
-            return SendLocation(
-                latitude=self.location.latitude,
-                longitude=self.location.longitude,
-                **kwargs,
-            ).as_(self._bot)
-        if self.poll:
-            from .input_poll_option import InputPollOption
+        match (self.content_type):
+            case ContentType.TEXT:
+                return SendMessage(
+                    text=self.text,
+                    entities=self.entities,
+                    link_preview_options=link_preview_options or self.link_preview_options,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.AUDIO:
+                return SendAudio(
+                    audio=self.audio.file_id,
+                    caption=self.caption,
+                    title=self.audio.title,
+                    performer=self.audio.performer,
+                    duration=self.audio.duration,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.ANIMATION:
+                return SendAnimation(
+                    animation=self.animation.file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.DOCUMENT:
+                return SendDocument(
+                    document=self.document.file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.PHOTO:
+                return SendPhoto(
+                    photo=self.photo[-1].file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.LIVE_PHOTO:
+                return SendLivePhoto(
+                    photo=self.photo[-1].file_id,
+                    live_photo=self.live_photo.file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.STICKER:
+                return SendSticker(
+                    sticker=self.sticker.file_id,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.VIDEO:
+                return SendVideo(
+                    video=self.video.file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.VIDEO_NOTE:
+                return SendVideoNote(
+                    video_note=self.video_note.file_id,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.VOICE:
+                return SendVoice(
+                    voice=self.voice.file_id,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.CONTACT:
+                return SendContact(
+                    phone_number=self.contact.phone_number,
+                    first_name=self.contact.first_name,
+                    last_name=self.contact.last_name,
+                    vcard=self.contact.vcard,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.VENUE:
+                return SendVenue(
+                    latitude=self.venue.location.latitude,
+                    longitude=self.venue.location.longitude,
+                    title=self.venue.title,
+                    address=self.venue.address,
+                    foursquare_id=self.venue.foursquare_id,
+                    foursquare_type=self.venue.foursquare_type,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.LOCATION:
+                return SendLocation(
+                    latitude=self.location.latitude,
+                    longitude=self.location.longitude,
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.POLL:
+                from .input_poll_option import InputPollOption
 
-            return SendPoll(
-                question=self.poll.question,
-                options=[
-                    InputPollOption(
-                        text=option.text,
-                        voter_count=option.voter_count,
-                        text_entities=option.text_entities,
-                        text_parse_mode=None,
-                    )
-                    for option in self.poll.options
-                ],
-                **kwargs,
-            ).as_(self._bot)
-        if self.dice:  # Dice value can't be controlled
-            return SendDice(
-                **kwargs,
-            ).as_(self._bot)
-        if self.story:
-            return ForwardMessage(
-                from_chat_id=self.chat.id,
-                message_id=self.message_id,
-                **kwargs,
-            ).as_(self._bot)
-
-        raise TypeError("This type of message can't be copied.")
+                return SendPoll(
+                    question=self.poll.question,
+                    options=[
+                        InputPollOption(
+                            text=option.text,
+                            voter_count=option.voter_count,
+                            text_entities=option.text_entities,
+                            text_parse_mode=None,
+                        )
+                        for option in self.poll.options
+                    ],
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.DICE: # Dice value can't be controlled
+                return SendDice(
+                    **kwargs,
+                ).as_(self._bot)
+            case ContentType.STORY:
+                return ForwardMessage(
+                    from_chat_id=self.chat.id,
+                    message_id=self.message_id,
+                    **kwargs,
+                ).as_(self._bot)
+            case _:
+                raise TypeError("This type of message can't be copied.")
 
     def copy_to(
         self,

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -27,6 +27,7 @@ from aiogram.methods import (
     SendDocument,
     SendGame,
     SendInvoice,
+    SendLivePhoto,
     SendLocation,
     SendMediaGroup,
     SendMessage,
@@ -911,6 +912,7 @@ TEST_MESSAGE_POLL_OPTION_DELETED = Message(
 TEST_MESSAGE_LIVE_PHOTO = Message(
     message_id=42,
     date=datetime.datetime.now(),
+    photo=[PhotoSize(file_id="file id", file_unique_id="file id", width=42, height=42)],
     live_photo=LivePhoto(
         file_id="file id",
         file_unique_id="file unique id",
@@ -1122,7 +1124,7 @@ MESSAGES_AND_COPY_METHODS = [
     [TEST_MESSAGE_MANAGED_BOT_CREATED, None],
     [TEST_MESSAGE_POLL_OPTION_ADDED, None],
     [TEST_MESSAGE_POLL_OPTION_DELETED, None],
-    [TEST_MESSAGE_LIVE_PHOTO, None],
+    [TEST_MESSAGE_LIVE_PHOTO, SendLivePhoto],
     [TEST_MESSAGE_RICH_MESSAGE, None],
     [TEST_MESSAGE_COMMUNITY_CHAT_ADDED, None],
     [TEST_MESSAGE_COMMUNITY_CHAT_REMOVED, None],


### PR DESCRIPTION
# Description

* fix: invalid `content_type` property identification for a live photo message.
* refactor: convert `if` blocks to `match` statement on `content_type` property.

Fixes #1841 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
