### PR TITLE
fix(i18n): resolve territory-specific locales from Telegram language_code

### DIFF
--- a/CHANGES/1755.bugfix.rst
+++ b/CHANGES/1755.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :class:`aiogram.utils.i18n.SimpleI18nMiddleware` never resolving
+territory-specific locales: a Telegram ``language_code`` like ``pt-br`` now
+selects an available ``pt_BR`` translations directory (falling back to the
+bare language when only it exists), instead of always resolving to the bare
+language and missing the territory directory.

--- a/aiogram/utils/i18n/middleware.py
+++ b/aiogram/utils/i18n/middleware.py
@@ -134,9 +134,16 @@ class SimpleI18nMiddleware(I18nMiddleware):
         except UnknownLocaleError:
             return self.i18n.default_locale
 
-        if locale.language not in self.i18n.available_locales:
-            return self.i18n.default_locale
-        return locale.language
+        # Telegram sends codes like "pt-br" (lowercased), while translation
+        # directories are usually named with the full territory form ("pt_BR").
+        # Prefer the most specific available locale, then the bare language.
+        candidates = [str(locale)]
+        if locale.territory:
+            candidates.append(locale.language)
+        for candidate in candidates:
+            if candidate in self.i18n.available_locales:
+                return candidate
+        return self.i18n.default_locale
 
 
 class ConstI18nMiddleware(I18nMiddleware):

--- a/tests/test_utils/test_i18n.py
+++ b/tests/test_utils/test_i18n.py
@@ -18,6 +18,34 @@ from tests.conftest import DATA_DIR
 from tests.mocked_bot import MockedBot
 
 
+def _write_minimal_mo(mo_path, catalog: dict[str, str]) -> None:
+    """Write a minimal GNU .mo file so locale dirs can be built on the fly."""
+    import struct
+
+    mo_path.parent.mkdir(parents=True, exist_ok=True)
+    keys = sorted(catalog)
+    ids = b""
+    strs = b""
+    offsets = []
+    for key in keys:
+        idb = key.encode("utf-8") + b"\x00"
+        vb = catalog[key].encode("utf-8") + b"\x00"
+        offsets.append((len(ids), len(idb) - 1, len(strs), len(vb) - 1))
+        ids += idb
+        strs += vb
+    num = len(keys)
+    key_table_off = 7 * 4
+    value_table_off = key_table_off + 8 * num
+    keystart = value_table_off + 8 * num
+    valuestart = keystart + len(ids)
+    output = struct.pack("Iiiiiii", 0x950412DE, 0, num, key_table_off, value_table_off, 0, 0)
+    for o1, l1, o2, l2 in offsets:
+        output += struct.pack("iiii", l1, keystart + o1, l2, valuestart + o2)
+    # gettext requires the last string to end strictly before EOF
+    # (real msgfmt pads to alignment), so append trailing padding.
+    mo_path.write_bytes(output + ids + strs + b"\x00" * 4)
+
+
 @pytest.fixture(name="i18n")
 def i18n_fixture() -> I18n:
     return I18n(path=DATA_DIR / "locales")
@@ -161,6 +189,86 @@ class TestSimpleI18nMiddleware:
         assert context["translator"] == i18n
         assert "middleware" in context
         assert context["middleware"] == middleware
+
+    @pytest.mark.parametrize(
+        "language_code,expected_locale",
+        [
+            ("pt-br", "pt_BR"),
+            ("pt-BR", "pt_BR"),
+            ("pt", "pt"),
+            ("uk-UA", "en"),
+            ("it-IT", "en"),
+            ("unknown", "en"),
+        ],
+    )
+    async def test_territory_locale_resolution(self, tmp_path, language_code, expected_locale):
+        i18n = I18n(path=tmp_path)
+        _write_minimal_mo(
+            tmp_path / "pt_BR" / "LC_MESSAGES" / "messages.mo",
+            {"test": "teste"},
+        )
+        _write_minimal_mo(
+            tmp_path / "pt" / "LC_MESSAGES" / "messages.mo",
+            {"test": "teste-pt"},
+        )
+        _write_minimal_mo(
+            tmp_path / "en" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test"},
+        )
+        i18n.reload()
+
+        middleware = SimpleI18nMiddleware(i18n=i18n)
+        locale = await middleware.get_locale(
+            None,
+            {
+                "event_from_user": User(
+                    id=42,
+                    is_bot=False,
+                    first_name="Test",
+                    language_code=language_code,
+                )
+            },
+        )
+        assert locale == expected_locale
+
+    @pytest.mark.parametrize(
+        "language_code,expected_text",
+        [
+            ("pt-br", "teste"),
+            ("pt", "teste-pt"),
+        ],
+    )
+    async def test_territory_locale_gettext(self, tmp_path, language_code, expected_text):
+        """The resolved territory directory must actually be the one used."""
+        i18n = I18n(path=tmp_path)
+        _write_minimal_mo(
+            tmp_path / "pt_BR" / "LC_MESSAGES" / "messages.mo",
+            {"test": "teste"},
+        )
+        _write_minimal_mo(
+            tmp_path / "pt" / "LC_MESSAGES" / "messages.mo",
+            {"test": "teste-pt"},
+        )
+        i18n.reload()
+
+        middleware = SimpleI18nMiddleware(i18n=i18n)
+
+        async def next_call(event, data):
+            return gettext("test")
+
+        result = await middleware(
+            next_call,
+            Update(update_id=42),
+            {
+                "event_from_user": User(
+                    id=42,
+                    is_bot=False,
+                    first_name="Test",
+                    language_code=language_code,
+                )
+            },
+        )
+        assert result == expected_text
 
 
 class TestConstI18nMiddleware:


### PR DESCRIPTION
Closes #1755

## Root cause

`SimpleI18nMiddleware.get_locale()` parsed the Telegram `language_code` with Babel but then only ever used `locale.language`:

```python
if locale.language not in self.i18n.available_locales:
    return self.i18n.default_locale
return locale.language
```

`available_locales` comes from translation **directory names** (`find_locales()`), which for Portuguese are conventionally named `pt_BR`. So when Telegram reports `pt-br`, the parsed locale's language is `pt`, that never matches `pt_BR`, and the bot silently falls back to the default locale — even though a matching translation exists. Territory-specific directories were unreachable through this middleware in every case.

## Fix

Build candidates from most specific to least and pick the first one that exists:

```python
candidates = [str(locale)]          # "pt_BR"
if locale.territory:
    candidates.append(locale.language)  # "pt" fallback
for candidate in candidates:
    if candidate in self.i18n.available_locales:
        return candidate
return self.i18n.default_locale
```

This also improves the case where both `pt` and `pt_BR` exist: `pt-br` now selects the territory directory instead of always degrading to bare `pt`.

## Testing

New parametrized tests build throwaway locale trees on the fly (minimal `.mo` files written by a small helper, no msgfmt dependency):

- `pt-br` / `pt-BR` → `pt_BR`; bare `pt` → `pt`; unknown/other territories → default
- an end-to-end check that `gettext()` inside the middleware actually returns the `pt_BR` catalog's translation

Regression proof: on unmodified `dev-3x` the three territory-resolution cases fail (`pt-br` resolves to default); with this branch all 42 tests in `tests/test_utils/test_i18n.py` pass. `ruff check` / `ruff format --check` clean. A towncrier fragment is included (`CHANGES/1755.bugfix.rst`).
