### PR TITLE
Preserve BotCommand metadata in Command filter, add Router.resolve_bot_commands()

### DIFF
--- a/CHANGES/1866.feature.rst
+++ b/CHANGES/1866.feature.rst
@@ -8,3 +8,9 @@ for bootstrapping :code:`bot.set_my_commands()` without maintaining a separate m
 command list. Mirrors :meth:`~aiogram.dispatcher.router.Router.resolve_used_update_types`,
 including the ``skip_events`` opt-out and collecting from all observers by default (not just
 ``message``).
+
+Added :class:`aiogram.filters.command.BotCommandMeta` — a :class:`~aiogram.types.bot_command.BotCommand`
+subclass that additionally carries a ``scope``/``language_code``, for grouping commands collected via
+``resolve_bot_commands()`` by scope/locale before calling ``bot.set_my_commands()``. Not meant to be
+passed directly to ``set_my_commands()`` — build a plain :class:`~aiogram.types.bot_command.BotCommand`
+from ``command``/``description`` first.

--- a/CHANGES/1866.feature.rst
+++ b/CHANGES/1866.feature.rst
@@ -1,0 +1,10 @@
+The :class:`aiogram.filters.command.Command` filter no longer discards the
+:class:`aiogram.types.bot_command.BotCommand` objects passed to it — they're now kept in a new
+:code:`bot_commands` attribute.
+
+Added :meth:`aiogram.dispatcher.router.Router.resolve_bot_commands` to collect these
+:class:`~aiogram.types.bot_command.BotCommand` objects from a router and all of its sub-routers,
+for bootstrapping :code:`bot.set_my_commands()` without maintaining a separate manually-synced
+command list. Mirrors :meth:`~aiogram.dispatcher.router.Router.resolve_used_update_types`,
+including the ``skip_events`` opt-out and collecting from all observers by default (not just
+``message``).

--- a/aiogram/dispatcher/router.py
+++ b/aiogram/dispatcher/router.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from typing import TYPE_CHECKING, Any, Final
+
+from aiogram.filters.command import Command
+from aiogram.types.bot_command import BotCommand
 
 from .event.bases import REJECTED, UNHANDLED
 from .event.event import EventObserver
@@ -150,6 +153,34 @@ class Router:
                     handlers_in_use.add(update_name)
 
         return sorted(handlers_in_use)
+
+    def _iter_command_filters(self, observer: TelegramEventObserver) -> Iterator[Command]:
+        """Yield :class:`Command` filter instances attached to the observer's handlers."""
+        for handler in observer.handlers:
+            for filt in handler.filters or ():
+                if isinstance(filt.callback, Command):
+                    yield filt.callback
+
+    def resolve_bot_commands(self, skip_events: set[str] | None = None) -> tuple[BotCommand, ...]:
+        """
+        Resolve :class:`BotCommand` objects passed to :class:`Command` filters
+        across this router and all of its sub-routers.
+
+        Is useful for bootstrapping :code:`bot.set_my_commands()` without keeping
+        a manually maintained list of commands in sync with the registered handlers.
+
+        :param skip_events: skip handlers registered on the specified event names
+        :return: flat tuple of collected bot commands, in registration order
+        """
+        skip_events = {*(skip_events or ()), *INTERNAL_UPDATE_TYPES}
+        bot_commands: list[BotCommand] = []
+        for router in self.chain_tail:
+            for update_name, observer in router.observers.items():
+                if update_name in skip_events:
+                    continue
+                for command_filter in self._iter_command_filters(observer):
+                    bot_commands.extend(command_filter.bot_commands)
+        return tuple(bot_commands)
 
     async def propagate_event(self, update_type: str, event: TelegramObject, **kwargs: Any) -> Any:
         kwargs.update(event_router=self)

--- a/aiogram/filters/command.py
+++ b/aiogram/filters/command.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from aiogram.filters.base import Filter
 from aiogram.types import BotCommand, Message
+from aiogram.types.bot_command_scope import BotCommandScope
 from aiogram.utils.deep_linking import decode_payload
 
 if TYPE_CHECKING:
@@ -22,15 +23,31 @@ class CommandException(Exception):
     pass
 
 
