### PR TITLE
feat(client): add dedicated ButagramAPIServer and ButagramBot in aiogram.client.butagram

### DIFF
--- a/CHANGES/1905.feature.rst
+++ b/CHANGES/1905.feature.rst
@@ -1,0 +1,1 @@
+Added :class:`aiogram.client.butagram.ButagramAPIServer` endpoint preset and :class:`aiogram.client.butagram.ButagramBot` convenience client for connecting to Butagram Bot API.

--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -4,7 +4,7 @@ from . import enums, methods, types
 from .__meta__ import __api_version__, __version__
 from .client import session
 from .client.bot import Bot
-from .client.butagram import ButagramAPIServer
+from .client.butagram import ButagramAPIServer, ButagramBot
 from .dispatcher.dispatcher import Dispatcher
 from .dispatcher.middlewares.base import BaseMiddleware
 from .dispatcher.router import Router
@@ -19,6 +19,7 @@ __all__ = (
     "BaseMiddleware",
     "Bot",
     "ButagramAPIServer",
+    "ButagramBot",
     "Dispatcher",
     "F",
     "Router",

--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -4,6 +4,7 @@ from . import enums, methods, types
 from .__meta__ import __api_version__, __version__
 from .client import session
 from .client.bot import Bot
+from .client.butagram import ButagramAPIServer
 from .dispatcher.dispatcher import Dispatcher
 from .dispatcher.middlewares.base import BaseMiddleware
 from .dispatcher.router import Router
@@ -17,6 +18,7 @@ flags = FlagGenerator()
 __all__ = (
     "BaseMiddleware",
     "Bot",
+    "ButagramAPIServer",
     "Dispatcher",
     "F",
     "Router",

--- a/aiogram/client/butagram.py
+++ b/aiogram/client/butagram.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from aiogram.client.telegram import (
+    BareFilesPathWrapper,
+    FilesPathWrapper,
+    TelegramAPIServer,
+)
+
+
+@dataclass(frozen=True)
+class ButagramAPIServer(TelegramAPIServer):
+    """
+    Base config for Butagram SuperApp Bot API endpoints (by NeonXprime).
+    Defaults to https://api.butagram.com
+    """
+
+    base: str = "https://api.butagram.com/bot{token}/{method}"
+    """Base URL for Butagram Bot API"""
+    file: str = "https://api.butagram.com/file/bot{token}/{path}"
+    """Files URL for Butagram Bot API"""
+    is_local: bool = False
+    """Mark if server is in local mode"""
+    wrap_local_file: FilesPathWrapper = field(default_factory=BareFilesPathWrapper)
+
+    @classmethod
+    def from_base(cls, base: str = "https://api.butagram.com", **kwargs: Any) -> "ButagramAPIServer":
+        """
+        Auto-generate ButagramAPIServer instance from base URL.
+        Defaults to https://api.butagram.com
+        """
+        base = base.rstrip("/")
+        return cls(
+            base=f"{base}/bot{{token}}/{{method}}",
+            file=f"{base}/file/bot{{token}}/{{path}}",
+            **kwargs,
+        )
+
+
+PRODUCTION = ButagramAPIServer(
+    base="https://api.butagram.com/bot{token}/{method}",
+    file="https://api.butagram.com/file/bot{token}/{path}",
+)
+TEST = ButagramAPIServer(
+    base="https://api.butagram.com/bot{token}/test/{method}",
+    file="https://api.butagram.com/file/bot{token}/test/{path}",
+)

--- a/aiogram/client/butagram.py
+++ b/aiogram/client/butagram.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from aiogram.client.bot import Bot
+from aiogram.client.default import DefaultBotProperties
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.session.base import BaseSession
 from aiogram.client.telegram import (
     BareFilesPathWrapper,
     FilesPathWrapper,
@@ -45,3 +49,21 @@ TEST = ButagramAPIServer(
     base="https://api.butagram.com/bot{token}/test/{method}",
     file="https://api.butagram.com/file/bot{token}/test/{path}",
 )
+
+
+class ButagramBot(Bot):
+    """
+    Native Bot class for Butagram SuperApp (by NeonXprime).
+    Connects to https://api.butagram.com automatically without any session boilerplate.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        session: BaseSession | None = None,
+        default: DefaultBotProperties | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if session is None:
+            session = AiohttpSession(api=PRODUCTION)
+        super().__init__(token=token, session=session, default=default, **kwargs)

--- a/tests/test_api/test_client/test_butagram.py
+++ b/tests/test_api/test_client/test_butagram.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from aiogram.client.butagram import (
+    PRODUCTION,
+    TEST,
+    ButagramAPIServer,
+    ButagramBot,
+)
+
+
+class TestButagramAPIServer:
+    def test_production_url(self):
+        method_url = PRODUCTION.api_url(token="42:TEST", method="apiMethod")
+        assert method_url == "https://api.butagram.com/bot42:TEST/apiMethod"
+
+    @pytest.mark.parametrize("path", ["path", Path("path")])
+    def test_file_url(self, path):
+        file_url = PRODUCTION.file_url(token="42:TEST", path=path)
+        assert file_url == "https://api.butagram.com/file/bot42:TEST/path"
+
+    def test_test_server(self):
+        method_url = TEST.api_url(token="42:TEST", method="apiMethod")
+        assert method_url == "https://api.butagram.com/bot42:TEST/test/apiMethod"
+        file_url = TEST.file_url(token="42:TEST", path="path")
+        assert file_url == "https://api.butagram.com/file/bot42:TEST/test/path"
+
+    @pytest.mark.parametrize("path", ["path", Path("path")])
+    def test_from_base(self, path):
+        server = ButagramAPIServer.from_base("https://custom.butagram.com")
+        method_url = server.api_url("42:TEST", method="apiMethod")
+        file_url = server.file_url(token="42:TEST", path=path)
+
+        assert method_url == "https://custom.butagram.com/bot42:TEST/apiMethod"
+        assert file_url == "https://custom.butagram.com/file/bot42:TEST/path"
+
+
+class TestButagramBot:
+    def test_default_session(self):
+        bot = ButagramBot("42:TEST")
+        assert bot.session.api == PRODUCTION
+        assert bot.session.api.api_url("42:TEST", "getMe") == "https://api.butagram.com/bot42:TEST/getMe"


### PR DESCRIPTION
### Summary
This PR introduces a dedicated `ButagramAPIServer` configuration and `ButagramBot` convenience class in `aiogram.client.butagram` pointing to `https://api.butagram.com/bot{token}/{method}`.

### Details
- Preserves 100% of existing `aiogram.client.telegram` and original code completely untouched.
- Adds `ButagramAPIServer(TelegramAPIServer)` and `ButagramBot(Bot)` in a separate module: `aiogram.client.butagram`.
- Exports `ButagramAPIServer` and `ButagramBot` in the root `aiogram` module namespace.
- 100% backward-compatible.

### Usage

Option 1: Using the convenience class (zero boilerplate):
```python
from aiogram import ButagramBot, Dispatcher

bot = ButagramBot(token="YOUR_TOKEN")
```

Option 2: Using standard `Bot` with session:
```python
from aiogram import Bot, Dispatcher, ButagramAPIServer
from aiogram.client.session.aiohttp import AiohttpSession

session = AiohttpSession(api=ButagramAPIServer())
bot = Bot(token="YOUR_TOKEN", session=session)
```
