### PR TITLE
fix(i18n): fall back to bare language for script-only codes and catch ValueError (#1896)

### DIFF
--- a/CHANGES/1896.bugfix.rst
+++ b/CHANGES/1896.bugfix.rst
@@ -1,0 +1,10 @@
+Fixed :class:`aiogram.utils.i18n.SimpleI18nMiddleware` falling back to the default locale for
+script-qualified Telegram language codes such as ``zh-hans`` or ``sr-latn`` (regression in 3.31.0):
+the bare language directory (``zh``, ``sr``) is used again when no ``zh_Hans``/``sr_Latn``
+translations exist, and for codes carrying a territory the ``zh_CN``-style directory is tried
+before the ``zh_Hans``-style one and the bare language. Locales already cached in FSM storage by
+:class:`aiogram.utils.i18n.FSMI18nMiddleware` are not re-resolved; clear the stored key or call
+``set_locale`` for affected users.
+
+Malformed or underscore-form ``language_code`` values (``en_US``, an empty string) no longer raise
+an error that dropped the whole update and now resolve to the default locale.

--- a/aiogram/utils/i18n/middleware.py
+++ b/aiogram/utils/i18n/middleware.py
@@ -98,7 +98,13 @@ class SimpleI18nMiddleware(I18nMiddleware):
     """
     Simple I18n middleware.
 
-    Chooses language code from the User object received in event
+    Chooses language code from the User object received in event.
+
+    The Telegram ``language_code`` is matched against the translation directories
+    from the most specific form to the bare language: ``pt-br`` tries ``pt_BR``,
+    then ``pt``; ``zh-hans`` tries ``zh_Hans``, then ``zh``; ``zh-cn`` tries
+    ``zh_Hans_CN``, ``zh_CN``, ``zh_Hans``, then ``zh``. Unknown or malformed codes
+    resolve to the default locale.
     """
 
     def __init__(
@@ -131,17 +137,24 @@ class SimpleI18nMiddleware(I18nMiddleware):
             return self.i18n.default_locale
         try:
             locale = Locale.parse(event_from_user.language_code, sep="-")
-        except UnknownLocaleError:
+        except (UnknownLocaleError, ValueError):
             return self.i18n.default_locale
 
-        # Telegram sends codes like "pt-br" (lowercased), while translation
-        # directories are usually named with the full territory form ("pt_BR").
-        # Prefer the most specific available locale, then the bare language.
+        # Telegram sends codes like "pt-br" or "zh-hans" (lowercased), while translation
+        # directories are usually named with the full territory ("pt_BR") or script
+        # ("zh_Hans") form. Try the most specific form first, then the territory-qualified
+        # one, then the script-qualified one, and finally the bare language. The territory
+        # goes before the script because Babel infers a script that the user never sent
+        # ("zh-cn" is parsed as "zh_Hans_CN"), while the territory is usually explicit.
         candidates = [str(locale)]
         if locale.territory:
-            candidates.append(locale.language)
+            candidates.append(f"{locale.language}_{locale.territory}")
+        if locale.script:
+            candidates.append(f"{locale.language}_{locale.script}")
+        candidates.append(locale.language)
+        locales = self.i18n.locales
         for candidate in candidates:
-            if candidate in self.i18n.available_locales:
+            if candidate in locales:
                 return candidate
         return self.i18n.default_locale
 

--- a/tests/test_utils/test_i18n.py
+++ b/tests/test_utils/test_i18n.py
@@ -199,6 +199,17 @@ class TestSimpleI18nMiddleware:
             ("uk-UA", "en"),
             ("it-IT", "en"),
             ("unknown", "en"),
+            ("zh-hans", "zh_Hans"),
+            ("zh-hant", "zh"),
+            ("sr-latn", "sr"),
+            ("uz-cyrl", "en"),
+            ("zh-hans-cn", "zh_CN"),
+            ("zh-cn", "zh_CN"),
+            ("zh-tw", "zh"),
+            ("zh-sg", "zh_Hans"),
+            ("en_US", "en"),
+            ("pt_BR", "en"),
+            pytest.param("", "en", id="empty"),
         ],
     )
     async def test_territory_locale_resolution(self, tmp_path, language_code, expected_locale):
@@ -214,6 +225,22 @@ class TestSimpleI18nMiddleware:
         _write_minimal_mo(
             tmp_path / "en" / "LC_MESSAGES" / "messages.mo",
             {"test": "test"},
+        )
+        _write_minimal_mo(
+            tmp_path / "zh" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-zh"},
+        )
+        _write_minimal_mo(
+            tmp_path / "zh_Hans" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-zh-hans"},
+        )
+        _write_minimal_mo(
+            tmp_path / "zh_CN" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-zh-cn"},
+        )
+        _write_minimal_mo(
+            tmp_path / "sr" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-sr"},
         )
         i18n.reload()
 
