### PR TITLE
Fix client session middleware type annotations to match the decoded result

### DIFF
--- a/CHANGES/1723.bugfix.rst
+++ b/CHANGES/1723.bugfix.rst
@@ -1,0 +1,9 @@
+Fixed the type annotations of client session middlewares.
+
+:class:`aiogram.client.session.middlewares.base.BaseRequestMiddleware`,
+:class:`aiogram.client.session.middlewares.base.RequestMiddlewareType` and
+:class:`aiogram.client.session.middlewares.base.NextRequestMiddlewareType`
+declared ``Response[TelegramType]`` as the middleware return type, while the
+actual request chain already works with the decoded Bot API result
+(the ``result`` field). The built-in :class:`~aiogram.client.session.middlewares.request_logging.RequestLogging`
+middleware and the documentation examples were updated accordingly.

--- a/aiogram/client/session/middlewares/base.py
+++ b/aiogram/client/session/middlewares/base.py
@@ -7,7 +7,7 @@ from aiogram.methods.base import TelegramType
 
 if TYPE_CHECKING:
     from aiogram.client.bot import Bot
-    from aiogram.methods import Response, TelegramMethod
+    from aiogram.methods import TelegramMethod
 
 
 class NextRequestMiddlewareType(Protocol[TelegramType]):  # pragma: no cover
@@ -15,7 +15,7 @@ class NextRequestMiddlewareType(Protocol[TelegramType]):  # pragma: no cover
         self,
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         pass
 
 
@@ -25,7 +25,7 @@ class RequestMiddlewareType(Protocol):  # pragma: no cover
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         pass
 
 
@@ -40,7 +40,7 @@ class BaseRequestMiddleware(ABC):
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: Bot,
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         """
         Execute middleware
 
@@ -48,5 +48,6 @@ class BaseRequestMiddleware(ABC):
         :param bot: bot for request making
         :param method: Request method (Subclass of :class:`aiogram.methods.base.TelegramMethod`)
 
-        :return: :class:`aiogram.methods.Response`
+        :return: The decoded result of the API call
+            (the ``result`` field of the Bot API response)
         """

--- a/aiogram/client/session/middlewares/request_logging.py
+++ b/aiogram/client/session/middlewares/request_logging.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiogram import loggers
 from aiogram.methods import TelegramMethod
-from aiogram.methods.base import Response, TelegramType
+from aiogram.methods.base import TelegramType
 
 from .base import BaseRequestMiddleware, NextRequestMiddlewareType
 
@@ -27,7 +27,7 @@ class RequestLogging(BaseRequestMiddleware):
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         if type(method) not in self.ignore_methods:
             loggers.middlewares.info(
                 "Make request with method=%r by bot id=%d",

--- a/docs/api/session/middleware.rst
+++ b/docs/api/session/middleware.rst
@@ -1,4 +1,4 @@
-##########################
+﻿##########################
 Client session middlewares
 ##########################
 
@@ -35,7 +35,7 @@ Register using decorator
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         # do something with request
         return await make_request(bot, method)
 
@@ -67,7 +67,7 @@ Function based session middleware
         make_request: NextRequestMiddlewareType[TelegramType],
         bot: "Bot",
         method: TelegramMethod[TelegramType],
-    ) -> Response[TelegramType]:
+    ) -> TelegramType:
         try:
             # do something with request
             return await make_request(bot, method)

--- a/tests/test_api/test_client/test_session/test_middlewares/test_manager.py
+++ b/tests/test_api/test_client/test_session/test_middlewares/test_manager.py
@@ -4,7 +4,7 @@ from aiogram.client.session.middlewares.base import (
     NextRequestMiddlewareType,
 )
 from aiogram.client.session.middlewares.manager import RequestMiddlewareManager
-from aiogram.methods import Response, TelegramMethod
+from aiogram.methods import TelegramMethod
 from aiogram.types import TelegramObject
 
 
@@ -29,7 +29,7 @@ class TestMiddlewareManager:
                 make_request: NextRequestMiddlewareType,
                 bot: Bot,
                 method: TelegramMethod[TelegramObject],
-            ) -> Response[TelegramObject]:
+            ) -> TelegramObject:
                 return await make_request(bot, method)
 
         manager.register(MyMiddleware())
@@ -43,3 +43,24 @@ class TestMiddlewareManager:
             return timeout
 
         assert await manager.wrap_middlewares(target_call, timeout=42)(None, None) == 42
+
+    async def test_middleware_receives_decoded_result(self):
+        # Session middlewares work with the decoded Bot API result,
+        # not with the raw Response envelope (see #1723)
+        manager = RequestMiddlewareManager()
+        sentinel = object()
+
+        async def target_call(bot, method):
+            return sentinel
+
+        seen = []
+
+        @manager
+        async def middleware(make_request, bot, method):
+            result = await make_request(bot, method)
+            seen.append(result)
+            return result
+
+        wrapped = manager.wrap_middlewares(target_call)
+        assert await wrapped(None, None) is sentinel
+        assert seen == [sentinel]


### PR DESCRIPTION
﻿### Description

Client session middlewares are annotated to receive and return `Response[TelegramType]`, but the actual request chain works with the decoded Bot API result. The mismatch is papered over by a `cast` in `BaseSession.__call__`, so type checkers make every custom session middleware look wrong.

Closes #1723

### Root cause

The runtime path unwraps the envelope long before the middleware boundary:

1. `AiohttpSession.make_request()` calls `check_response()` and returns the decoded `TelegramType` (the `result` field), not a `Response`.
2. `RequestMiddlewareManager.wrap_middlewares()` wraps that callback into the middleware chain.
3. `BaseSession.__call__()` needs `cast(TelegramType, await middleware(bot, method))` precisely because the protocol claims the chain still returns a raw `Response`.

Meanwhile the annotations in `aiogram/client/session/middlewares/base.py` (`NextRequestMiddlewareType`, `RequestMiddlewareType`, `BaseRequestMiddleware`) still declare `Response[TelegramType]`, and the built-in `RequestLogging` middleware repeats it. The documentation examples in `docs/api/session/middleware.rst` teach the same incorrect signature, so users following the docs get type errors in correct code.

### Changes

- `NextRequestMiddlewareType`, `RequestMiddlewareType`, `BaseRequestMiddleware`: return type `Response[TelegramType]` -> `TelegramType`; docstring updated to describe the decoded result
- `RequestLogging`: annotation aligned with the corrected protocols
- Docs examples updated (both code blocks on the session middlewares page)
- Regression test asserting a middleware sees the decoded sentinel object, not a wrapped response
- CHANGES fragment `1723.bugfix.rst`

Note: `check_response()` in `session/base.py` intentionally keeps using `Response` — it operates on the raw envelope internally before unwrapping; this PR does not touch it.

### Testing

```console
python -m pytest tests/test_api/test_client/test_session/ -q
59 passed
```

Including the new `test_middleware_receives_decoded_result`. No runtime behavior change: annotations, docstrings and docs only, plus the test.
