### PR TITLE
Fix Markdown expandable_blockquote missing the expandability mark

### DIFF
--- a/CHANGES/1862.bugfix.rst
+++ b/CHANGES/1862.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :code:`MarkdownDecoration.expandable_blockquote` not emitting the ``**>`` expandability mark, so it produced invalid MarkdownV2 (a lone trailing ``||``) that Telegram rejected instead of a valid expandable block quotation.

--- a/aiogram/utils/text_decorations.py
+++ b/aiogram/utils/text_decorations.py
@@ -330,7 +330,13 @@ class MarkdownDecoration(TextDecoration):
         return "\n".join(f">{line}" for line in value.splitlines())
 
     def expandable_blockquote(self, value: str) -> str:
-        return "\n".join(f">{line}" for line in value.splitlines()) + "||"
+        return (
+            "\n".join(
+                f"**>{line}" if index == 0 else f">{line}"
+                for index, line in enumerate(value.splitlines())
+            )
+            + "||"
+        )
 
     def date_time(
         self,

--- a/tests/test_utils/test_text_decorations.py
+++ b/tests/test_utils/test_text_decorations.py
@@ -135,7 +135,7 @@ class TestTextDecoration:
             [
                 markdown_decoration,
                 MessageEntity(type="expandable_blockquote", offset=0, length=5),
-                ">test||",
+                "**>test||",
             ],
             [
                 markdown_decoration,
@@ -164,6 +164,13 @@ class TestTextDecoration:
         self, decorator: TextDecoration, entity: MessageEntity, result: str
     ):
         assert decorator.apply_entity(entity, "test") == result
+
+    def test_markdown_expandable_blockquote_multiline(self):
+        # Only the first line carries the ``**>`` expandability mark; the
+        # remaining lines use ``>`` like a normal blockquote, and the closing
+        # ``||`` follows the last line.
+        result = markdown_decoration.expandable_blockquote("line1\nline2\nline3")
+        assert result == "**>line1\n>line2\n>line3||"
 
     @pytest.mark.parametrize(
         "decorator,date_time_format,expected",


### PR DESCRIPTION
### Problem

`MarkdownDecoration.expandable_blockquote` produces the same output as a plain blockquote with a bare `||` appended — it never emits the `**>` that MarkdownV2 uses to mark a block quotation as *expandable*:

```python
from aiogram.utils.text_decorations import markdown_decoration as md

md.expandable_blockquote("secret")   # -> '>secret||'
md.blockquote("secret")              # -> '>secret'
```

Per the [MarkdownV2 style](https://core.telegram.org/bots/api#markdownv2-style), an expandable block quotation must prefix the **first** line with `**>` and end the last line with `||`. Without the `**>`, a lone trailing `||` is not the expandability mark — Telegram reads it as the start of a spoiler (`||...||`) that is never closed, so sending the result with `parse_mode="MarkdownV2"` fails with `can't parse entities: Can't find end of Spoiler entity...`. At best, the expandable property is silently lost.

This also affects `aiogram.utils.formatting.Text(...).as_markdown()`, which routes an `ExpandableBlockquote` node through this method.

### Cause

```python
def expandable_blockquote(self, value: str) -> str:
    return "\n".join(f">{line}" for line in value.splitlines()) + "||"
```

The HTML sibling `HtmlDecoration.expandable_blockquote` correctly preserves expandability (`<blockquote expandable>`); the Markdown one drops it.

### Fix

Prefix the first line with `**>` (keeping `>` for the remaining lines):

```python
def expandable_blockquote(self, value: str) -> str:
    return (
        "\n".join(
            f"**>{line}" if index == 0 else f">{line}"
            for index, line in enumerate(value.splitlines())
        )
        + "||"
    )
```

Now `expandable_blockquote("secret")` → `**>secret||` and `expandable_blockquote("l1\nl2")` → `**>l1\n>l2||`.

### Tests

Updated the existing `expandable_blockquote` case in `test_text_decorations.py` (which asserted the old `>test||`) to `**>test||`, and added a multi-line test asserting only the first line carries the `**>` mark. Both fail on `dev-3.x` and pass with the fix; the rest of the module is unaffected.