+class BotCommandMeta(BotCommand):
+    """
+    A :class:`BotCommand` variant that additionally carries aiogram-side metadata
+    for bootstrapping :code:`bot.set_my_commands()` — a scope and a language code.
+
+    Not meant to be passed directly to :code:`set_my_commands()`: :code:`scope` and
+    :code:`language_code` are not fields of the Bot API :class:`BotCommand`. Build a plain
+    :class:`BotCommand` from :code:`command`/:code:`description` before calling the API.
+    """
+
+    scope: BotCommandScope | None = None
+    """Scope this command should be registered for"""
+    language_code: str | None = None
+    """Language code this command's description is localized for"""
+
+
 class Command(Filter):
     """
     This filter can be helpful for handling commands from the text messages.
 
     Works only with :class:`aiogram.types.message.Message` events which have the :code:`text`.
 
-    Any :class:`aiogram.types.bot_command.BotCommand` passed to the filter is kept as-is in
-    :code:`bot_commands`, so it can be collected later (e.g. via
-    :code:`Router.resolve_bot_commands()`) without losing its metadata.
+    Any :class:`aiogram.types.bot_command.BotCommand` (or :class:`BotCommandMeta`) passed
+    to the filter is kept as-is in :code:`bot_commands`, so it can be collected later
+    (e.g. via :code:`Router.resolve_bot_commands()`) without losing its metadata.
     """
 
     __slots__ = (

--- a/aiogram/filters/command.py
+++ b/aiogram/filters/command.py
@@ -27,9 +27,14 @@ class Command(Filter):
     This filter can be helpful for handling commands from the text messages.
 
     Works only with :class:`aiogram.types.message.Message` events which have the :code:`text`.
+
+    Any :class:`aiogram.types.bot_command.BotCommand` passed to the filter is kept as-is in
+    :code:`bot_commands`, so it can be collected later (e.g. via
+    :code:`Router.resolve_bot_commands()`) without losing its metadata.
     """
 
     __slots__ = (
+        "bot_commands",
         "commands",
         "ignore_case",
         "ignore_mention",
@@ -70,8 +75,10 @@ class Command(Filter):
             raise ValueError(msg)
 
         items = []
+        bot_commands = []
         for command in (*values, *commands):
             if isinstance(command, BotCommand):
+                bot_commands.append(command)
                 command = command.command
             if not isinstance(command, (str, re.Pattern)):
                 msg = (
@@ -87,6 +94,7 @@ class Command(Filter):
             msg = "At least one command should be specified"
             raise ValueError(msg)
 
+        self.bot_commands = tuple(bot_commands)
         self.commands = tuple(items)
         self.prefix = prefix
         self.ignore_case = ignore_case

--- a/docs/dispatcher/filters/command.rst
+++ b/docs/dispatcher/filters/command.rst
@@ -29,6 +29,17 @@ When filter is passed the :class:`aiogram.filters.command.CommandObject` will be
     :member-order: bysource
     :undoc-members: False
 
+:class:`aiogram.filters.command.BotCommandMeta` can be used instead of a plain
+:class:`~aiogram.types.bot_command.BotCommand` to additionally carry a scope and a language
+code, for grouping commands collected via :meth:`aiogram.dispatcher.router.Router.resolve_bot_commands`
+by scope/locale before calling :code:`bot.set_my_commands()`. It is not meant to be passed
+directly to :code:`set_my_commands()`.
+
+.. autoclass:: aiogram.filters.command.BotCommandMeta
+    :members:
+    :member-order: bysource
+    :undoc-members: False
+
 Allowed handlers
 ================
 

--- a/docs/dispatcher/filters/command.rst
+++ b/docs/dispatcher/filters/command.rst
@@ -10,6 +10,7 @@ Usage
 3. Match command by multiple variants: :code:`Command("item", re.compile(r"item_(\\d+)"))`
 4. Handle commands in public chats intended for other bots: :code:`Command("command", ignore_mention=True)`
 5. Use :class:`aiogram.types.bot_command.BotCommand` object as command reference :code:`Command(BotCommand(command="command", description="My awesome command")`
+6. Any :class:`aiogram.types.bot_command.BotCommand` passed to the filter is kept in :code:`Command.bot_commands`, and can be collected across a router tree via :meth:`aiogram.dispatcher.router.Router.resolve_bot_commands` for bootstrapping :code:`bot.set_my_commands()`
 
 .. warning::
 
@@ -35,3 +36,10 @@ Allowed update types for this filter:
 
 - `message`
 - `edited_message`
+- `channel_post`
+- `edited_channel_post`
+- `business_message`
+- `edited_business_message`
+
+Any observer that dispatches :class:`aiogram.types.message.Message` events works — the filter
+itself doesn't check which observer it's attached to.

--- a/docs/dispatcher/router.rst
+++ b/docs/dispatcher/router.rst
@@ -19,7 +19,7 @@ Usage:
 
 
 .. autoclass:: aiogram.dispatcher.router.Router
-    :members: __init__, include_router, include_routers, resolve_used_update_types
+    :members: __init__, include_router, include_routers, resolve_used_update_types, resolve_bot_commands
     :show-inheritance:
 
 

--- a/tests/test_dispatcher/test_dispatcher.py
+++ b/tests/test_dispatcher/test_dispatcher.py
@@ -15,8 +15,10 @@ from aiogram import Bot
 from aiogram.dispatcher.dispatcher import Dispatcher
 from aiogram.dispatcher.event.bases import UNHANDLED, SkipHandler
 from aiogram.dispatcher.router import Router
+from aiogram.filters.command import Command
 from aiogram.methods import GetMe, GetUpdates, SendMessage, TelegramMethod
 from aiogram.types import (
+    BotCommand,
     BotSubscriptionUpdated,
     BusinessConnection,
     BusinessMessagesDeleted,
@@ -1268,3 +1270,55 @@ class TestDispatcher:
         useful_updates5 = router2.resolve_used_update_types()
 
         assert sorted(useful_updates5) == sorted(["poll", "edited_message"])
+
+    def test_specify_bot_commands(self):
+        def simple_handler() -> None: ...
+
+        dispatcher = Dispatcher()
+        dispatcher_command = BotCommand(command="dispatcher", description="dispatcher")
+        dispatcher.message.register(simple_handler, Command(dispatcher_command))
+
+        router1 = Router()
+        router1_command = BotCommand(command="router1", description="router1")
+        router1.channel_post.register(simple_handler, Command(router1_command))
+
+        router2 = Router()
+        router2.message.register(simple_handler, Command("router2"))
+
+        router21 = Router()
+        shared_command = BotCommand(command="shared", description="shared")
+        router21.message.register(simple_handler, Command(shared_command))
+        router21.channel_post.register(simple_handler, Command(shared_command))
+
+        router3 = Router()
+        router3.message.register(simple_handler, Command(router1_command))
+
+        router4 = Router()
+        router4.message.register(simple_handler)
+
+        assert set(dispatcher.resolve_bot_commands()) == {dispatcher_command}
+        dispatcher.include_router(router1)
+
+        assert set(dispatcher.resolve_bot_commands()) == {dispatcher_command, router1_command}
+        assert set(dispatcher.resolve_bot_commands(skip_events={"channel_post"})) == {
+            dispatcher_command
+        }
+
+        dispatcher.include_router(router2)
+        assert set(dispatcher.resolve_bot_commands()) == {dispatcher_command, router1_command}
+
+        router2.include_router(router21)
+        assert set(dispatcher.resolve_bot_commands()) == {
+            dispatcher_command,
+            router1_command,
+            shared_command,
+        }
+        assert set(router2.resolve_bot_commands()) == {shared_command}
+        assert Counter(router2.resolve_bot_commands())[shared_command] == 2
+
+        dispatcher.include_router(router3)
+        useful_commands3 = dispatcher.resolve_bot_commands()
+        assert Counter(useful_commands3).get(router1_command) == 2
+
+        dispatcher.include_router(router4)
+        assert set(dispatcher.resolve_bot_commands()) == set(useful_commands3)

--- a/tests/test_filters/test_command.py
+++ b/tests/test_filters/test_command.py
@@ -5,8 +5,8 @@ import pytest
 
 from aiogram import F
 from aiogram.filters import Command, CommandObject
-from aiogram.filters.command import CommandStart
-from aiogram.types import BotCommand, Chat, Message, User
+from aiogram.filters.command import BotCommandMeta, CommandStart
+from aiogram.types import BotCommand, BotCommandScopeDefault, Chat, Message, User
 from tests.mocked_bot import MockedBot
 
 
@@ -23,8 +23,9 @@ class TestCommandFilter:
         with pytest.raises(ValueError):
             Command()
 
-    def test_resolve_bot_command(self):
-        bot_command = BotCommand(command="test", description="Test")
+    @pytest.mark.parametrize("bot_command_cls", [BotCommand, BotCommandMeta])
+    def test_resolve_bot_command(self, bot_command_cls: type[BotCommand]):
+        bot_command = bot_command_cls(command="test", description="Test")
         command = Command(bot_command)
         assert isinstance(command.commands[0], str)
         assert command.commands[0] == "test"
@@ -41,6 +42,15 @@ class TestCommandFilter:
     def test_empty_bot_commands(self):
         command = Command(re.compile(r"test(\d+)"), "test")
         assert len(command.bot_commands) == 0
+
+    def test_bot_command_meta_fields_preserved(self):
+        meta = BotCommandMeta(
+            command="test", description="Test", scope=BotCommandScopeDefault(), language_code="en"
+        )
+        command = Command(meta)
+        assert isinstance(command.bot_commands[0], BotCommandMeta)
+        assert command.bot_commands[0].scope == meta.scope
+        assert command.bot_commands[0].language_code == "en"
 
     @pytest.mark.parametrize(
         "commands,checklist",
@@ -67,6 +77,19 @@ class TestCommandFilter:
             [
                 "/test@tbot",
                 Command(BotCommand(command="test", description="description"), prefix="/"),
+                True,
+            ],
+            [
+                "/test@tbot",
+                Command(
+                    BotCommandMeta(
+                        command="test",
+                        description="description",
+                        scope=BotCommandScopeDefault(),
+                        language_code="en",
+                    ),
+                    prefix="/",
+                ),
                 True,
             ],
             ["!test", Command(commands=["test"], prefix="/"), False],

--- a/tests/test_filters/test_command.py
+++ b/tests/test_filters/test_command.py
@@ -24,9 +24,12 @@ class TestCommandFilter:
             Command()
 
     def test_resolve_bot_command(self):
-        command = Command(BotCommand(command="test", description="Test"))
+        bot_command = BotCommand(command="test", description="Test")
+        command = Command(bot_command)
         assert isinstance(command.commands[0], str)
         assert command.commands[0] == "test"
+        assert isinstance(command.bot_commands, tuple)
+        assert command.bot_commands[0] is bot_command
 
     def test_convert_to_list(self):
         cmd = Command(commands="start")
@@ -34,6 +37,10 @@ class TestCommandFilter:
         assert isinstance(cmd.commands, tuple)
         assert cmd.commands[0] == "start"
         # assert cmd == Command(commands=["start"])
+
+    def test_empty_bot_commands(self):
+        command = Command(re.compile(r"test(\d+)"), "test")
+        assert len(command.bot_commands) == 0
 
     @pytest.mark.parametrize(
         "commands,checklist",


### PR DESCRIPTION
# Description


`Command` accepted `BotCommand` objects but only ever extracted `.command` for text matching,
discarding `description` and everything else. This PR stops throwing that data away and adds a
way to collect it back from a router tree.

- `Command` now keeps every `BotCommand` it was constructed with in a new `bot_commands: tuple[BotCommand, ...]`
  attribute. Matching logic (`self.commands`, `validate_command`) is untouched.
- `Router.resolve_bot_commands(skip_events: set[str] | None = None) -> tuple[BotCommand, ...]`
  walks the router tree (mirrors `resolve_used_update_types()`) and collects `bot_commands` from
  every `Command` filter on every handler, across **all** observers by default — not just
  `message`. This also closes #933 as a side effect, since `channel_post`/`business_message`/
  `edited_message` handlers are picked up without any extra configuration.
- `BotCommandMeta(BotCommand)` — adds `scope`/`language_code` fields (aiogram-side only, not
  Bot API fields) for setups that need to group commands by scope/locale before calling
  `set_my_commands()`. Not meant to be passed directly to `set_my_commands()`.
- Docs: added `resolve_bot_commands` to the `Router` autoclass member list and `BotCommandMeta`
  to the `Command` filter page, and fixed the "Allowed handlers" section there, which only
  listed `message`/`edited_message` despite the filter working on any `Message`-dispatching
  observer (`channel_post`, `business_message`, etc.) — the same stale assumption behind #933.

None of this groups results, deduplicates commands, or calls `set_my_commands()` itself — that
stays in userland. This is a mechanism, not a policy.

Discussed in #1866 before implementation, since it's new public surface (new method, new
class). The history is 4 commits, in two independent pairs (code + its own docs each):
core (`bot_commands` + `resolve_bot_commands()`) first, `BotCommandMeta` last and separable —
happy to drop the last two commits if you'd rather ship the core mechanism on its own and treat
scope/locale grouping as a follow-up.

Fixes #1866

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `tests/test_filters/test_command.py::TestCommandFilter::test_resolve_bot_command` — `Command` keeps the original `BotCommand`/`BotCommandMeta` instance in `bot_commands`, in construction order
- [x] `tests/test_filters/test_command.py::TestCommandFilter::test_empty_bot_commands` — plain `str`/`re.Pattern` commands don't end up in `bot_commands`
- [x] `tests/test_filters/test_command.py::TestCommandFilter::test_bot_command_meta_fields_preserved` — `scope`/`language_code` survive being passed through `Command`
- [x] `tests/test_filters/test_command.py::TestCommandFilter::test_parse_command` — text matching behavior is unchanged when a `BotCommand`/`BotCommandMeta` is used instead of a plain string
- [x] `tests/test_dispatcher/test_dispatcher.py::TestDispatcher::test_specify_bot_commands` — collects commands across a multi-level router tree, respects `skip_events`, ignores handlers without any filters and handlers whose `Command` has no `BotCommand`, and does not deduplicate a command registered on two observers of the same router
- [x] Full suite: `uv run pytest tests` — 1863 passed, 53 skipped
- [x] `uv run ruff check --preview aiogram examples`, `uv run ruff format --check --diff aiogram tests scripts examples`, `uv run mypy aiogram` — all clean
- [x] `uv run --extra docs sphinx-build -b html docs docs/_build` — build succeeded, no warnings on the changed pages

**Test Configuration**:
* Operating System: Windows 11
* Python version: 3.14.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes