### PR TITLE
Fix content type detection for live photos

### DIFF
--- a/CHANGES/1841.bugfix.rst
+++ b/CHANGES/1841.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :code:`Message.content_type` returning :code:`photo` for Live Photo messages.
+Telegram sends a regular :code:`photo` alongside :code:`live_photo`, so
+:code:`live_photo` is now checked first and :code:`ContentType.LIVE_PHOTO` is returned.
+:code:`Message.send_copy` also copies such messages via
+:class:`aiogram.methods.send_live_photo.SendLivePhoto` instead of sending a static photo.

--- a/aiogram/types/message.py
+++ b/aiogram/types/message.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         SendDocument,
         SendGame,
         SendInvoice,
+        SendLivePhoto,
         SendLocation,
         SendMediaGroup,
         SendMessage,
@@ -712,6 +713,8 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.DOCUMENT
         if self.game:
             return ContentType.GAME
+        if self.live_photo:
+            return ContentType.LIVE_PHOTO
         if self.photo:
             return ContentType.PHOTO
         if self.sticker:
@@ -850,8 +853,6 @@ class Message(MaybeInaccessibleMessage):
             return ContentType.POLL_OPTION_ADDED
         if self.poll_option_deleted:
             return ContentType.POLL_OPTION_DELETED
-        if self.live_photo:
-            return ContentType.LIVE_PHOTO
         if self.rich_message:
             return ContentType.RICH_MESSAGE
         if self.community_chat_added:
@@ -3928,6 +3929,7 @@ class Message(MaybeInaccessibleMessage):
         | SendAudio
         | SendContact
         | SendDocument
+        | SendLivePhoto
         | SendLocation
         | SendMessage
         | SendPhoto
@@ -3972,6 +3974,7 @@ class Message(MaybeInaccessibleMessage):
             SendContact,
             SendDice,
             SendDocument,
+            SendLivePhoto,
             SendLocation,
             SendMessage,
             SendPhoto,
@@ -4029,6 +4032,16 @@ class Message(MaybeInaccessibleMessage):
                 caption_entities=self.caption_entities,
                 **kwargs,
             ).as_(self._bot)
+        if self.live_photo:
+            photo = self.photo or self.live_photo.photo
+            if photo:
+                return SendLivePhoto(
+                    live_photo=self.live_photo.file_id,
+                    photo=photo[-1].file_id,
+                    caption=self.caption,
+                    caption_entities=self.caption_entities,
+                    **kwargs,
+                ).as_(self._bot)
         if self.photo:
             return SendPhoto(
                 photo=self.photo[-1].file_id,

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -27,6 +27,7 @@ from aiogram.methods import (
     SendDocument,
     SendGame,
     SendInvoice,
+    SendLivePhoto,
     SendLocation,
     SendMediaGroup,
     SendMessage,
@@ -917,6 +918,7 @@ TEST_MESSAGE_LIVE_PHOTO = Message(
         width=640,
         height=480,
         duration=3,
+        photo=[PhotoSize(file_id="file id", file_unique_id="file unique id", width=1, height=1)],
     ),
     chat=Chat(id=42, type="private"),
     from_user=User(id=42, is_bot=False, first_name="Test"),
@@ -1122,7 +1124,7 @@ MESSAGES_AND_COPY_METHODS = [
     [TEST_MESSAGE_MANAGED_BOT_CREATED, None],
     [TEST_MESSAGE_POLL_OPTION_ADDED, None],
     [TEST_MESSAGE_POLL_OPTION_DELETED, None],
-    [TEST_MESSAGE_LIVE_PHOTO, None],
+    [TEST_MESSAGE_LIVE_PHOTO, SendLivePhoto],
     [TEST_MESSAGE_RICH_MESSAGE, None],
     [TEST_MESSAGE_COMMUNITY_CHAT_ADDED, None],
     [TEST_MESSAGE_COMMUNITY_CHAT_REMOVED, None],
@@ -1179,6 +1181,17 @@ class TestMessage:
     )
     def test_content_type(self, message: Message, content_type: str):
         assert message.content_type == content_type
+
+    def test_live_photo_takes_precedence_over_photo(self):
+        # Telegram sends a regular `photo` alongside `live_photo`
+        message = TEST_MESSAGE_LIVE_PHOTO.model_copy(
+            update={
+                "photo": [
+                    PhotoSize(file_id="file id", file_unique_id="file id", width=1, height=1)
+                ]
+            }
+        )
+        assert message.content_type == ContentType.LIVE_PHOTO
 
     def test_chat_owner_left_no_successor(self):
         assert (

--- a/tests/test_api/test_types/test_message.py
+++ b/tests/test_api/test_types/test_message.py
@@ -1187,7 +1187,9 @@ class TestMessage:
         message = TEST_MESSAGE_LIVE_PHOTO.model_copy(
             update={
                 "photo": [
-                    PhotoSize(file_id="file id", file_unique_id="file id", width=1, height=1)
+                    PhotoSize(
+                        file_id="file id", file_unique_id="file unique id", width=1, height=1
+                    )
                 ]
             }
         )


### PR DESCRIPTION
## Description

Telegram sends a regular `photo` alongside `live_photo`, so `Message.content_type` matched the `photo` branch first and never returned `ContentType.LIVE_PHOTO`.

- `content_type` now checks `live_photo` before `photo`.
- `send_copy` copies such messages via `SendLivePhoto` (using `message.photo` or `live_photo.photo` as the static photo), instead of degrading them to a plain `SendPhoto`.

Closes #1841

## Validation

```bash
uv run ruff check --preview aiogram examples
uv run ruff format --check aiogram tests scripts examples
uv run mypy aiogram          # 751 files, no issues
uv run pytest tests          # 1861 passed, 51 skipped
```

`aiogram/types/message.py` stays at 100% coverage.

Reproduction: send a Live Photo to a bot — `message.content_type` was `photo`, now `live_photo`.