### PR TITLE
Fix changelog check failing on fork PRs (unsafe pull_request_target checkout)

### DIFF
--- a/.github/workflows/pull_request_changelog.yml
+++ b/.github/workflows/pull_request_changelog.yml
@@ -1,12 +1,15 @@
 name: "Check that changes are described"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - "opened"
       - "reopened"
       - "synchronize"
       - "labeled"
       - "unlabeled"
+
+permissions:
+  contents: read
 
 jobs:
   changes-required:
@@ -16,7 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: '0'
 
       - name: Set up Python 3.12
@@ -28,72 +30,35 @@ jobs:
         run: pip install -U towncrier
 
       - name: Check changelog
+        id: towncrier
         env:
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
           git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
           towncrier check --compare-with origin/${BASE_BRANCH}
 
-      - name: Find bot comment
+      - name: Save check result
         if: "always()"
-        uses: peter-evans/find-comment@v3
-        id: fc
+        env:
+          CHECK_OUTCOME: ${{ steps.towncrier.outcome }}
+        run: echo "${CHECK_OUTCOME}" > "${RUNNER_TEMP}/changelog-state.txt"
+
+      - name: Upload check result
+        if: "always()"
+        uses: actions/upload-artifact@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Changelog
-
-      - name: Ask for changelog
-        if: "failure()"
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          edit-mode: replace
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            # :x: Changelog is required!
-
-            You need to add a brief description of the changes to the `CHANGES` directory.
-
-            Changes file should be named like `<issue or PR number>.<category>.rst`,
-            example `1234.bugfix.rst` where `1234` is the PR or issue number and `bugfix` is the category.
-
-            The content of the file should be a brief description of the changes in
-            the PR in the format of a description of what has been done.
-
-            Possible categories are: `feature`, `bugfix`, `doc`, `removal` and `misc`.
-
-      - name: Changelog found
-        if: "success()"
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          edit-mode: replace
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            # :heavy_check_mark: Changelog found.
-
-            Thank you for adding a description of the changes
+          name: changelog-check
+          path: ${{ runner.temp }}/changelog-state.txt
 
   skip-news:
     runs-on: ubuntu-latest
     if: "contains(github.event.pull_request.labels.*.name, 'skip news')"
     steps:
-      - name: Find bot comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Changelog
+      - name: Save check result
+        run: echo "skip-news" > "${RUNNER_TEMP}/changelog-state.txt"
 
-      - name: Comment when docs is not needed
-        uses: peter-evans/create-or-update-comment@v4
+      - name: Upload check result
+        uses: actions/upload-artifact@v4
         with:
-          edit-mode: replace
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            # :corn: Changelog is not needed.
-
-            This PR does not require a changelog because `skip news` label is present.
+          name: changelog-check
+          path: ${{ runner.temp }}/changelog-state.txt

--- a/.github/workflows/pull_request_changelog.yml
+++ b/.github/workflows/pull_request_changelog.yml
@@ -41,7 +41,15 @@ jobs:
         if: "always()"
         env:
           CHECK_OUTCOME: ${{ steps.towncrier.outcome }}
-        run: echo "${CHECK_OUTCOME}" > "${RUNNER_TEMP}/changelog-state.txt"
+        # The outcome can also be `skipped`/`cancelled` (e.g. when checkout
+        # fails); report those as `inconclusive` so the comment workflow
+        # neither asks for a changelog nor confirms one.
+        run: |
+          case "${CHECK_OUTCOME}" in
+            success|failure) state="${CHECK_OUTCOME}" ;;
+            *) state="inconclusive" ;;
+          esac
+          echo "${state}" > "${RUNNER_TEMP}/changelog-state.txt"
 
       - name: Upload check result
         if: "always()"

--- a/.github/workflows/pull_request_changelog_comment.yml
+++ b/.github/workflows/pull_request_changelog_comment.yml
@@ -34,10 +34,13 @@ jobs:
         # The artifact was produced under the unprivileged `pull_request`
         # workflow, so treat its content as untrusted: accept only the known
         # state values and never interpolate the raw content anywhere else.
+        # `inconclusive` means the check job aborted before towncrier ran
+        # (e.g. checkout failure); it is accepted here but matches no comment
+        # step below, so no comment is posted or updated for it.
         run: |
           state="$(head -c 32 changelog-state.txt | tr -d '[:space:]')"
           case "${state}" in
-            success|failure|skip-news) ;;
+            success|failure|skip-news|inconclusive) ;;
             *)
               echo "Unexpected changelog check state" >&2
               exit 1

