### PR TITLE
Detect async callable objects as awaitable handlers

### DIFF
--- a/CHANGES/1721.bugfix.rst
+++ b/CHANGES/1721.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed detection of asynchronous callable objects: an instance whose :code:`__call__` is a coroutine function is now recognized as awaitable, so such handlers and filters are awaited instead of returning a never-awaited coroutine.

--- a/CHANGES/1858.bugfix.rst
+++ b/CHANGES/1858.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed detection of async callable objects as awaitable handlers: an instance whose :code:`__call__` is a coroutine function is now recognized as awaitable (via :code:`type(callback).__call__`), so such handlers and filters are awaited instead of being dispatched to a thread and returning a never-awaited coroutine.

--- a/aiogram/dispatcher/event/handler.py
+++ b/aiogram/dispatcher/event/handler.py
@@ -33,7 +33,12 @@ class CallableObject:
 
     def __post_init__(self) -> None:
         callback = inspect.unwrap(self.callback)
-        self.awaitable = inspect.isawaitable(callback) or inspect.iscoroutinefunction(callback)
+        self.awaitable = (
+            inspect.isawaitable(callback)
+            or inspect.iscoroutinefunction(callback)
+            # A callable object is async when its `__call__` is a coroutine function
+            or (callable(callback) and inspect.iscoroutinefunction(type(callback).__call__))
+        )
 
         kwargs: dict[str, Any] = {}
         if sys.version_info >= (3, 14):

--- a/tests/test_dispatcher/test_event/test_handler.py
+++ b/tests/test_dispatcher/test_event/test_handler.py
@@ -39,12 +39,27 @@ class SyncCallable:
         return locals()
 
 
+class AsyncCallable:
+    async def __call__(self, foo, bar, baz):
+        return locals()
+
+
 class TestCallableObject:
-    @pytest.mark.parametrize("callback", [callback2, TestFilter()])
+    @pytest.mark.parametrize("callback", [callback2, TestFilter(), AsyncCallable()])
     def test_init_awaitable(self, callback):
         obj = CallableObject(callback)
         assert obj.awaitable
         assert obj.callback == callback
+
+    @pytest.mark.asyncio
+    async def test_call_async_callable_object(self):
+        obj = CallableObject(AsyncCallable())
+        assert await obj.call(foo=1, bar=2, baz=3) == {
+            "self": obj.callback,
+            "foo": 1,
+            "bar": 2,
+            "baz": 3,
+        }
 
     @pytest.mark.parametrize("callback", [callback1, SyncCallable()])
     def test_init_not_awaitable(self, callback):


### PR DESCRIPTION
# Description

`CallableObject.__post_init__` decided awaitability with `inspect.iscoroutinefunction(callback)`, which is `False` for an *instance* of a class whose `__call__` is a coroutine function. Such handlers/filters were therefore dispatched through `asyncio.to_thread()`, so calling them just returned an un-awaited coroutine ("coroutine was never awaited") and the handler body never ran. Awaitability now also considers `type(callback).__call__`, matching how `Filter` subclasses were already special-cased.

Note: the issue also mentions lambdas that *return* a coroutine. That is a plain sync function whose return value happens to be awaitable, which cannot be detected by introspection, so this PR intentionally only covers async callable objects.

Fixes #1721

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New `test_call_async_callable_object` and the extended `test_init_awaitable` parametrization fail on `dev-3.x` (never-awaited coroutine returned) and pass with the fix.
- [x] `pytest tests/test_dispatcher` — 133 passed, 1 skipped.

**Test Configuration**:
* Operating System: macOS
* Python version: 3.14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
