### PR TITLE
fix: drop the self-assignment at the top of ContextInstanceMixin.get_current

### DIFF
--- a/CHANGES/1895.misc.rst
+++ b/CHANGES/1895.misc.rst
@@ -1,0 +1,2 @@
+Removed a statement in :code:`ContextInstanceMixin.get_current` that assigned the
+context variable attribute to itself and had no effect.

--- a/aiogram/utils/mixins.py
+++ b/aiogram/utils/mixins.py
@@ -70,8 +70,6 @@ class ContextInstanceMixin(Generic[ContextInstance]):
         cls,
         no_error: bool = True,
     ) -> ContextInstance | None:  # pragma: no cover
-        cls.__context_instance = cls.__context_instance
-
         try:
             current: ContextInstance | None = cls.__context_instance.get()
         except LookupError:


### PR DESCRIPTION
`get_current` opens with `cls.__context_instance = cls.__context_instance`. `__init_subclass__` already sets that attribute on every subclass, so the read and the write hit the same entry in the class dict and the line is a no-op. It reads as if it were priming something, which is what sent me looking.