--- a/.github/workflows/pull_request_changelog_comment.yml
+++ b/.github/workflows/pull_request_changelog_comment.yml
@@ -1,0 +1,117 @@
+# Posts/updates the changelog check comment on the PR.
+#
+# Runs in a separate workflow_run-triggered workflow because the check itself
+# runs on the unprivileged `pull_request` event (fork PRs get a read-only
+# token there and cannot comment), while this workflow has write access but
+# never checks out or executes PR code.
+name: "Comment changelog check result"
+on:
+  workflow_run:
+    workflows:
+      - "Check that changes are described"
+    types:
+      - "completed"
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: "github.event.workflow_run.event == 'pull_request'"
+    steps:
+      - name: Download check result
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-check
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read check result
+        id: result
+        # The artifact was produced under the unprivileged `pull_request`
+        # workflow, so treat its content as untrusted: accept only the known
+        # state values and never interpolate the raw content anywhere else.
+        run: |
+          state="$(head -c 32 changelog-state.txt | tr -d '[:space:]')"
+          case "${state}" in
+            success|failure|skip-news) ;;
+            *)
+              echo "Unexpected changelog check state" >&2
+              exit 1
+              ;;
+          esac
+          echo "state=${state}" >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const pr = prs.find((item) => item.head.sha === headSha);
+            if (!pr) {
+              core.info(`No pull request found for head ${headSha}, skipping comment`);
+              return;
+            }
+            core.setOutput("number", pr.number);
+
+      - name: Find bot comment
+        if: "steps.pr.outputs.number"
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Changelog
+
+      - name: Ask for changelog
+        if: "steps.pr.outputs.number && steps.result.outputs.state == 'failure'"
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          edit-mode: replace
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: |
+            # :x: Changelog is required!
+
+            You need to add a brief description of the changes to the `CHANGES` directory.
+
+            Changes file should be named like `<issue or PR number>.<category>.rst`,
+            example `1234.bugfix.rst` where `1234` is the PR or issue number and `bugfix` is the category.
+
+            The content of the file should be a brief description of the changes in
+            the PR in the format of a description of what has been done.
+
+            Possible categories are: `feature`, `bugfix`, `doc`, `removal` and `misc`.
+
+      - name: Changelog found
+        if: "steps.pr.outputs.number && steps.result.outputs.state == 'success'"
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          edit-mode: replace
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: |
+            # :heavy_check_mark: Changelog found.
+
+            Thank you for adding a description of the changes
+
+      - name: Comment when docs is not needed
+        if: "steps.pr.outputs.number && steps.result.outputs.state == 'skip-news'"
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          edit-mode: replace
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: |
+            # :corn: Changelog is not needed.
+
+            This PR does not require a changelog because `skip news` label is present.

--- a/CHANGES/1884.misc.rst
+++ b/CHANGES/1884.misc.rst
@@ -1,0 +1,1 @@
+Fixed the changelog-presence CI check failing for pull requests from forks: the ``towncrier`` check now runs on the unprivileged ``pull_request`` event, and the PR comment is posted by a separate privileged workflow that never checks out contributed code.


### PR DESCRIPTION
## Description

The changelog-presence workflow (`pull_request_changelog.yml`) fails for **every fork PR** at the "Checkout code" step: it runs on `pull_request_target`, and `actions/checkout` now refuses to check out fork PR code in that privileged context ("pwn request" guard; the error suggests `allow-unsafe-pr-checkout: true`). As a result `towncrier check` never runs and the ":x: Changelog is required!" comment is posted spuriously. Verified failing on #1874, #1878, #1879, #1881, #1883.

Rather than opting into the unsafe checkout, this splits the workflow along the privilege boundary:

- **`pull_request_changelog.yml`** now runs on plain `pull_request` (read-only token, `permissions: contents: read`). Fork code checkout is safe here. It runs `towncrier check --compare-with origin/$BASE_BRANCH` exactly as before, keeps the `skip news` label gate, and uploads a one-word `changelog-check` artifact (`success` / `failure` / `skip-news`). The job still fails when the changelog is missing, so the PR check stays red/green as before.
- **`pull_request_changelog_comment.yml`** (new) runs on `workflow_run` with `pull-requests: write`. It never checks out or executes PR code: it downloads the artifact, validates it against the three known state values (artifact content from the unprivileged run is treated as untrusted), resolves the PR number from the API by `head_sha` (not from the artifact), and posts/updates the same find-comment / create-or-update-comment messages as before.

## Notes

- The `workflow_run` workflow only triggers once this lands on the default branch (`dev-3.x`); on this PR itself only the check half runs.
- The check now runs the workflow definition from the PR branch (inherent to `pull_request`), which is acceptable for an informational changelog reminder; the privileged half always runs the default-branch definition.

## Validation

- Both files parse as valid YAML.
- Comment bodies, `find-comment`/`create-or-update-comment` behavior (edit-mode: replace), and the `skip news` gate are unchanged from the current workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