@@ -236,6 +263,8 @@ class TestSimpleI18nMiddleware:
         [
             ("pt-br", "teste"),
             ("pt", "teste-pt"),
+            ("zh-hans", "test-zh"),
+            ("zh-cn", "test-zh-cn"),
         ],
     )
     async def test_territory_locale_gettext(self, tmp_path, language_code, expected_text):
@@ -248,6 +277,14 @@ class TestSimpleI18nMiddleware:
         _write_minimal_mo(
             tmp_path / "pt" / "LC_MESSAGES" / "messages.mo",
             {"test": "teste-pt"},
+        )
+        _write_minimal_mo(
+            tmp_path / "zh" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-zh"},
+        )
+        _write_minimal_mo(
+            tmp_path / "zh_CN" / "LC_MESSAGES" / "messages.mo",
+            {"test": "test-zh-cn"},
         )
         i18n.reload()
 


### PR DESCRIPTION
Fixes #1896.

## Problem

#1881 (shipped in 3.31.0) changed `SimpleI18nMiddleware.get_locale()` to append the bare-language candidate only when `locale.territory` is set. Telegram sends script-qualified codes with no territory (`zh-hans`, `zh-hant`, `sr-latn`, `uz-cyrl`); Babel parses them to e.g. `zh_Hans` with `territory=None`, so the only candidate was `zh_Hans` and a bot shipping a plain `zh/` catalogue silently fell to `default_locale`. On 3.30.0 the same users got `zh`.

Separately, `Locale.parse("en_US", sep="-")` and `Locale.parse("", sep="-")` raise a plain `ValueError` (`UnknownLocaleError` is not a `ValueError` subclass), which propagated out of the middleware and dropped every update from such a user.

## Fix

- Candidates are tried in order: full form (`str(locale)`), `language_TERRITORY`, `language_Script`, bare `language`. Territory goes before script because Babel infers a script the user never sent (`zh-cn` → `zh_Hans_CN`), while the territory is usually explicit; with `zh_Hans/` and `zh_CN/` both present, `zh-cn` now resolves to `zh_CN`.
- `except (UnknownLocaleError, ValueError)` → default locale.
- Membership is checked on `I18n.locales` (the dict `gettext` itself keys on), hoisted out of the loop.
- The resolution order is documented in the `SimpleI18nMiddleware` docstring (rendered via autoclass).

Resolution examples with catalogues `{en, zh, zh_Hans, zh_CN}`:

| `language_code` | 3.30.0 | 3.31.0 | this PR |
|---|---|---|---|
| `zh-hans` | `zh` | `en` | `zh_Hans` |
| `zh-hant` | `zh` | `en` | `zh` |
| `sr-latn` (with `sr/`) | `sr` | `en` | `sr` |
| `zh-cn` | `zh` | `zh` | `zh_CN` |
| `en_US`, `""` | raises | raises | `en` (default) |

## Not changed (deliberately)

- Underscore-form codes (`en_US`) are not normalized to `en-US`; they resolve to the default locale as before-the-crash behaviour would suggest. Telegram never sends underscores.
- Babel's likely-subtag resolution can still override an explicit script for exotic codes (`zh-hant-cn` parses with script `Hans`). Fixing that would require bypassing `Locale.parse`; out of scope.
- `FSMI18nMiddleware` does not re-resolve locales already cached in FSM storage; the changelog fragment tells operators of 3.31.0 to clear the key or call `set_locale`.

## Validation

```
uv run ruff check --show-fixes --preview aiogram examples
uv run ruff format --check --diff aiogram tests scripts examples
uv run mypy aiogram                       # Success: no issues found in 763 source files
uv run pytest tests                       # 2326 passed, 51 skipped
uv run pytest tests/test_utils/test_i18n.py --cov=aiogram/utils/i18n   # middleware.py 100%
uv run towncrier build --draft --version 3.99.0
```

New regression rows in `tests/test_utils/test_i18n.py`: `zh-hans`, `zh-hant`, `sr-latn`, `uz-cyrl`, `zh-hans-cn`, `zh-cn`, `zh-tw`, `zh-sg`, `en_US`, `pt_BR`, empty string; gettext checks prove the `zh/` (script fallback) and `zh_CN/` (territory tier) catalogues are the ones actually used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
